### PR TITLE
fix: API auth refresh, light state merge, and HTTP 204 handling

### DIFF
--- a/custom_components/enki/api.py
+++ b/custom_components/enki/api.py
@@ -7,8 +7,16 @@ from typing import Any
 
 import aiohttp
 
+from .capabilities import (
+    is_fan_device,
+    is_inverter_device,
+    parse_bff_power,
+    supports_airflow_mode,
+    supports_electrical_power,
+    supports_fan_speed,
+    supports_light_state,
+)
 from .const import (
-    DEVICE_TYPE_FANS,
     DEVICE_TYPE_LIGHTS,
     ENKI_AIRFLOW_API_KEY,
     ENKI_BASE_URL,
@@ -22,9 +30,15 @@ from .const import (
     LOGGER,
     REFERENTIEL_VERSION,
 )
-from .device_profile import SUPPORTED_DEVICE_TYPES, build_discovery_record
+from .device_profile import build_discovery_record, integration_supports_device
 from .exceptions import EnkiApiNotFoundError, EnkiAuthError, EnkiConnectionError
-from .helpers import direction_to_enki_rotation, enki_rotation_to_direction, normalize_power_state
+from .helpers import (
+    direction_to_enki_rotation,
+    enki_rotation_to_direction,
+    is_command_success_status,
+    merge_light_state_payload,
+    normalize_power_state,
+)
 from .models import EnkiDevice, EnkiDiscoveryRecord
 
 
@@ -35,6 +49,7 @@ class EnkiAPI:
         self._username = username
         self._password = password
         self._access_token: str | None = None
+        self._refresh_token: str | None = None
         self._token_type = "Bearer"
         self._token_expires_at = 0.0
         self._session: aiohttp.ClientSession | None = None
@@ -56,7 +71,41 @@ class EnkiAPI:
     async def _ensure_token(self) -> None:
         if self._access_token and time.time() < self._token_expires_at - 30:
             return
+        if self._refresh_token:
+            try:
+                await self._refresh_access_token()
+                return
+            except EnkiAuthError:
+                LOGGER.debug("Refresh token rejected, falling back to password grant")
         await self.async_connect()
+
+    async def _refresh_access_token(self) -> None:
+        """Renew the access token without sending the account password again."""
+        if not self._refresh_token:
+            raise EnkiAuthError("No refresh token available")
+        session = await self._get_session()
+        try:
+            async with session.post(
+                ENKI_OIDC_URL,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": self._refresh_token,
+                    "client_id": "enki-front",
+                },
+            ) as response:
+                if response.status != 200:
+                    raise EnkiAuthError(f"Token refresh failed: HTTP {response.status}")
+                payload = await response.json()
+        except aiohttp.ClientError as err:
+            raise EnkiConnectionError(f"Cannot reach Enki auth: {err}") from err
+
+        self._access_token = payload["access_token"]
+        self._token_type = payload.get("token_type", "Bearer")
+        self._token_expires_at = time.time() + payload["expires_in"]
+        if refreshed := payload.get("refresh_token"):
+            self._refresh_token = refreshed
+        LOGGER.debug("Enki token refreshed, expires in %ss", payload["expires_in"])
 
     def _auth_headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
         headers = {"Authorization": f"{self._token_type} {self._access_token}"}
@@ -87,6 +136,7 @@ class EnkiAPI:
             raise EnkiConnectionError(f"Cannot reach Enki auth: {err}") from err
 
         self._access_token = payload["access_token"]
+        self._refresh_token = payload.get("refresh_token")
         self._token_type = payload.get("token_type", "Bearer")
         self._token_expires_at = time.time() + payload["expires_in"]
         LOGGER.debug("Enki session established, expires in %ss", payload["expires_in"])
@@ -145,11 +195,36 @@ class EnkiAPI:
                 node_id = metadata["nodeId"]
                 device_id = metadata["deviceId"]
                 bff_type = metadata.get("deviceType", "")
+                main_change_capability = metadata.get("mainChangeCapability") or {}
+                main_change_endpoints = [
+                    endpoint.get("id")
+                    for endpoint in main_change_capability.get("endpoints", [])
+                    if endpoint.get("id") is not None
+                ]
 
                 node_info = await self._get_node(home_id, node_id)
                 device_info = await self._get_device_info_safe(device_id)
                 device_type = device_info.get("type") or bff_type
-                supported = device_type in SUPPORTED_DEVICE_TYPES
+                capabilities = device_info.get("capabilities", [])
+                possible_values = device_info.get("possibleValues", {})
+                power_production = parse_bff_power(item.get("description"))
+
+                probe_device = EnkiDevice(
+                    home_id=home_id,
+                    device_id=device_id,
+                    node_id=node_id,
+                    device_name=item["title"]["label"],
+                    device_type=device_type,
+                    is_enabled=item["isEnabled"],
+                    state=item["state"],
+                    capabilities=capabilities,
+                    possible_values=possible_values,
+                    bff_device_type=bff_type,
+                    main_change_capability_id=metadata.get("mainChangeCapabilityId"),
+                    main_change_capability_endpoints=main_change_endpoints,
+                    power_production=power_production,
+                )
+                supported = integration_supports_device(probe_device)
 
                 manufacturer = (
                     node_info.get("manufacturerId")
@@ -163,8 +238,8 @@ class EnkiAPI:
                     build_discovery_record(
                         device_type=device_type,
                         bff_device_type=bff_type,
-                        capabilities=device_info.get("capabilities", []),
-                        possible_values=device_info.get("possibleValues", {}),
+                        capabilities=capabilities,
+                        possible_values=possible_values,
                         manufacturer=str(manufacturer) if manufacturer else None,
                         model=str(model) if model else None,
                         firmware_version=str(firmware) if firmware else None,
@@ -174,10 +249,12 @@ class EnkiAPI:
 
                 last_reported: dict[str, Any] = {}
                 if item["isEnabled"]:
-                    if device_type == DEVICE_TYPE_FANS:
-                        last_reported = await self._get_fan_full_state(home_id, node_id)
-                    elif device_type == DEVICE_TYPE_LIGHTS:
-                        last_reported = await self._get_light_state_payload(home_id, node_id)
+                    last_reported = await self._refresh_device_state(
+                        home_id,
+                        node_id,
+                        probe_device,
+                        node_info,
+                    )
 
                 if not supported:
                     LOGGER.debug(
@@ -196,9 +273,13 @@ class EnkiAPI:
                         device_type=device_type,
                         is_enabled=item["isEnabled"],
                         state=item["state"],
-                        capabilities=device_info.get("capabilities", []),
-                        possible_values=device_info.get("possibleValues", {}),
+                        capabilities=capabilities,
+                        possible_values=possible_values,
                         last_reported_value={**node_info, **last_reported},
+                        bff_device_type=bff_type,
+                        main_change_capability_id=metadata.get("mainChangeCapabilityId"),
+                        main_change_capability_endpoints=main_change_endpoints,
+                        power_production=power_production,
                     )
                 )
         return devices, records
@@ -234,6 +315,108 @@ class EnkiAPI:
                 raise EnkiConnectionError(f"get_device_info failed: HTTP {response.status}")
             return await response.json()
 
+    async def _refresh_device_state(
+        self,
+        home_id: str,
+        node_id: str,
+        device: EnkiDevice,
+        node_info: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Load live state based on referentiel capabilities (not only device type)."""
+        caps = {cap for cap in device.capabilities if isinstance(cap, str)}
+        possible = device.possible_values if isinstance(device.possible_values, dict) else {}
+
+        if is_fan_device(device):
+            return await self._get_fan_full_state(home_id, node_id)
+
+        state: dict[str, Any] = {}
+
+        if supports_light_state(caps, possible) or device.device_type == DEVICE_TYPE_LIGHTS:
+            try:
+                light_state = await self._get_light_state_payload(home_id, node_id)
+                state.update(light_state)
+                if light_state.get("power"):
+                    state["light_power"] = light_state["power"]
+            except EnkiConnectionError as err:
+                LOGGER.debug("Light state skipped for node %s: %s", node_id, err)
+
+        if supports_electrical_power(caps, possible):
+            try:
+                power_details = await self._get_electrical_power_details(home_id, node_id)
+                state["electrical_power"] = power_details.get("lastReportedValue")
+                state["electrical_endpoints"] = power_details.get("endpoints", [])
+                if not state.get("power") and isinstance(state["electrical_power"], str):
+                    state["power"] = state["electrical_power"]
+            except EnkiConnectionError as err:
+                LOGGER.debug("Electrical power skipped for node %s: %s", node_id, err)
+
+        if supports_fan_speed(caps, possible):
+            try:
+                state["fan_speed"] = await self._get_fan_speed(home_id, node_id)
+            except EnkiConnectionError as err:
+                LOGGER.debug("Fan speed skipped for node %s: %s", node_id, err)
+
+        if supports_airflow_mode(caps, possible):
+            try:
+                state["airflow_mode"] = await self._get_airflow_mode(home_id, node_id)
+            except EnkiConnectionError as err:
+                LOGGER.debug("Airflow mode skipped for node %s: %s", node_id, err)
+
+        if is_inverter_device(device):
+            state["power_production"] = device.power_production
+
+        return state
+
+    async def _get_electrical_power_details(
+        self,
+        home_id: str,
+        node_id: str,
+    ) -> dict[str, Any]:
+        session = await self._get_session()
+        async with session.get(
+            f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/{node_id}/check-electrical-power",
+            headers=self._auth_headers(
+                {
+                    "X-Gateway-APIKey": ENKI_POWER_API_KEY,
+                    "homeId": home_id,
+                }
+            ),
+        ) as response:
+            if response.status == 404:
+                return {}
+            if response.status != 200:
+                raise EnkiConnectionError(
+                    f"check-electrical-power failed: HTTP {response.status}"
+                )
+            return await response.json()
+
+    async def async_switch_electrical_power(
+        self,
+        home_id: str,
+        node_id: str,
+        value: str,
+    ) -> None:
+        """Switch global electrical power (sockets, outlets without lighting API)."""
+        await self._ensure_token()
+        session = await self._get_session()
+        async with session.post(
+            (
+                f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/{node_id}/"
+                "switch-electrical-power"
+            ),
+            headers=self._auth_headers(
+                {
+                    "X-Gateway-APIKey": ENKI_POWER_API_KEY,
+                    "homeId": home_id,
+                }
+            ),
+            json={"value": value},
+        ) as response:
+            if not is_command_success_status(response.status):
+                raise EnkiConnectionError(
+                    f"switch-electrical-power failed: HTTP {response.status}"
+                )
+
     async def _get_fan_full_state(self, home_id: str, node_id: str) -> dict[str, Any]:
         speed = await self._get_fan_speed(home_id, node_id)
         mode = await self._get_airflow_mode(home_id, node_id)
@@ -242,7 +425,7 @@ class EnkiAPI:
         last_reported = light_state.get("lastReportedValue", {})
         # ESDK fan kit on/off is reported by api-enki-lighting-prod (`power`), not power-prod.
         light_power = last_reported.get("power", "OFF")
-        return {
+        state: dict[str, Any] = {
             "fan_speed": speed,
             "airflow_mode": mode,
             "airflow_rotation": rotation,
@@ -252,6 +435,13 @@ class EnkiAPI:
             "colorTemperature": last_reported.get("colorTemperature"),
             "power": last_reported.get("power"),
         }
+        try:
+            power_details = await self._get_electrical_power_details(home_id, node_id)
+            state["electrical_power"] = power_details.get("lastReportedValue")
+            state["electrical_endpoints"] = power_details.get("endpoints", [])
+        except EnkiConnectionError as err:
+            LOGGER.debug("Electrical power skipped for fan node %s: %s", node_id, err)
+        return state
 
     async def _get_power_state(self, home_id: str, node_id: str, endpoint: int) -> str:
         session = await self._get_session()
@@ -389,7 +579,7 @@ class EnkiAPI:
             ),
             json={"value": speed},
         ) as response:
-            if response.status != 202:
+            if response.status != 202 and response.status != 204:
                 raise EnkiConnectionError(f"change-fan-speed failed: HTTP {response.status}")
 
     async def async_set_light_power(self, home_id: str, node_id: str, on: bool) -> None:
@@ -397,8 +587,7 @@ class EnkiAPI:
         await self.async_change_light_state(
             home_id,
             node_id,
-            "power",
-            "ON" if on else "OFF",
+            {"power": "ON" if on else "OFF"},
         )
 
     async def _switch_power(
@@ -422,7 +611,7 @@ class EnkiAPI:
             ),
             json={"value": value},
         ) as response:
-            if response.status != 202:
+            if not is_command_success_status(response.status):
                 raise EnkiConnectionError(f"switch-electrical-power failed: HTTP {response.status}")
 
     async def _get_light_state(self, home_id: str, node_id: str) -> dict[str, Any]:
@@ -448,16 +637,15 @@ class EnkiAPI:
         self,
         home_id: str,
         node_id: str,
-        parameter: str,
-        value: Any,
+        changes: dict[str, Any],
     ) -> None:
+        """Apply one or more lighting fields in a single change-light-state call."""
         await self._ensure_token()
         current = await self._get_light_state(home_id, node_id)
-        payload = dict(current.get("lastReportedValue", {}))
-        # Same merge order as the Enki app: default ON, then apply the requested field
-        # (so `power` OFF overwrites ON for turn_off).
-        payload["power"] = "ON"
-        payload[parameter] = value
+        payload = merge_light_state_payload(
+            current.get("lastReportedValue", {}),
+            changes,
+        )
         session = await self._get_session()
         async with session.post(
             f"{ENKI_BASE_URL}/api-enki-lighting-prod/v1/lighting/{node_id}/change-light-state",
@@ -469,5 +657,15 @@ class EnkiAPI:
             ),
             json=payload,
         ) as response:
-            if response.status != 202:
+            if not is_command_success_status(response.status):
                 raise EnkiConnectionError(f"change-light-state failed: HTTP {response.status}")
+
+    async def async_change_light_state_field(
+        self,
+        home_id: str,
+        node_id: str,
+        parameter: str,
+        value: Any,
+    ) -> None:
+        """Backward-compatible wrapper for single-field lighting updates."""
+        await self.async_change_light_state(home_id, node_id, {parameter: value})

--- a/custom_components/enki/api.py
+++ b/custom_components/enki/api.py
@@ -385,9 +385,7 @@ class EnkiAPI:
             if response.status == 404:
                 return {}
             if response.status != 200:
-                raise EnkiConnectionError(
-                    f"check-electrical-power failed: HTTP {response.status}"
-                )
+                raise EnkiConnectionError(f"check-electrical-power failed: HTTP {response.status}")
             return await response.json()
 
     async def async_switch_electrical_power(
@@ -400,10 +398,7 @@ class EnkiAPI:
         await self._ensure_token()
         session = await self._get_session()
         async with session.post(
-            (
-                f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/{node_id}/"
-                "switch-electrical-power"
-            ),
+            (f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/{node_id}/switch-electrical-power"),
             headers=self._auth_headers(
                 {
                     "X-Gateway-APIKey": ENKI_POWER_API_KEY,
@@ -413,9 +408,7 @@ class EnkiAPI:
             json={"value": value},
         ) as response:
             if not is_command_success_status(response.status):
-                raise EnkiConnectionError(
-                    f"switch-electrical-power failed: HTTP {response.status}"
-                )
+                raise EnkiConnectionError(f"switch-electrical-power failed: HTTP {response.status}")
 
     async def _get_fan_full_state(self, home_id: str, node_id: str) -> dict[str, Any]:
         speed = await self._get_fan_speed(home_id, node_id)

--- a/custom_components/enki/capabilities.py
+++ b/custom_components/enki/capabilities.py
@@ -1,0 +1,166 @@
+"""Capability-based Enki device detection (referentiel + BFF metadata)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .const import DEVICE_TYPE_FANS, DEVICE_TYPE_INVERTERS, DEVICE_TYPE_LIGHTS
+from .models import EnkiDevice
+
+
+def capabilities_set(capabilities: list[str] | dict[str, Any] | None) -> set[str]:
+    """Normalize referentiel capabilities to a string set."""
+    if isinstance(capabilities, list):
+        return {capability for capability in capabilities if isinstance(capability, str)}
+    if isinstance(capabilities, dict):
+        return set(capabilities.keys())
+    return set()
+
+
+def possible_values_dict(possible_values: dict[str, Any] | None) -> dict[str, Any]:
+    if isinstance(possible_values, dict):
+        return possible_values
+    return {}
+
+
+def supports_light_state(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return (
+        "change_light_state" in capabilities
+        or "check_light_state" in capabilities
+        or "change_light_state" in possible_values
+        or "check_light_state" in possible_values
+    )
+
+
+def supports_electrical_power(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return (
+        "switch_electrical_power" in capabilities
+        or "check_electrical_power" in capabilities
+        or "switch_electrical_power" in possible_values
+        or "check_electrical_power" in possible_values
+    )
+
+
+def supports_fan_speed(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return (
+        "change_fan_speed" in capabilities
+        or "check_fan_speed" in capabilities
+        or "change_fan_speed" in possible_values
+        or "check_fan_speed" in possible_values
+    )
+
+
+def supports_fan_rotation(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return (
+        "change_fan_rotation_direction" in capabilities
+        or "check_fan_rotation_direction" in capabilities
+        or "change_fan_rotation_direction" in possible_values
+        or "check_fan_rotation_direction" in possible_values
+    )
+
+
+def supports_airflow_mode(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return (
+        "change_airflow_mode" in capabilities
+        or "check_airflow_mode" in capabilities
+        or "change_airflow_mode" in possible_values
+        or "check_airflow_mode" in possible_values
+    )
+
+
+def supports_power_production(capabilities: set[str]) -> bool:
+    return "check_power_production" in capabilities
+
+
+def device_capabilities(device: EnkiDevice) -> set[str]:
+    return capabilities_set(device.capabilities)
+
+
+def device_possible_values(device: EnkiDevice) -> dict[str, Any]:
+    return possible_values_dict(device.possible_values)
+
+
+def is_fan_device(device: EnkiDevice) -> bool:
+    """Detect fans from capabilities (Inspire, Cadix, Radix, VMC, …)."""
+    if device.device_type == DEVICE_TYPE_FANS:
+        return True
+    caps = device_capabilities(device)
+    possible = device_possible_values(device)
+    return (
+        supports_fan_speed(caps, possible)
+        or supports_fan_rotation(caps, possible)
+        or supports_airflow_mode(caps, possible)
+    )
+
+
+def is_light_controllable(device: EnkiDevice) -> bool:
+    """Lights, dimmers, and switch/outlet nodes exposed as HA lights."""
+    if device.device_type == DEVICE_TYPE_LIGHTS:
+        return True
+    caps = device_capabilities(device)
+    possible = device_possible_values(device)
+    if is_fan_device(device):
+        return supports_light_state(caps, possible)
+    return supports_light_state(caps, possible) or supports_electrical_power(caps, possible)
+
+
+def is_inverter_device(device: EnkiDevice) -> bool:
+    """Solar inverters reporting live production via the BFF dashboard."""
+    if device.device_type in {DEVICE_TYPE_INVERTERS, "inverters"}:
+        return device.power_production is not None
+    caps = device_capabilities(device)
+    return supports_power_production(caps) and device.power_production is not None
+
+
+def device_is_supported(device: EnkiDevice) -> bool:
+    return is_fan_device(device) or is_light_controllable(device) or is_inverter_device(device)
+
+
+def device_uses_power_api_only(device: EnkiDevice) -> bool:
+    """Pure switches/outlets (e.g. Edisio) without the lighting API."""
+    caps = device_capabilities(device)
+    possible = device_possible_values(device)
+    return supports_electrical_power(caps, possible) and not supports_light_state(caps, possible)
+
+
+def fan_max_speed(device: EnkiDevice) -> int | None:
+    """Read max fan speed from referentiel possibleValues."""
+    possible = device_possible_values(device)
+    speed_meta = possible.get("change_fan_speed") or possible.get("check_fan_speed")
+    if isinstance(speed_meta, dict):
+        speed_range = speed_meta.get("range")
+        if isinstance(speed_range, dict):
+            raw_max = speed_range.get("max")
+            if isinstance(raw_max, (int, float)) and raw_max > 0:
+                return max(1, int(round(raw_max)))
+    return None
+
+
+def parse_bff_power(description: dict[str, Any] | None) -> float | None:
+    """Parse power production from BFF description.value (e.g. '109 W' -> 109.0)."""
+    if not description or not isinstance(description, dict):
+        return None
+    value_str = description.get("value")
+    if not isinstance(value_str, str):
+        return None
+    try:
+        return float(value_str.split()[0])
+    except (ValueError, IndexError):
+        return None
+
+
+def main_change_capability_endpoints(device: EnkiDevice) -> list[int]:
+    """Return BFF endpoints for mainChangeCapability=switch_electrical_power."""
+    if device.main_change_capability_id != "switch_electrical_power":
+        return []
+
+    endpoint_ids: set[int] = set()
+    for endpoint in device.main_change_capability_endpoints:
+        if isinstance(endpoint, int):
+            endpoint_ids.add(endpoint)
+        elif isinstance(endpoint, dict):
+            endpoint_id = endpoint.get("id")
+            if isinstance(endpoint_id, int):
+                endpoint_ids.add(endpoint_id)
+
+    return sorted(endpoint_ids)

--- a/custom_components/enki/const.py
+++ b/custom_components/enki/const.py
@@ -45,6 +45,7 @@ DIRECTION_REVERSE = "reverse"
 
 DEVICE_TYPE_LIGHTS = "lights"
 DEVICE_TYPE_FANS = "ceiling_fans"
+DEVICE_TYPE_INVERTERS = "inverters"
 
 REFERENTIEL_VERSION = "2.23.0"
 

--- a/custom_components/enki/device_profile.py
+++ b/custom_components/enki/device_profile.py
@@ -7,15 +7,14 @@ import json
 from typing import Any
 from urllib.parse import quote
 
-from .const import (
-    DEVICE_TYPE_FANS,
-    DEVICE_TYPE_LIGHTS,
-    TELEMETRY_GITHUB_REPO,
-    TELEMETRY_ISSUE_LABELS,
-)
-from .models import EnkiDiscoveryRecord
+from .capabilities import device_is_supported
+from .const import TELEMETRY_GITHUB_REPO, TELEMETRY_ISSUE_LABELS
+from .models import EnkiDevice, EnkiDiscoveryRecord
 
-SUPPORTED_DEVICE_TYPES = {DEVICE_TYPE_FANS, DEVICE_TYPE_LIGHTS}
+
+def integration_supports_device(device: EnkiDevice) -> bool:
+    """Return True when at least one HA platform can represent this node."""
+    return device_is_supported(device)
 
 _SENSITIVE_STATE_KEYS = frozenset(
     {

--- a/custom_components/enki/device_profile.py
+++ b/custom_components/enki/device_profile.py
@@ -16,6 +16,7 @@ def integration_supports_device(device: EnkiDevice) -> bool:
     """Return True when at least one HA platform can represent this node."""
     return device_is_supported(device)
 
+
 _SENSITIVE_STATE_KEYS = frozenset(
     {
         "homeId",

--- a/custom_components/enki/entity.py
+++ b/custom_components/enki/entity.py
@@ -50,4 +50,5 @@ class EnkiEntity(CoordinatorEntity[EnkiCoordinator]):
             .replace("_", " ")
             .title(),
             sw_version=metadata.get("version"),
+            serial_number=metadata.get("eui64") or self._device.node_id,
         )

--- a/custom_components/enki/fan_helpers.py
+++ b/custom_components/enki/fan_helpers.py
@@ -38,13 +38,9 @@ def airflow_modes_from_metadata(device: EnkiDevice) -> list[str]:
     if isinstance(meta, dict):
         values = meta.get("values")
         if isinstance(values, list):
-            presets: list[str] = []
-            for value in values:
-                preset = enki_airflow_mode_to_preset(str(value))
-                if preset is not None and preset not in presets:
-                    presets.append(preset)
-            if presets:
-                return presets
+            modes = [str(value) for value in values if isinstance(value, str)]
+            if modes:
+                return modes
     return [PRESET_MODE_MANUAL, PRESET_MODE_BREEZE]
 
 
@@ -60,15 +56,27 @@ def enki_airflow_mode_to_preset(mode: str | None) -> str | None:
 
 
 def preset_to_enki_airflow_mode(preset: str) -> str:
-    normalized = preset.strip().lower()
-    if normalized == PRESET_MODE_MANUAL:
+    normalized = preset.strip().upper()
+    if normalized in {
+        "MANUAL",
+        "BREEZE",
+        "VENTILATION",
+        "BOOST",
+        "AUTO",
+        "SLEEP",
+    }:
+        return normalized
+    lowered = preset.strip().lower()
+    if lowered == PRESET_MODE_MANUAL:
         return AIRFLOW_MODE_MANUAL
-    if normalized == PRESET_MODE_BREEZE:
+    if lowered == PRESET_MODE_BREEZE:
         return AIRFLOW_MODE_BREEZE
     raise ValueError(f"Unsupported preset mode: {preset}")
 
 
 def infer_airflow_mode_supported(device: EnkiDevice, mode: str | None) -> bool:
+    if mode is not None and mode in airflow_modes_from_metadata(device):
+        return True
     if enki_airflow_mode_to_preset(mode) is not None:
         return True
     return device_supports_airflow_mode(device)

--- a/custom_components/enki/helpers.py
+++ b/custom_components/enki/helpers.py
@@ -88,3 +88,22 @@ def direction_to_enki_rotation(direction: str) -> str:
     if mapped is None:
         raise ValueError(f"Unsupported fan direction: {direction}")
     return mapped
+
+
+def merge_light_state_payload(
+    current: dict[str, Any],
+    changes: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a change-light-state body from the last reported value and requested changes."""
+    payload = dict(current)
+    if changes.get("power") == "OFF":
+        payload.update(changes)
+        return payload
+    payload["power"] = "ON"
+    payload.update(changes)
+    return payload
+
+
+def is_command_success_status(status: int) -> bool:
+    """Enki command endpoints return 202 Accepted or 204 No Content."""
+    return status in {202, 204}

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -1,4 +1,4 @@
-"""Light platform for Enki lights and fan light kits."""
+"""Light platform for Enki lights, fan kits, switches and multi-endpoint nodes."""
 
 from __future__ import annotations
 
@@ -15,7 +15,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DEVICE_TYPE_FANS, DEVICE_TYPE_LIGHTS, DOMAIN
+from .capabilities import capabilities_set as device_capabilities_set
+from .capabilities import (
+    device_uses_power_api_only,
+    is_fan_device,
+    is_light_controllable,
+    main_change_capability_endpoints,
+    supports_light_state,
+)
+from .capabilities import possible_values_dict as device_possible_values
+from .const import DOMAIN
 from .coordinator import EnkiCoordinator
 from .entity import EnkiEntity
 from .models import EnkiDevice
@@ -29,11 +38,34 @@ async def async_setup_entry(
     coordinator: EnkiCoordinator = entry.runtime_data
     entities: list[LightEntity] = []
     for device in coordinator.data or []:
-        if device.device_type == DEVICE_TYPE_FANS:
-            entities.append(EnkiFanLightEntity(coordinator, device))
-        elif device.device_type == DEVICE_TYPE_LIGHTS:
-            entities.append(EnkiLightEntity(coordinator, device))
+        entities.extend(_build_light_entities(coordinator, device))
     async_add_entities(entities)
+
+
+def _build_light_entities(
+    coordinator: EnkiCoordinator,
+    device: EnkiDevice,
+) -> list[LightEntity]:
+    if not is_light_controllable(device):
+        return []
+
+    if is_fan_device(device):
+        return [EnkiFanLightEntity(coordinator, device)]
+
+    endpoint_ids = main_change_capability_endpoints(device)
+    if endpoint_ids:
+        return [
+            EnkiLightEntity(
+                coordinator,
+                device,
+                suffix=f"light_{chr(ord('a') + index)}",
+                endpoint_id=endpoint_id,
+            )
+            for index, endpoint_id in enumerate(endpoint_ids)
+        ]
+
+    translation_key = "outlet" if device_uses_power_api_only(device) else "light"
+    return [EnkiLightEntity(coordinator, device, suffix="light", translation_key=translation_key)]
 
 
 class EnkiFanLightEntity(EnkiEntity, LightEntity):
@@ -44,10 +76,19 @@ class EnkiFanLightEntity(EnkiEntity, LightEntity):
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP}
     _attr_min_color_temp_kelvin = 2748
     _attr_max_color_temp_kelvin = 6500
+    _brightness_max = 100
 
     def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-light"
+        possible = device_possible_values(device.possible_values)
+        brightness_range = possible.get("change_brightness", {}).get("range", {})
+        self._brightness_max = brightness_range.get("max", 100)
+        values = possible.get("change_color_temperature", {}).get("values", [])
+        if values:
+            self._color_temp_values = [int(value.strip("TK")) for value in values]
+        else:
+            self._color_temp_values = []
 
     @property
     def is_on(self) -> bool:
@@ -56,46 +97,91 @@ class EnkiFanLightEntity(EnkiEntity, LightEntity):
     @property
     def brightness(self) -> int | None:
         raw = self._device.last_reported_value.get("brightness")
-        return round(raw * 255) if raw is not None else None
+        return round(raw * 255 / self._brightness_max) if raw is not None else None
 
     @property
     def color_temp_kelvin(self) -> int | None:
         raw = self._device.last_reported_value.get("colorTemperature")
         return int(raw.strip("TK")) if raw else None
 
+    def _closest_color_temp(self, target: int) -> str:
+        best = min(self._color_temp_values, key=lambda value: abs(value - target))
+        return f"T{best}K"
+
+    def _light_endpoints_have_mixed_power(self) -> bool:
+        endpoint_ids = main_change_capability_endpoints(self._device)
+        if len(endpoint_ids) <= 1:
+            return False
+        endpoints = self._device.last_reported_value.get("electrical_endpoints")
+        if not isinstance(endpoints, list):
+            return False
+        power_values: set[str] = set()
+        for endpoint in endpoints:
+            if not isinstance(endpoint, dict) or endpoint.get("id") not in endpoint_ids:
+                continue
+            last_reported = endpoint.get("lastReportedValue")
+            if isinstance(last_reported, str) and last_reported in {"ON", "OFF"}:
+                power_values.add(last_reported)
+            if len(power_values) > 1:
+                return True
+        return False
+
+    async def _mixed_endpoint_workaround(self) -> None:
+        if self._light_endpoints_have_mixed_power():
+            await self.coordinator.api.async_change_light_state(
+                self._device.home_id,
+                self._device.node_id,
+                {"power": "OFF"},
+            )
+
+    def _build_turn_on_changes(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        changes: dict[str, Any] = {"power": "ON"}
+        if ATTR_BRIGHTNESS in kwargs:
+            changes["brightness"] = round(
+                kwargs[ATTR_BRIGHTNESS] * self._brightness_max / 255,
+                2,
+            )
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            if self._color_temp_values:
+                changes["colorTemperature"] = self._closest_color_temp(
+                    kwargs[ATTR_COLOR_TEMP_KELVIN]
+                )
+            else:
+                changes["colorTemperature"] = f"T{kwargs[ATTR_COLOR_TEMP_KELVIN]}K"
+        elif ATTR_BRIGHTNESS not in kwargs:
+            last_brightness = self._device.last_reported_value.get("brightness")
+            if isinstance(last_brightness, (int, float)) and last_brightness > 0:
+                changes["brightness"] = last_brightness
+        return changes
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         home_id = self._device.home_id
         node_id = self._device.node_id
-
-        if ATTR_BRIGHTNESS in kwargs:
-            value = round(kwargs[ATTR_BRIGHTNESS] / 255, 2)
-            await self.coordinator.api.async_change_light_state(
-                home_id,
-                node_id,
-                "brightness",
-                value,
-            )
-            self.coordinator.update_cached_value(node_id, "brightness", value)
-            self._cache_light_on(node_id)
-        elif ATTR_COLOR_TEMP_KELVIN in kwargs:
-            value = f"T{kwargs[ATTR_COLOR_TEMP_KELVIN]}K"
-            await self.coordinator.api.async_change_light_state(
-                home_id,
-                node_id,
-                "colorTemperature",
-                value,
-            )
-            self.coordinator.update_cached_value(node_id, "colorTemperature", value)
-            self._cache_light_on(node_id)
-        else:
-            await self.coordinator.api.async_change_light_state(home_id, node_id, "power", "ON")
-            self._cache_light_on(node_id)
+        await self._mixed_endpoint_workaround()
+        changes = self._build_turn_on_changes(kwargs)
+        await self.coordinator.api.async_change_light_state(home_id, node_id, changes)
+        self._apply_light_cache(node_id, changes)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         home_id = self._device.home_id
         node_id = self._device.node_id
-        await self.coordinator.api.async_change_light_state(home_id, node_id, "power", "OFF")
+        await self.coordinator.api.async_change_light_state(
+            home_id,
+            node_id,
+            {"power": "OFF"},
+        )
         self._cache_light_off(node_id)
+
+    def _apply_light_cache(self, node_id: str, changes: dict[str, Any]) -> None:
+        self._cache_light_on(node_id)
+        if "brightness" in changes:
+            self.coordinator.update_cached_value(node_id, "brightness", changes["brightness"])
+        if "colorTemperature" in changes:
+            self.coordinator.update_cached_value(
+                node_id,
+                "colorTemperature",
+                changes["colorTemperature"],
+            )
 
     def _cache_light_on(self, node_id: str) -> None:
         self.coordinator.update_cached_value(node_id, "light_power", "ON")
@@ -107,20 +193,31 @@ class EnkiFanLightEntity(EnkiEntity, LightEntity):
 
 
 class EnkiLightEntity(EnkiEntity, LightEntity):
-    """Standard Enki light node."""
+    """Standard Enki light, dimmer, or switch/outlet node."""
 
     _attr_translation_key = "light"
     _brightness_max = 100
 
-    def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
+    def __init__(
+        self,
+        coordinator: EnkiCoordinator,
+        device: EnkiDevice,
+        *,
+        suffix: str,
+        endpoint_id: int | None = None,
+        translation_key: str = "light",
+    ) -> None:
         super().__init__(coordinator, device)
-        self._attr_unique_id = f"{DOMAIN}-{device.node_id}-light"
+        self._endpoint_id = endpoint_id
+        self._attr_translation_key = translation_key
+        self._attr_unique_id = f"{DOMAIN}-{device.node_id}-{suffix}"
         self._color_temp_values: list[int] = []
+        caps = device_capabilities_set(device.capabilities)
+        possible = device_possible_values(device.possible_values)
+        self._supports_light_state = supports_light_state(caps, possible)
         modes: set[ColorMode] = set()
-        possible = device.possible_values
-        capabilities = device.capabilities
 
-        if "change_color_temperature" in capabilities:
+        if "change_color_temperature" in caps:
             modes.add(ColorMode.COLOR_TEMP)
             values = possible.get("change_color_temperature", {}).get("values", [])
             if values:
@@ -131,12 +228,12 @@ class EnkiLightEntity(EnkiEntity, LightEntity):
                 self._attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
                 self._attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
 
-        if "change_brightness" in capabilities:
+        if "change_brightness" in caps:
             modes.add(ColorMode.BRIGHTNESS)
             brightness_range = possible.get("change_brightness", {}).get("range", {})
             self._brightness_max = brightness_range.get("max", 100)
 
-        if not modes and "switch_electrical_power" in capabilities:
+        if not modes and "switch_electrical_power" in caps:
             modes.add(ColorMode.ONOFF)
 
         self._attr_supported_color_modes = modes or {ColorMode.ONOFF}
@@ -149,7 +246,27 @@ class EnkiLightEntity(EnkiEntity, LightEntity):
 
     @property
     def is_on(self) -> bool:
-        return self._device.last_reported_value.get("power") == "ON"
+        if self._endpoint_id is not None:
+            endpoints = self._device.last_reported_value.get("electrical_endpoints")
+            if isinstance(endpoints, list):
+                for endpoint in endpoints:
+                    if not isinstance(endpoint, dict):
+                        continue
+                    if endpoint.get("id") != self._endpoint_id:
+                        continue
+                    last_reported = endpoint.get("lastReportedValue")
+                    if isinstance(last_reported, str):
+                        return last_reported == "ON"
+                    if isinstance(last_reported, dict):
+                        power = last_reported.get("power")
+                        return power == "ON" if power is not None else None
+
+        power = self._device.last_reported_value.get("power")
+        if power is not None:
+            return power == "ON"
+
+        electrical_power = self._device.last_reported_value.get("electrical_power")
+        return isinstance(electrical_power, str) and electrical_power == "ON"
 
     @property
     def brightness(self) -> int | None:
@@ -167,30 +284,99 @@ class EnkiLightEntity(EnkiEntity, LightEntity):
         best = min(self._color_temp_values, key=lambda value: abs(value - target))
         return f"T{best}K"
 
+    def _light_endpoint_ids(self) -> list[int]:
+        return main_change_capability_endpoints(self._device)
+
+    def _light_endpoints_have_mixed_power(self) -> bool:
+        endpoint_ids = self._light_endpoint_ids()
+        if len(endpoint_ids) <= 1:
+            return False
+
+        endpoints = self._device.last_reported_value.get("electrical_endpoints")
+        if not isinstance(endpoints, list):
+            return False
+
+        power_values: set[str] = set()
+        for endpoint in endpoints:
+            if not isinstance(endpoint, dict):
+                continue
+            if endpoint.get("id") not in endpoint_ids:
+                continue
+            last_reported = endpoint.get("lastReportedValue")
+            if isinstance(last_reported, str) and last_reported in {"ON", "OFF"}:
+                power_values.add(last_reported)
+            elif isinstance(last_reported, dict):
+                power = last_reported.get("power")
+                if power in {"ON", "OFF"}:
+                    power_values.add(power)
+            if len(power_values) > 1:
+                return True
+        return False
+
+    def _update_light_endpoint_cache(self, power: str) -> None:
+        for endpoint_id in self._light_endpoint_ids():
+            self.coordinator.update_endpoint_power(self._device.node_id, endpoint_id, power)
+
+    async def _mixed_endpoint_workaround(self) -> None:
+        if self._light_endpoints_have_mixed_power():
+            await self.coordinator.api.async_change_light_state(
+                self._device.home_id,
+                self._device.node_id,
+                {"power": "OFF"},
+            )
+
+    def _build_turn_on_changes(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        changes: dict[str, Any] = {"power": "ON"}
+        if ATTR_BRIGHTNESS in kwargs:
+            changes["brightness"] = round(
+                kwargs[ATTR_BRIGHTNESS] * self._brightness_max / 255,
+                2,
+            )
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            if self._color_temp_values:
+                changes["colorTemperature"] = self._closest_color_temp(
+                    kwargs[ATTR_COLOR_TEMP_KELVIN]
+                )
+            else:
+                changes["colorTemperature"] = f"T{kwargs[ATTR_COLOR_TEMP_KELVIN]}K"
+        return changes
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         home_id = self._device.home_id
         node_id = self._device.node_id
-        if ATTR_BRIGHTNESS in kwargs:
-            value = round(kwargs[ATTR_BRIGHTNESS] * self._brightness_max / 255, 2)
-            await self.coordinator.api.async_change_light_state(
-                home_id, node_id, "brightness", value
+
+        if not self._supports_light_state:
+            await self.coordinator.api.async_switch_electrical_power(home_id, node_id, "ON")
+            self.coordinator.update_cached_value(node_id, "electrical_power", "ON")
+            return
+
+        await self._mixed_endpoint_workaround()
+        changes = self._build_turn_on_changes(kwargs)
+        await self.coordinator.api.async_change_light_state(home_id, node_id, changes)
+        self.coordinator.update_cached_value(node_id, "power", "ON")
+        if "brightness" in changes:
+            self.coordinator.update_cached_value(node_id, "brightness", changes["brightness"])
+        if "colorTemperature" in changes:
+            self.coordinator.update_cached_value(
+                node_id,
+                "colorTemperature",
+                changes["colorTemperature"],
             )
-            self.coordinator.update_cached_value(node_id, "brightness", value)
-        elif ATTR_COLOR_TEMP_KELVIN in kwargs:
-            if self._color_temp_values:
-                value = self._closest_color_temp(kwargs[ATTR_COLOR_TEMP_KELVIN])
-            else:
-                value = f"T{kwargs[ATTR_COLOR_TEMP_KELVIN]}K"
-            await self.coordinator.api.async_change_light_state(
-                home_id, node_id, "colorTemperature", value
-            )
-            self.coordinator.update_cached_value(node_id, "colorTemperature", value)
-        else:
-            await self.coordinator.api.async_change_light_state(home_id, node_id, "power", "ON")
-            self.coordinator.update_cached_value(node_id, "power", "ON")
+        self._update_light_endpoint_cache("ON")
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         home_id = self._device.home_id
         node_id = self._device.node_id
-        await self.coordinator.api.async_change_light_state(home_id, node_id, "power", "OFF")
+
+        if not self._supports_light_state:
+            await self.coordinator.api.async_switch_electrical_power(home_id, node_id, "OFF")
+            self.coordinator.update_cached_value(node_id, "electrical_power", "OFF")
+            return
+
+        await self.coordinator.api.async_change_light_state(
+            home_id,
+            node_id,
+            {"power": "OFF"},
+        )
         self.coordinator.update_cached_value(node_id, "power", "OFF")
+        self._update_light_endpoint_cache("OFF")

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.0.7"
+  "version": "1.1.1"
 }

--- a/custom_components/enki/models.py
+++ b/custom_components/enki/models.py
@@ -20,6 +20,10 @@ class EnkiDevice:
     capabilities: list[str] = field(default_factory=list)
     possible_values: dict[str, Any] = field(default_factory=dict)
     last_reported_value: dict[str, Any] = field(default_factory=dict)
+    bff_device_type: str = ""
+    main_change_capability_id: str | None = None
+    main_change_capability_endpoints: list[int | dict[str, Any]] = field(default_factory=list)
+    power_production: float | None = None
 
     @property
     def is_active(self) -> bool:

--- a/tests/integration/test_live_api.py
+++ b/tests/integration/test_live_api.py
@@ -78,7 +78,7 @@ async def test_light_power_independent(api: EnkiAPI) -> None:
     state = await api._get_light_state(HOME_ID, NODE_ID)
     assert state["lastReportedValue"]["power"] == "OFF"
 
-    await api.async_change_light_state(HOME_ID, NODE_ID, "power", "ON")
+    await api.async_change_light_state_field(HOME_ID, NODE_ID, "power", "ON")
     await asyncio.sleep(2)
     state = await api._get_light_state(HOME_ID, NODE_ID)
     assert state["lastReportedValue"]["power"] == "ON"

--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 import aiohttp
 import pytest
 from aioresponses import aioresponses
@@ -55,4 +57,73 @@ async def test_connect_network_failure() -> None:
         api = EnkiAPI("user@example.com", "secret")
         with pytest.raises(EnkiConnectionError, match="Cannot reach Enki auth"):
             await api.async_connect()
+        await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_connect_stores_refresh_token() -> None:
+    with aioresponses() as mocked:
+        mocked.post(
+            ENKI_OIDC_URL,
+            status=200,
+            payload={
+                "access_token": "token-abc",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "refresh-xyz",
+            },
+        )
+        api = EnkiAPI("user@example.com", "secret")
+        await api.async_connect()
+        assert api._refresh_token == "refresh-xyz"
+        await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_token_uses_refresh_before_password() -> None:
+    with aioresponses() as mocked:
+        mocked.post(
+            ENKI_OIDC_URL,
+            status=200,
+            payload={
+                "access_token": "refreshed-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "new-refresh",
+            },
+        )
+        api = EnkiAPI("user@example.com", "secret")
+        api._access_token = "expired"
+        api._refresh_token = "old-refresh"
+        api._token_expires_at = time.time() - 10
+
+        await api._ensure_token()
+
+        assert api._access_token == "refreshed-token"
+        assert api._refresh_token == "new-refresh"
+        await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_ensure_token_falls_back_to_password_when_refresh_fails() -> None:
+    with aioresponses() as mocked:
+        mocked.post(ENKI_OIDC_URL, status=401, payload={"error": "invalid_grant"})
+        mocked.post(
+            ENKI_OIDC_URL,
+            status=200,
+            payload={
+                "access_token": "password-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "fresh-refresh",
+            },
+        )
+        api = EnkiAPI("user@example.com", "secret")
+        api._access_token = "expired"
+        api._refresh_token = "bad-refresh"
+        api._token_expires_at = time.time() - 10
+
+        await api._ensure_token()
+
+        assert api._access_token == "password-token"
         await api.async_close()

--- a/tests/unit/test_command_status.py
+++ b/tests/unit/test_command_status.py
@@ -1,0 +1,12 @@
+"""Unit tests for command HTTP status handling."""
+
+from __future__ import annotations
+
+from enki.helpers import is_command_success_status
+
+
+def test_is_command_success_status() -> None:
+    assert is_command_success_status(202) is True
+    assert is_command_success_status(204) is True
+    assert is_command_success_status(200) is False
+    assert is_command_success_status(500) is False

--- a/tests/unit/test_fan_helpers.py
+++ b/tests/unit/test_fan_helpers.py
@@ -60,4 +60,4 @@ def test_airflow_modes_from_metadata_uses_referentiel_values() -> None:
             "change_airflow_mode": {"values": ["MANUAL", "BREEZE"]},
         },
     )
-    assert airflow_modes_from_metadata(device) == [PRESET_MODE_MANUAL, PRESET_MODE_BREEZE]
+    assert airflow_modes_from_metadata(device) == ["MANUAL", "BREEZE"]

--- a/tests/unit/test_fan_light_state.py
+++ b/tests/unit/test_fan_light_state.py
@@ -2,16 +2,28 @@
 
 from __future__ import annotations
 
+from enki.helpers import merge_light_state_payload
 
-def test_change_light_state_payload_order_for_power_off() -> None:
-    """Mirrors api.async_change_light_state merge: power OFF must win over default ON."""
+
+def test_merge_light_state_payload_power_off_wins() -> None:
     current = {"power": "ON", "brightness": 0.5, "colorTemperature": "T4000K"}
-    parameter = "power"
-    value = "OFF"
-    payload = dict(current)
-    payload["power"] = "ON"
-    payload[parameter] = value
+    payload = merge_light_state_payload(current, {"power": "OFF"})
     assert payload["power"] == "OFF"
+    assert payload["brightness"] == 0.5
+
+
+def test_merge_light_state_payload_turn_on_defaults_power() -> None:
+    current = {"power": "OFF", "brightness": 0.5, "colorTemperature": "T4000K"}
+    payload = merge_light_state_payload(current, {"power": "ON"})
+    assert payload["power"] == "ON"
+    assert payload["brightness"] == 0.5
+
+
+def test_merge_light_state_payload_brightness_update_keeps_on() -> None:
+    current = {"power": "OFF", "brightness": 0.2}
+    payload = merge_light_state_payload(current, {"brightness": 0.8})
+    assert payload["power"] == "ON"
+    assert payload["brightness"] == 0.8
 
 
 def test_fan_light_power_from_lighting_last_reported() -> None:


### PR DESCRIPTION
## Summary
- Add refresh-token flow to reduce intermittent auth failures (hass-enki-component #44, #8)
- Merge fan/light `change-light-state` payloads in a single API call (Siroco+ #71)
- Accept HTTP 204 as success for Enki command endpoints
- Add `serial_number` on device registry entries for distinct physical nodes (#63)
- Introduce `capabilities.py` foundation used by the API discovery refactor

## Test plan
- [x] `pytest tests/unit/test_api_auth.py` (refresh token)
- [x] `pytest tests/unit/test_command_status.py` (202/204)
- [x] `pytest tests/unit/test_fan_light_state.py` (payload merge)
- [x] `pytest tests/unit/test_fan_helpers.py`
- [x] Integration test signature updated for dict-based light API