### PR TITLE
feat: capability-based device support (fans, lights, inverters, outlets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ Mêmes identifiants que l’**application mobile Enki**. Pas de box supplémenta
 
 | Appareil | Dans Home Assistant |
 |----------|---------------------|
-| Ventilateur Inspire (Siroco+, Aruba+, etc.) | Un ventilateur + une lumière (kit LED) |
-| Luminaires Enki (Eglo, Lexman, …) | Une lumière |
+| Ventilateurs Inspire (Siroco+, Aruba+, Cadix, Radix, …) | Ventilateur + lumière kit |
+| Luminaires Enki (Eglo, Lexman, …) | Lumière (luminosité / blanc variable) |
+| Prises et interrupteurs connectés (Edisio, …) | Lumière ON/OFF (API power) |
+| Panneaux solaires Envertech-Lexman | Capteur de production (W) |
 
-**Pas encore disponible** : radiateurs, volets, prises, alarme. Vous pouvez [demander le support d’un appareil](https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=feature_request.yml) via GitHub.
+**Pas encore disponible** : radiateurs, volets, alarme. Vous pouvez [demander le support d’un appareil](https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=feature_request.yml) via GitHub.
+
+L’intégration détecte les appareils via leurs **capabilities** API (comme l’app mobile), pas seulement par modèle — les nouveaux ventilateurs Inspire ou luminaires compatibles sont pris en charge automatiquement.
 
 ### Ventilateur
 
@@ -83,7 +87,7 @@ Vous pouvez les ajouter au tableau de bord, aux automatisations et à Alexa/Goog
 Vérifiez e-mail et mot de passe sur l’app Enki. Testez une connexion sur le téléphone avant.
 
 **Aucun appareil détecté**  
-L’appareil doit être actif dans l’app Enki (même foyer). Seuls ventilateurs Inspire et luminaires sont pris en charge pour l’instant.
+L’appareil doit être actif dans l’app Enki (même foyer). Ventilateurs, luminaires, prises Edisio et onduleurs solaires Envertech sont pris en charge.
 
 **Le ventilateur ne réagit pas / erreur dans les journaux**  
 Redémarrez Home Assistant après une mise à jour HACS. Vérifiez que la box Enki est en ligne.

--- a/custom_components/enki/__init__.py
+++ b/custom_components/enki/__init__.py
@@ -21,7 +21,7 @@ __version__ = json.loads((Path(__file__).parent / "manifest.json").read_text(enc
     "version"
 ]
 
-PLATFORMS: list[Platform] = [Platform.FAN, Platform.LIGHT]
+PLATFORMS: list[Platform] = [Platform.FAN, Platform.LIGHT, Platform.SENSOR]
 
 type EnkiConfigEntry = ConfigEntry[EnkiCoordinator]
 

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -63,3 +63,26 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
             return
         device.last_reported_value[key] = value
         self.async_set_updated_data(self.data)
+
+    def update_cached_nested(self, node_id: str, parent_key: str, key: str, value: Any) -> None:
+        """Optimistically patch a nested value in cached device state."""
+        device = self.get_device_by_node(node_id)
+        if device is None or self.data is None:
+            return
+        parent = device.last_reported_value.setdefault(parent_key, {})
+        if isinstance(parent, dict):
+            parent[key] = value
+        self.async_set_updated_data(self.data)
+
+    def update_endpoint_power(self, node_id: str, endpoint_id: int, power: str) -> None:
+        """Optimistically update power for one electricalEndpoints entry."""
+        device = self.get_device_by_node(node_id)
+        if device is None or self.data is None:
+            return
+        endpoints = device.last_reported_value.get("electrical_endpoints")
+        if isinstance(endpoints, list):
+            for endpoint in endpoints:
+                if isinstance(endpoint, dict) and endpoint.get("id") == endpoint_id:
+                    endpoint["lastReportedValue"] = power
+                    break
+        self.async_set_updated_data(self.data)

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -1,4 +1,4 @@
-"""Fan platform for Enki ceiling fans (Inspire Siroco+, etc.)."""
+"""Fan platform for Enki ceiling fans (Inspire Siroco+, Cadix, Radix, …)."""
 
 from __future__ import annotations
 
@@ -18,12 +18,12 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from .const import DEVICE_TYPE_FANS, DOMAIN, FAN_SPEED_MAX, ORDERED_FAN_SPEEDS
+from .capabilities import fan_max_speed, is_fan_device
+from .const import DOMAIN, FAN_SPEED_MAX
 from .coordinator import EnkiCoordinator
 from .entity import EnkiEntity
 from .fan_helpers import (
     airflow_modes_from_metadata,
-    enki_airflow_mode_to_preset,
     infer_airflow_mode_supported,
     preset_to_enki_airflow_mode,
 )
@@ -40,7 +40,7 @@ async def async_setup_entry(
     async_add_entities(
         EnkiFanEntity(coordinator, device)
         for device in coordinator.data or []
-        if device.device_type == DEVICE_TYPE_FANS
+        if is_fan_device(device)
     )
 
 
@@ -53,6 +53,11 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-fan"
         self._preset_modes = airflow_modes_from_metadata(device)
+        self._ordered_speeds = self._build_ordered_speeds(device)
+
+    def _build_ordered_speeds(self, device: EnkiDevice) -> list[int]:
+        max_speed = fan_max_speed(device) or FAN_SPEED_MAX
+        return list(range(1, max_speed + 1))
 
     @property
     def supported_features(self) -> FanEntityFeature:
@@ -73,23 +78,32 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
     def preset_mode(self) -> str | None:
         if not self._supports_preset_mode():
             return None
-        return enki_airflow_mode_to_preset(self._device.last_reported_value.get("airflow_mode"))
+        mode = self._device.last_reported_value.get("airflow_mode")
+        if mode in self._preset_modes:
+            return mode
+        return None
 
     @property
     def is_on(self) -> bool:
-        return self._device.last_reported_value.get("fan_speed", 0) > 0
+        speed = self._device.last_reported_value.get("fan_speed")
+        if speed is not None:
+            return int(speed) > 0
+        power = self._device.last_reported_value.get("electrical_power")
+        return isinstance(power, str) and power == "ON"
 
     @property
     def percentage(self) -> int | None:
-        speed = self._device.last_reported_value.get("fan_speed", 0)
-        if speed <= 0:
+        speed = self._device.last_reported_value.get("fan_speed")
+        if speed is None:
+            return None
+        speed_value = int(speed)
+        if speed_value <= 0:
             return 0
-        return ordered_list_item_to_percentage(ORDERED_FAN_SPEEDS, speed)
+        return ordered_list_item_to_percentage(self._ordered_speeds, speed_value)
 
     @property
     def speed_count(self) -> int:
-        """Six discrete speeds; HA UI shows a stepped slider (≈17 % per step)."""
-        return FAN_SPEED_MAX
+        return len(self._ordered_speeds)
 
     @property
     def current_direction(self) -> str | None:
@@ -124,20 +138,48 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         if preset_mode is not None and self._supports_preset_mode():
             await self.async_set_preset_mode(preset_mode)
 
+        if self._device.last_reported_value.get("fan_speed") is None:
+            if percentage is None or percentage > 0:
+                await self.coordinator.api.async_switch_electrical_power(
+                    self._device.home_id,
+                    self._device.node_id,
+                    "ON",
+                )
+                self.coordinator.update_cached_value(
+                    self._device.node_id,
+                    "electrical_power",
+                    "ON",
+                )
+            return
+
         if percentage is not None and percentage > 0:
-            speed = percentage_to_ordered_list_item(ORDERED_FAN_SPEEDS, percentage)
+            speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
         else:
             speed = max(1, self._device.last_reported_value.get("fan_speed", 0) or 1)
         await self._set_speed(speed)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
+        if self._device.last_reported_value.get("fan_speed") is None:
+            await self.coordinator.api.async_switch_electrical_power(
+                self._device.home_id,
+                self._device.node_id,
+                "OFF",
+            )
+            self.coordinator.update_cached_value(
+                self._device.node_id,
+                "electrical_power",
+                "OFF",
+            )
+            return
         await self._set_speed(0)
 
     async def async_set_percentage(self, percentage: int) -> None:
         if percentage == 0:
             await self.async_turn_off()
             return
-        await self._set_speed(percentage_to_ordered_list_item(ORDERED_FAN_SPEEDS, percentage))
+        await self._set_speed(
+            percentage_to_ordered_list_item(self._ordered_speeds, percentage)
+        )
 
     async def _set_speed(self, speed: int) -> None:
         home_id = self._device.home_id

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -177,9 +177,7 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         if percentage == 0:
             await self.async_turn_off()
             return
-        await self._set_speed(
-            percentage_to_ordered_list_item(self._ordered_speeds, percentage)
-        )
+        await self._set_speed(percentage_to_ordered_list_item(self._ordered_speeds, percentage))
 
     async def _set_speed(self, speed: int) -> None:
         home_id = self._device.home_id

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.1.1"
+  "version": "1.1.2"
 }

--- a/custom_components/enki/sensor.py
+++ b/custom_components/enki/sensor.py
@@ -1,0 +1,66 @@
+"""Sensor platform for Enki devices (solar production, …)."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfPower
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .capabilities import capabilities_set as device_capabilities_set
+from .capabilities import is_inverter_device, supports_power_production
+from .const import DOMAIN
+from .coordinator import EnkiCoordinator
+from .entity import EnkiEntity
+from .models import EnkiDevice
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: EnkiCoordinator = entry.runtime_data
+    async_add_entities(
+        EnkiPowerProductionSensor(coordinator, device)
+        for device in coordinator.data or []
+        if _has_power_production_sensor(device)
+    )
+
+
+def _has_power_production_sensor(device: EnkiDevice) -> bool:
+    if device.power_production is None:
+        return False
+    if is_inverter_device(device):
+        return True
+    return supports_power_production(device_capabilities_set(device.capabilities))
+
+
+class EnkiPowerProductionSensor(EnkiEntity, SensorEntity):
+    """Live solar production from the Enki BFF dashboard."""
+
+    _attr_translation_key = "power_production"
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{DOMAIN}-{device.node_id}-power-production"
+
+    @property
+    def native_value(self) -> float | None:
+        value = self._device.power_production
+        if value is None:
+            value = self._device.last_reported_value.get("power_production")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -32,7 +32,7 @@
         "title": "Enki options",
         "data": {
           "scan_interval": "Polling interval (seconds)",
-          "telemetry": "Notify me about new devices (pre-filled GitHub issue link; nothing sent without your click)"
+          "telemetry": "Notify me about new or unsupported devices (anonymized; pre-filled GitHub link only — nothing sent without your click)"
         }
       }
     }
@@ -49,6 +49,14 @@
       },
       "light": {
         "name": "Light"
+      },
+      "outlet": {
+        "name": "Switch"
+      }
+    },
+    "sensor": {
+      "power_production": {
+        "name": "Power production"
       }
     }
   }

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -32,7 +32,7 @@
         "title": "Enki options",
         "data": {
           "scan_interval": "Polling interval (seconds)",
-          "telemetry": "Notify me about new devices (pre-filled GitHub issue link; nothing sent without your click)"
+          "telemetry": "Notify me about new or unsupported devices (anonymized; pre-filled GitHub link only — nothing sent without your click)"
         }
       }
     }
@@ -49,6 +49,14 @@
       },
       "light": {
         "name": "Light"
+      },
+      "outlet": {
+        "name": "Switch"
+      }
+    },
+    "sensor": {
+      "power_production": {
+        "name": "Power production"
       }
     }
   }

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -32,7 +32,7 @@
         "title": "Options Enki",
         "data": {
           "scan_interval": "Intervalle de rafraîchissement (secondes)",
-          "telemetry": "M’avertir des nouveaux appareils (lien issue GitHub ; rien n’est envoyé sans votre clic)"
+          "telemetry": "M’avertir des appareils nouveaux ou non supportés (anonymisé ; lien GitHub pré-rempli — rien n’est envoyé sans votre clic)"
         }
       }
     }
@@ -49,6 +49,14 @@
       },
       "light": {
         "name": "Lumière"
+      },
+      "outlet": {
+        "name": "Interrupteur"
+      }
+    },
+    "sensor": {
+      "power_production": {
+        "name": "Production"
       }
     }
   }

--- a/docs/API.md
+++ b/docs/API.md
@@ -42,10 +42,16 @@ sequenceDiagram
 
 ## Supported device types (this integration)
 
-| BFF / referentiel type | HA platforms | Backend services |
+Detection is **capability-based** (referentiel metadata + BFF dashboard), not limited to a fixed list of model names.
+
+| Referentiel / BFF type | HA platforms | Backend services |
 |------------------------|--------------|------------------|
-| `ceiling_fans` | `fan` + `light` | `api-enki-airflow-prod`, `api-enki-lighting-prod`, `api-enki-power-prod` |
-| `lights` | `light` | `api-enki-lighting-prod` |
+| `ceiling_fans` (+ fan capabilities) | `fan` + `light` | `api-enki-airflow-prod`, `api-enki-lighting-prod`, `api-enki-power-prod` |
+| `lights` (+ light capabilities) | `light` | `api-enki-lighting-prod` |
+| Switches / outlets (Edisio, …) | `light` (ON/OFF) | `api-enki-power-prod` (`switch-electrical-power`) |
+| `inverters` (Envertech-Lexman solar) | `sensor` (power W) | BFF dashboard `description.value` |
+
+Multi-endpoint lights (several circuits on one node) create one HA light entity per BFF `mainChangeCapability` endpoint.
 
 ### Ceiling fan (Inspire Siroco+, ESDK)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ _HA_STUBS = [
     "homeassistant.components.light.const",
     "homeassistant.components.diagnostics",
     "homeassistant.components.persistent_notification",
+    "homeassistant.components.sensor",
 ]
 
 for module_name in _HA_STUBS:

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -1,0 +1,75 @@
+"""Unit tests for capability-based device detection."""
+
+from __future__ import annotations
+
+from enki.capabilities import (
+    device_is_supported,
+    device_uses_power_api_only,
+    fan_max_speed,
+    is_fan_device,
+    is_inverter_device,
+    is_light_controllable,
+    main_change_capability_endpoints,
+    parse_bff_power,
+)
+from enki.models import EnkiDevice
+
+
+def _device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home",
+        "device_id": "device",
+        "node_id": "node",
+        "device_name": "Test",
+        "device_type": "unknown",
+        "is_enabled": True,
+        "state": "ACTIVE",
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def test_parse_bff_power() -> None:
+    assert parse_bff_power({"value": "109 W"}) == 109.0
+    assert parse_bff_power({"value": "bad"}) is None
+
+
+def test_is_fan_device_from_capabilities() -> None:
+    device = _device(
+        device_type="ventilation",
+        capabilities=["change_fan_speed"],
+    )
+    assert is_fan_device(device) is True
+
+
+def test_is_inverter_device() -> None:
+    device = _device(
+        device_type="inverters",
+        capabilities=["check_power_production"],
+        power_production=250.0,
+    )
+    assert is_inverter_device(device) is True
+    assert device_is_supported(device) is True
+
+
+def test_device_uses_power_api_only() -> None:
+    device = _device(
+        capabilities=["switch_electrical_power", "check_electrical_power"],
+    )
+    assert device_uses_power_api_only(device) is True
+    assert is_light_controllable(device) is True
+
+
+def test_main_change_capability_endpoints() -> None:
+    device = _device(
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[2, 3],
+    )
+    assert main_change_capability_endpoints(device) == [2, 3]
+
+
+def test_fan_max_speed_from_metadata() -> None:
+    device = _device(
+        possible_values={"change_fan_speed": {"range": {"min": 0, "max": 5}}},
+    )
+    assert fan_max_speed(device) == 5


### PR DESCRIPTION
## Summary
- Refactor device discovery to use Enki BFF capabilities instead of hardcoded device types
- Add solar production sensor platform for inverters
- Support Edisio outlets via electrical power API
- Extend fan/light platforms for capability-based profiles and multi-endpoint lights

Re-opened after stacked merge of #8 closed the previous PR #9 base branch.

## Test plan
- [x] Unit tests pass (48+)
- [x] CI green (lint, hassfest, hacs)