### PR TITLE
feat: telemetry onboarding, OOP refactor, and legacy nudge

### DIFF
--- a/custom_components/enki/__init__.py
+++ b/custom_components/enki/__init__.py
@@ -41,6 +41,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnkiConfigEntry) -> bool
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
+    from .telemetry_nudge import async_handle_telemetry_nudge
+
+    await async_handle_telemetry_nudge(hass, entry)
+
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/custom_components/enki/api.py
+++ b/custom_components/enki/api.py
@@ -2,57 +2,37 @@
 
 from __future__ import annotations
 
-import time
 from typing import Any
 
 import aiohttp
 
-from .capabilities import (
-    is_fan_device,
-    is_inverter_device,
-    parse_bff_power,
-    supports_airflow_mode,
-    supports_electrical_power,
-    supports_fan_speed,
-    supports_light_state,
-)
-from .const import (
-    DEVICE_TYPE_LIGHTS,
-    ENKI_AIRFLOW_API_KEY,
-    ENKI_BASE_URL,
-    ENKI_BFF_API_KEY,
-    ENKI_HOME_API_KEY,
-    ENKI_LIGHTS_API_KEY,
-    ENKI_NODE_API_KEY,
-    ENKI_OIDC_URL,
-    ENKI_POWER_API_KEY,
-    ENKI_REFERENTIEL_API_KEY,
-    LOGGER,
-    REFERENTIEL_VERSION,
-)
+from .auth import EnkiAuthSession
+from .capabilities import parse_bff_power
+from .const import DEVICE_TYPE_LIGHTS, LOGGER
 from .device_profile import build_discovery_record, integration_supports_device
-from .exceptions import EnkiApiNotFoundError, EnkiAuthError, EnkiConnectionError
+from .exceptions import EnkiApiNotFoundError, EnkiConnectionError
 from .helpers import (
     direction_to_enki_rotation,
     enki_rotation_to_direction,
-    is_command_success_status,
     merge_light_state_payload,
     normalize_power_state,
 )
+from .http_client import EnkiHttpClient
 from .models import EnkiDevice, EnkiDiscoveryRecord
 
 
 class EnkiAPI:
-    """Async client for the unofficial Enki REST API."""
+    """Async facade over Enki REST micro-services.
+
+    Composes :class:`EnkiAuthSession` (OAuth) and :class:`EnkiHttpClient`
+    (per-domain HTTP). Platform modules call the public ``async_*`` methods;
+    discovery and state refresh stay internal.
+    """
 
     def __init__(self, username: str, password: str) -> None:
-        self._username = username
-        self._password = password
-        self._access_token: str | None = None
-        self._refresh_token: str | None = None
-        self._token_type = "Bearer"
-        self._token_expires_at = 0.0
+        self._auth = EnkiAuthSession(username, password)
         self._session: aiohttp.ClientSession | None = None
+        self._http: EnkiHttpClient | None = None
         self._discovery_records: list[EnkiDiscoveryRecord] = []
 
     async def async_close(self) -> None:
@@ -60,95 +40,35 @@ class EnkiAPI:
         if self._session and not self._session.closed:
             await self._session.close()
         self._session = None
+        self._http = None
 
-    async def _get_session(self) -> aiohttp.ClientSession:
+    async def _ensure_token(self) -> None:
+        """Ensure a valid OAuth token (refresh, then password grant)."""
+        http = await self._get_http()
+        await http.ensure_token()
+
+    async def _get_http(self) -> EnkiHttpClient:
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=30),
             )
-        return self._session
-
-    async def _ensure_token(self) -> None:
-        if self._access_token and time.time() < self._token_expires_at - 30:
-            return
-        if self._refresh_token:
-            try:
-                await self._refresh_access_token()
-                return
-            except EnkiAuthError:
-                LOGGER.debug("Refresh token rejected, falling back to password grant")
-        await self.async_connect()
-
-    async def _refresh_access_token(self) -> None:
-        """Renew the access token without sending the account password again."""
-        if not self._refresh_token:
-            raise EnkiAuthError("No refresh token available")
-        session = await self._get_session()
-        try:
-            async with session.post(
-                ENKI_OIDC_URL,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                data={
-                    "grant_type": "refresh_token",
-                    "refresh_token": self._refresh_token,
-                    "client_id": "enki-front",
-                },
-            ) as response:
-                if response.status != 200:
-                    raise EnkiAuthError(f"Token refresh failed: HTTP {response.status}")
-                payload = await response.json()
-        except aiohttp.ClientError as err:
-            raise EnkiConnectionError(f"Cannot reach Enki auth: {err}") from err
-
-        self._access_token = payload["access_token"]
-        self._token_type = payload.get("token_type", "Bearer")
-        self._token_expires_at = time.time() + payload["expires_in"]
-        if refreshed := payload.get("refresh_token"):
-            self._refresh_token = refreshed
-        LOGGER.debug("Enki token refreshed, expires in %ss", payload["expires_in"])
-
-    def _auth_headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
-        headers = {"Authorization": f"{self._token_type} {self._access_token}"}
-        if extra:
-            headers.update(extra)
-        return headers
+            self._http = EnkiHttpClient(self._auth, self._session)
+        assert self._http is not None
+        return self._http
 
     async def async_connect(self) -> None:
         """Authenticate with Keycloak (resource-owner password grant)."""
-        session = await self._get_session()
-        try:
-            async with session.post(
-                ENKI_OIDC_URL,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                data={
-                    "grant_type": "password",
-                    "client_id": "enki-front",
-                    "username": self._username,
-                    "password": self._password,
-                },
-            ) as response:
-                if response.status == 401:
-                    raise EnkiAuthError("Invalid username or password")
-                if response.status != 200:
-                    raise EnkiConnectionError(f"Authentication failed: HTTP {response.status}")
-                payload = await response.json()
-        except aiohttp.ClientError as err:
-            raise EnkiConnectionError(f"Cannot reach Enki auth: {err}") from err
-
-        self._access_token = payload["access_token"]
-        self._refresh_token = payload.get("refresh_token")
-        self._token_type = payload.get("token_type", "Bearer")
-        self._token_expires_at = time.time() + payload["expires_in"]
-        LOGGER.debug("Enki session established, expires in %ss", payload["expires_in"])
+        http = await self._get_http()
+        await self._auth.connect(http.session)
 
     async def async_get_devices(self) -> list[EnkiDevice]:
         """Discover all nodes across every home on the account."""
-        await self._ensure_token()
-        homes = await self._get_homes()
+        http = await self._get_http()
+        homes = await http.get_homes()
         devices: list[EnkiDevice] = []
         self._discovery_records = []
         for home_id in homes:
-            home_devices, records = await self._get_devices_for_home(home_id)
+            home_devices, records = await self._discover_home(http, home_id)
             devices.extend(home_devices)
             self._discovery_records.extend(records)
         return devices
@@ -157,192 +77,147 @@ class EnkiAPI:
     def discovery_records(self) -> list[EnkiDiscoveryRecord]:
         return list(self._discovery_records)
 
-    async def _get_homes(self) -> list[str]:
-        session = await self._get_session()
-        async with session.get(
-            f"{ENKI_BASE_URL}/api-enki-home-prod/v1/homes",
-            headers=self._auth_headers({"X-Gateway-APIKey": ENKI_HOME_API_KEY}),
-        ) as response:
-            if response.status != 200:
-                raise EnkiConnectionError(f"get_homes failed: HTTP {response.status}")
-            data = await response.json()
-            return [home["id"] for home in data["items"]]
-
-    async def _get_devices_for_home(
+    async def _discover_home(
         self,
+        http: EnkiHttpClient,
         home_id: str,
     ) -> tuple[list[EnkiDevice], list[EnkiDiscoveryRecord]]:
-        session = await self._get_session()
-        async with session.get(
-            (
-                f"{ENKI_BASE_URL}/api-enki-mobile-bff-prod/v1/dashboard/homes/"
-                f"{home_id}?hasGroups=true"
-            ),
-            headers=self._auth_headers({"X-Gateway-APIKey": ENKI_BFF_API_KEY}),
-        ) as response:
-            if response.status != 200:
-                raise EnkiConnectionError(f"dashboard failed: HTTP {response.status}")
-            dashboard = await response.json()
-
+        dashboard = await http.get_dashboard(home_id)
         devices: list[EnkiDevice] = []
         records: list[EnkiDiscoveryRecord] = []
+
         for section in dashboard.get("sections", []):
             for item in section.get("items", []):
-                metadata = item.get("metadata", {})
-                if "nodeId" not in metadata:
-                    continue
-
-                node_id = metadata["nodeId"]
-                device_id = metadata["deviceId"]
-                bff_type = metadata.get("deviceType", "")
-                main_change_capability = metadata.get("mainChangeCapability") or {}
-                main_change_endpoints = [
-                    endpoint.get("id")
-                    for endpoint in main_change_capability.get("endpoints", [])
-                    if endpoint.get("id") is not None
-                ]
-
-                node_info = await self._get_node(home_id, node_id)
-                device_info = await self._get_device_info_safe(device_id)
-                device_type = device_info.get("type") or bff_type
-                capabilities = device_info.get("capabilities", [])
-                possible_values = device_info.get("possibleValues", {})
-                power_production = parse_bff_power(item.get("description"))
-
-                probe_device = EnkiDevice(
-                    home_id=home_id,
-                    device_id=device_id,
-                    node_id=node_id,
-                    device_name=item["title"]["label"],
-                    device_type=device_type,
-                    is_enabled=item["isEnabled"],
-                    state=item["state"],
-                    capabilities=capabilities,
-                    possible_values=possible_values,
-                    bff_device_type=bff_type,
-                    main_change_capability_id=metadata.get("mainChangeCapabilityId"),
-                    main_change_capability_endpoints=main_change_endpoints,
-                    power_production=power_production,
-                )
-                supported = integration_supports_device(probe_device)
-
-                manufacturer = (
-                    node_info.get("manufacturerId")
-                    or device_info.get("manufacturerId")
-                    or device_info.get("manufacturer")
-                )
-                model = node_info.get("modelNumber") or device_info.get("modelNumber")
-                firmware = node_info.get("version") or device_info.get("version")
-
-                records.append(
-                    build_discovery_record(
-                        device_type=device_type,
-                        bff_device_type=bff_type,
-                        capabilities=capabilities,
-                        possible_values=possible_values,
-                        manufacturer=str(manufacturer) if manufacturer else None,
-                        model=str(model) if model else None,
-                        firmware_version=str(firmware) if firmware else None,
-                        supported_by_integration=supported,
-                    )
-                )
-
-                last_reported: dict[str, Any] = {}
-                if item["isEnabled"]:
-                    last_reported = await self._refresh_device_state(
-                        home_id,
-                        node_id,
-                        probe_device,
-                        node_info,
-                    )
-
-                if not supported:
-                    LOGGER.debug(
-                        "Skipping unsupported Enki device type %s (%s)",
-                        device_type,
-                        item.get("title", {}).get("label"),
-                    )
-                    continue
-
-                devices.append(
-                    EnkiDevice(
-                        home_id=home_id,
-                        device_id=device_id,
-                        node_id=node_id,
-                        device_name=item["title"]["label"],
-                        device_type=device_type,
-                        is_enabled=item["isEnabled"],
-                        state=item["state"],
-                        capabilities=capabilities,
-                        possible_values=possible_values,
-                        last_reported_value={**node_info, **last_reported},
-                        bff_device_type=bff_type,
-                        main_change_capability_id=metadata.get("mainChangeCapabilityId"),
-                        main_change_capability_endpoints=main_change_endpoints,
-                        power_production=power_production,
-                    )
-                )
+                device, record = await self._discover_dashboard_item(http, home_id, item)
+                if record is not None:
+                    records.append(record)
+                if device is not None:
+                    devices.append(device)
         return devices, records
 
-    async def _get_node(self, home_id: str, node_id: str) -> dict[str, Any]:
-        session = await self._get_session()
-        async with session.get(
-            f"{ENKI_BASE_URL}/api-enki-node-agg-prod/v1/nodes/{node_id}",
-            headers=self._auth_headers(
-                {
-                    "X-Gateway-APIKey": ENKI_NODE_API_KEY,
-                    "homeId": home_id,
-                }
-            ),
-        ) as response:
-            if response.status != 200:
-                raise EnkiConnectionError(f"get_node failed: HTTP {response.status}")
-            return await response.json()
+    async def _discover_dashboard_item(
+        self,
+        http: EnkiHttpClient,
+        home_id: str,
+        item: dict[str, Any],
+    ) -> tuple[EnkiDevice | None, EnkiDiscoveryRecord | None]:
+        metadata = item.get("metadata", {})
+        if "nodeId" not in metadata:
+            return None, None
 
-    async def _get_device_info_safe(self, device_id: str) -> dict[str, Any]:
-        """Referentiel metadata; ESDK fan nodes may return 404."""
-        session = await self._get_session()
-        async with session.get(
-            (
-                f"{ENKI_BASE_URL}/api-enki-referentiel-agg-prod/v1/devices/"
-                f"{device_id}?version={REFERENTIEL_VERSION}"
+        node_id = metadata["nodeId"]
+        device_id = metadata["deviceId"]
+        bff_type = metadata.get("deviceType", "")
+        main_change_capability = metadata.get("mainChangeCapability") or {}
+        main_change_endpoints = [
+            endpoint.get("id")
+            for endpoint in main_change_capability.get("endpoints", [])
+            if endpoint.get("id") is not None
+        ]
+
+        node_info = await http.get_node(home_id, node_id)
+        device_info = await http.get_referentiel_device(device_id)
+        device_type = device_info.get("type") or bff_type
+        capabilities = device_info.get("capabilities", [])
+        possible_values = device_info.get("possibleValues", {})
+        power_production = parse_bff_power(item.get("description"))
+
+        skeleton = EnkiDevice(
+            home_id=home_id,
+            device_id=device_id,
+            node_id=node_id,
+            device_name=item["title"]["label"],
+            device_type=device_type,
+            is_enabled=item["isEnabled"],
+            state=item["state"],
+            capabilities=capabilities,
+            possible_values=possible_values,
+            bff_device_type=bff_type,
+            main_change_capability_id=metadata.get("mainChangeCapabilityId"),
+            main_change_capability_endpoints=main_change_endpoints,
+            power_production=power_production,
+        )
+        supported = integration_supports_device(skeleton)
+
+        manufacturer = (
+            node_info.get("manufacturerId")
+            or device_info.get("manufacturerId")
+            or device_info.get("manufacturer")
+        )
+        model = node_info.get("modelNumber") or device_info.get("modelNumber")
+        firmware = node_info.get("version") or device_info.get("version")
+
+        record = build_discovery_record(
+            device_type=device_type,
+            bff_device_type=bff_type,
+            capabilities=capabilities,
+            possible_values=possible_values,
+            manufacturer=str(manufacturer) if manufacturer else None,
+            model=str(model) if model else None,
+            firmware_version=str(firmware) if firmware else None,
+            supported_by_integration=supported,
+        )
+
+        last_reported: dict[str, Any] = {}
+        if item["isEnabled"]:
+            last_reported = await self._refresh_device_state(http, skeleton, node_info)
+
+        if not supported:
+            LOGGER.debug(
+                "Skipping unsupported Enki device type %s (%s)",
+                device_type,
+                item.get("title", {}).get("label"),
+            )
+            return None, record
+
+        return (
+            EnkiDevice(
+                home_id=home_id,
+                device_id=device_id,
+                node_id=node_id,
+                device_name=item["title"]["label"],
+                device_type=device_type,
+                is_enabled=item["isEnabled"],
+                state=item["state"],
+                capabilities=capabilities,
+                possible_values=possible_values,
+                last_reported_value={**node_info, **last_reported},
+                bff_device_type=bff_type,
+                main_change_capability_id=metadata.get("mainChangeCapabilityId"),
+                main_change_capability_endpoints=main_change_endpoints,
+                power_production=power_production,
             ),
-            headers=self._auth_headers({"X-Gateway-APIKey": ENKI_REFERENTIEL_API_KEY}),
-        ) as response:
-            if response.status == 404:
-                return {}
-            if response.status != 200:
-                raise EnkiConnectionError(f"get_device_info failed: HTTP {response.status}")
-            return await response.json()
+            record,
+        )
 
     async def _refresh_device_state(
         self,
-        home_id: str,
-        node_id: str,
+        http: EnkiHttpClient,
         device: EnkiDevice,
         node_info: dict[str, Any],
     ) -> dict[str, Any]:
         """Load live state based on referentiel capabilities (not only device type)."""
-        caps = {cap for cap in device.capabilities if isinstance(cap, str)}
-        possible = device.possible_values if isinstance(device.possible_values, dict) else {}
+        profile = device.profile
+        home_id = device.home_id
+        node_id = device.node_id
 
-        if is_fan_device(device):
-            return await self._get_fan_full_state(home_id, node_id)
+        if profile.is_fan:
+            return await self._read_fan_state(http, home_id, node_id)
 
         state: dict[str, Any] = {}
 
-        if supports_light_state(caps, possible) or device.device_type == DEVICE_TYPE_LIGHTS:
+        if profile.supports_light_state or device.device_type == DEVICE_TYPE_LIGHTS:
             try:
-                light_state = await self._get_light_state_payload(home_id, node_id)
+                light_state = await self._read_light_payload(http, home_id, node_id)
                 state.update(light_state)
                 if light_state.get("power"):
                     state["light_power"] = light_state["power"]
             except EnkiConnectionError as err:
                 LOGGER.debug("Light state skipped for node %s: %s", node_id, err)
 
-        if supports_electrical_power(caps, possible):
+        if profile.supports_electrical_power:
             try:
-                power_details = await self._get_electrical_power_details(home_id, node_id)
+                power_details = await http.get_electrical_power(home_id, node_id)
                 state["electrical_power"] = power_details.get("lastReportedValue")
                 state["electrical_endpoints"] = power_details.get("endpoints", [])
                 if not state.get("power") and isinstance(state["electrical_power"], str):
@@ -350,77 +225,41 @@ class EnkiAPI:
             except EnkiConnectionError as err:
                 LOGGER.debug("Electrical power skipped for node %s: %s", node_id, err)
 
-        if supports_fan_speed(caps, possible):
+        if profile.supports_fan_speed:
             try:
-                state["fan_speed"] = await self._get_fan_speed(home_id, node_id)
+                data = await http.airflow_get(home_id, node_id, "check-fan-speed")
+                state["fan_speed"] = data["lastReportedValue"]
             except EnkiConnectionError as err:
                 LOGGER.debug("Fan speed skipped for node %s: %s", node_id, err)
 
-        if supports_airflow_mode(caps, possible):
+        if profile.supports_airflow_mode:
             try:
-                state["airflow_mode"] = await self._get_airflow_mode(home_id, node_id)
+                data = await http.airflow_get(home_id, node_id, "check-airflow-mode")
+                state["airflow_mode"] = data["lastReportedValue"]
             except EnkiConnectionError as err:
                 LOGGER.debug("Airflow mode skipped for node %s: %s", node_id, err)
 
-        if is_inverter_device(device):
+        if profile.is_inverter:
             state["power_production"] = device.power_production
 
         return state
 
-    async def _get_electrical_power_details(
+    async def _read_fan_state(
         self,
+        http: EnkiHttpClient,
         home_id: str,
         node_id: str,
     ) -> dict[str, Any]:
-        session = await self._get_session()
-        async with session.get(
-            f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/{node_id}/check-electrical-power",
-            headers=self._auth_headers(
-                {
-                    "X-Gateway-APIKey": ENKI_POWER_API_KEY,
-                    "homeId": home_id,
-                }
-            ),
-        ) as response:
-            if response.status == 404:
-                return {}
-            if response.status != 200:
-                raise EnkiConnectionError(f"check-electrical-power failed: HTTP {response.status}")
-            return await response.json()
-
-    async def async_switch_electrical_power(
-        self,
-        home_id: str,
-        node_id: str,
-        value: str,
-    ) -> None:
-        """Switch global electrical power (sockets, outlets without lighting API)."""
-        await self._ensure_token()
-        session = await self._get_session()
-        async with session.post(
-            (f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/{node_id}/switch-electrical-power"),
-            headers=self._auth_headers(
-                {
-                    "X-Gateway-APIKey": ENKI_POWER_API_KEY,
-                    "homeId": home_id,
-                }
-            ),
-            json={"value": value},
-        ) as response:
-            if not is_command_success_status(response.status):
-                raise EnkiConnectionError(f"switch-electrical-power failed: HTTP {response.status}")
-
-    async def _get_fan_full_state(self, home_id: str, node_id: str) -> dict[str, Any]:
-        speed = await self._get_fan_speed(home_id, node_id)
-        mode = await self._get_airflow_mode(home_id, node_id)
-        rotation, rotation_supported = await self._get_fan_rotation(home_id, node_id)
-        light_state = await self._get_light_state(home_id, node_id)
+        speed_data = await http.airflow_get(home_id, node_id, "check-fan-speed")
+        mode_data = await http.airflow_get(home_id, node_id, "check-airflow-mode")
+        rotation, rotation_supported = await self._read_fan_rotation(http, home_id, node_id)
+        light_state = await http.get_light_state(home_id, node_id)
         last_reported = light_state.get("lastReportedValue", {})
-        # ESDK fan kit on/off is reported by api-enki-lighting-prod (`power`), not power-prod.
         light_power = last_reported.get("power", "OFF")
+
         state: dict[str, Any] = {
-            "fan_speed": speed,
-            "airflow_mode": mode,
+            "fan_speed": speed_data["lastReportedValue"],
+            "airflow_mode": mode_data["lastReportedValue"],
             "airflow_rotation": rotation,
             "airflow_rotation_supported": rotation_supported,
             "light_power": light_power,
@@ -429,118 +268,52 @@ class EnkiAPI:
             "power": last_reported.get("power"),
         }
         try:
-            power_details = await self._get_electrical_power_details(home_id, node_id)
+            power_details = await http.get_electrical_power(home_id, node_id)
             state["electrical_power"] = power_details.get("lastReportedValue")
             state["electrical_endpoints"] = power_details.get("endpoints", [])
         except EnkiConnectionError as err:
             LOGGER.debug("Electrical power skipped for fan node %s: %s", node_id, err)
         return state
 
-    async def _get_power_state(self, home_id: str, node_id: str, endpoint: int) -> str:
-        session = await self._get_session()
-        async with session.get(
-            (
-                f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/{node_id}/"
-                f"check-electrical-power?endpoints={endpoint}"
-            ),
-            headers=self._auth_headers(
-                {
-                    "X-Gateway-APIKey": ENKI_POWER_API_KEY,
-                    "homeId": home_id,
-                }
-            ),
-        ) as response:
-            if response.status != 200:
-                raise EnkiConnectionError(f"check-electrical-power failed: HTTP {response.status}")
-            data = await response.json()
-            return normalize_power_state(data.get("lastReportedValue"), endpoint)
-
-    def _airflow_headers(self, home_id: str) -> dict[str, str]:
-        return self._auth_headers(
-            {
-                "X-Gateway-APIKey": ENKI_AIRFLOW_API_KEY,
-                "homeId": home_id,
-            }
-        )
-
-    async def _airflow_get(
+    async def _read_fan_rotation(
         self,
-        home_id: str,
-        node_id: str,
-        action: str,
-    ) -> dict[str, Any]:
-        session = await self._get_session()
-        async with session.get(
-            f"{ENKI_BASE_URL}/api-enki-airflow-prod/v1/airflow/{node_id}/{action}",
-            headers=self._airflow_headers(home_id),
-        ) as response:
-            if response.status == 404:
-                raise EnkiApiNotFoundError(f"{action} not found", status=404)
-            if response.status != 200:
-                raise EnkiConnectionError(
-                    f"{action} failed: HTTP {response.status}",
-                    status=response.status,
-                )
-            return await response.json()
-
-    async def _airflow_post(
-        self,
-        home_id: str,
-        node_id: str,
-        action: str,
-        value: Any,
-    ) -> None:
-        session = await self._get_session()
-        async with session.post(
-            f"{ENKI_BASE_URL}/api-enki-airflow-prod/v1/airflow/{node_id}/{action}",
-            headers=self._airflow_headers(home_id),
-            json={"value": value},
-        ) as response:
-            if response.status == 404:
-                raise EnkiApiNotFoundError(f"{action} not found", status=404)
-            if response.status != 202 and response.status != 204:
-                raise EnkiConnectionError(
-                    f"{action} failed: HTTP {response.status}",
-                    status=response.status,
-                )
-
-    async def _get_fan_speed(self, home_id: str, node_id: str) -> int:
-        data = await self._airflow_get(home_id, node_id, "check-fan-speed")
-        return data["lastReportedValue"]
-
-    async def _get_airflow_mode(self, home_id: str, node_id: str) -> str:
-        data = await self._airflow_get(home_id, node_id, "check-airflow-mode")
-        return data["lastReportedValue"]
-
-    async def _try_airflow_get(
-        self,
-        home_id: str,
-        node_id: str,
-        action: str,
-    ) -> dict[str, Any] | None:
-        """Best-effort airflow read; never fails discovery (404/500 on optional probes)."""
-        try:
-            return await self._airflow_get(home_id, node_id, action)
-        except (EnkiApiNotFoundError, EnkiConnectionError) as err:
-            LOGGER.debug(
-                "Optional airflow %s for node %s skipped: %s",
-                action,
-                node_id,
-                err,
-            )
-            return None
-
-    async def _get_fan_rotation(
-        self,
+        http: EnkiHttpClient,
         home_id: str,
         node_id: str,
     ) -> tuple[str | None, bool]:
-        """Return (HA direction, supported) via check-fan-rotation-direction."""
-        data = await self._try_airflow_get(home_id, node_id, "check-fan-rotation-direction")
-        if data is None:
+        """Best-effort rotation read; optional probes must not fail discovery."""
+        try:
+            data = await http.airflow_get(home_id, node_id, "check-fan-rotation-direction")
+        except (EnkiApiNotFoundError, EnkiConnectionError) as err:
+            LOGGER.debug(
+                "Optional airflow check-fan-rotation-direction for node %s skipped: %s",
+                node_id,
+                err,
+            )
             return None, False
         direction = enki_rotation_to_direction(data.get("lastReportedValue"))
         return direction, True
+
+    async def _read_light_payload(
+        self,
+        http: EnkiHttpClient,
+        home_id: str,
+        node_id: str,
+    ) -> dict[str, Any]:
+        state = await http.get_light_state(home_id, node_id)
+        return state.get("lastReportedValue", {})
+
+    # --- public command API --------------------------------------------------
+
+    async def async_switch_electrical_power(
+        self,
+        home_id: str,
+        node_id: str,
+        value: str,
+    ) -> None:
+        """Switch global electrical power (sockets, outlets without lighting API)."""
+        http = await self._get_http()
+        await http.switch_electrical_power(home_id, node_id, value)
 
     async def async_set_fan_rotation(
         self,
@@ -549,31 +322,19 @@ class EnkiAPI:
         direction: str,
     ) -> None:
         """Set blade rotation via change-fan-rotation-direction."""
-        await self._ensure_token()
+        http = await self._get_http()
         enki_value = direction_to_enki_rotation(direction)
-        await self._airflow_post(home_id, node_id, "change-fan-rotation-direction", enki_value)
+        await http.airflow_post(home_id, node_id, "change-fan-rotation-direction", enki_value)
 
     async def async_set_airflow_mode(self, home_id: str, node_id: str, mode: str) -> None:
         """Set ventilation mode (MANUAL / BREEZE)."""
-        await self._ensure_token()
-        await self._airflow_post(home_id, node_id, "change-airflow-mode", mode)
+        http = await self._get_http()
+        await http.airflow_post(home_id, node_id, "change-airflow-mode", mode)
 
     async def async_set_fan_speed(self, home_id: str, node_id: str, speed: int) -> None:
         """Set fan speed (0 = off, 1–6 = levels)."""
-        await self._ensure_token()
-        session = await self._get_session()
-        async with session.post(
-            f"{ENKI_BASE_URL}/api-enki-airflow-prod/v1/airflow/{node_id}/change-fan-speed",
-            headers=self._auth_headers(
-                {
-                    "X-Gateway-APIKey": ENKI_AIRFLOW_API_KEY,
-                    "homeId": home_id,
-                }
-            ),
-            json={"value": speed},
-        ) as response:
-            if response.status != 202 and response.status != 204:
-                raise EnkiConnectionError(f"change-fan-speed failed: HTTP {response.status}")
+        http = await self._get_http()
+        await http.airflow_post(home_id, node_id, "change-fan-speed", speed)
 
     async def async_set_light_power(self, home_id: str, node_id: str, on: bool) -> None:
         """Turn the ESDK fan light kit on or off (lighting API)."""
@@ -583,49 +344,6 @@ class EnkiAPI:
             {"power": "ON" if on else "OFF"},
         )
 
-    async def _switch_power(
-        self,
-        home_id: str,
-        node_id: str,
-        endpoint: int,
-        value: str,
-    ) -> None:
-        session = await self._get_session()
-        async with session.post(
-            (
-                f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/{node_id}/"
-                f"switch-electrical-power?endpoints={endpoint}"
-            ),
-            headers=self._auth_headers(
-                {
-                    "X-Gateway-APIKey": ENKI_POWER_API_KEY,
-                    "homeId": home_id,
-                }
-            ),
-            json={"value": value},
-        ) as response:
-            if not is_command_success_status(response.status):
-                raise EnkiConnectionError(f"switch-electrical-power failed: HTTP {response.status}")
-
-    async def _get_light_state(self, home_id: str, node_id: str) -> dict[str, Any]:
-        session = await self._get_session()
-        async with session.get(
-            f"{ENKI_BASE_URL}/api-enki-lighting-prod/v1/lighting/{node_id}/check-light-state",
-            headers=self._auth_headers(
-                {
-                    "X-Gateway-APIKey": ENKI_LIGHTS_API_KEY,
-                    "homeId": home_id,
-                }
-            ),
-        ) as response:
-            if response.status != 200:
-                raise EnkiConnectionError(f"check-light-state failed: HTTP {response.status}")
-            return await response.json()
-
-    async def _get_light_state_payload(self, home_id: str, node_id: str) -> dict[str, Any]:
-        state = await self._get_light_state(home_id, node_id)
-        return state.get("lastReportedValue", {})
-
     async def async_change_light_state(
         self,
         home_id: str,
@@ -633,25 +351,13 @@ class EnkiAPI:
         changes: dict[str, Any],
     ) -> None:
         """Apply one or more lighting fields in a single change-light-state call."""
-        await self._ensure_token()
-        current = await self._get_light_state(home_id, node_id)
+        http = await self._get_http()
+        current = await http.get_light_state(home_id, node_id)
         payload = merge_light_state_payload(
             current.get("lastReportedValue", {}),
             changes,
         )
-        session = await self._get_session()
-        async with session.post(
-            f"{ENKI_BASE_URL}/api-enki-lighting-prod/v1/lighting/{node_id}/change-light-state",
-            headers=self._auth_headers(
-                {
-                    "X-Gateway-APIKey": ENKI_LIGHTS_API_KEY,
-                    "homeId": home_id,
-                }
-            ),
-            json=payload,
-        ) as response:
-            if not is_command_success_status(response.status):
-                raise EnkiConnectionError(f"change-light-state failed: HTTP {response.status}")
+        await http.change_light_state(home_id, node_id, payload)
 
     async def async_change_light_state_field(
         self,
@@ -662,3 +368,9 @@ class EnkiAPI:
     ) -> None:
         """Backward-compatible wrapper for single-field lighting updates."""
         await self.async_change_light_state(home_id, node_id, {parameter: value})
+
+    async def _get_power_state(self, home_id: str, node_id: str, endpoint: int) -> str:
+        """Read one endpoint power state (used by integration tests)."""
+        http = await self._get_http()
+        data = await http.get_electrical_power(home_id, node_id)
+        return normalize_power_state(data.get("lastReportedValue"), endpoint)

--- a/custom_components/enki/auth.py
+++ b/custom_components/enki/auth.py
@@ -1,0 +1,121 @@
+"""OAuth session management for the Enki Keycloak realm."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import aiohttp
+
+from .const import ENKI_OIDC_URL, LOGGER
+from .exceptions import EnkiAuthError, EnkiConnectionError
+
+
+class EnkiAuthSession:
+    """Maintains access and refresh tokens for Enki cloud APIs.
+
+    Tokens are renewed via refresh_token when possible, falling back to the
+    resource-owner password grant only when refresh fails (#44).
+    """
+
+    _TOKEN_SKEW_SECONDS = 30
+
+    def __init__(self, username: str, password: str) -> None:
+        self._username = username
+        self._password = password
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._token_type = "Bearer"
+        self._token_expires_at = 0.0
+
+    @property
+    def access_token(self) -> str | None:
+        return self._access_token
+
+    @property
+    def token_type(self) -> str:
+        return self._token_type
+
+    def is_valid(self) -> bool:
+        return (
+            bool(self._access_token)
+            and time.time() < self._token_expires_at - self._TOKEN_SKEW_SECONDS
+        )
+
+    def auth_headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        """Build Authorization header; call ``ensure_valid`` first."""
+        headers = {"Authorization": f"{self._token_type} {self._access_token}"}
+        if extra:
+            headers.update(extra)
+        return headers
+
+    async def ensure_valid(self, session: aiohttp.ClientSession) -> None:
+        """Refresh or re-authenticate when the access token is near expiry."""
+        if self.is_valid():
+            return
+        if self._refresh_token:
+            try:
+                await self.refresh(session)
+                return
+            except EnkiAuthError:
+                LOGGER.debug("Refresh token rejected, falling back to password grant")
+        await self.connect(session)
+
+    async def connect(self, session: aiohttp.ClientSession) -> None:
+        """Authenticate with Keycloak (resource-owner password grant)."""
+        payload = await self._token_request(
+            session,
+            {
+                "grant_type": "password",
+                "client_id": "enki-front",
+                "username": self._username,
+                "password": self._password,
+            },
+        )
+        if payload is None:
+            raise EnkiAuthError("Invalid username or password")
+        self._apply_token_payload(payload)
+        LOGGER.debug("Enki session established, expires in %ss", payload["expires_in"])
+
+    async def refresh(self, session: aiohttp.ClientSession) -> None:
+        """Renew the access token without sending the account password again."""
+        if not self._refresh_token:
+            raise EnkiAuthError("No refresh token available")
+        payload = await self._token_request(
+            session,
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": self._refresh_token,
+                "client_id": "enki-front",
+            },
+        )
+        if payload is None:
+            raise EnkiAuthError("Token refresh rejected")
+        self._apply_token_payload(payload)
+        LOGGER.debug("Enki token refreshed, expires in %ss", payload["expires_in"])
+
+    def _apply_token_payload(self, payload: dict[str, Any]) -> None:
+        self._access_token = payload["access_token"]
+        self._token_type = payload.get("token_type", "Bearer")
+        self._token_expires_at = time.time() + payload["expires_in"]
+        if refreshed := payload.get("refresh_token"):
+            self._refresh_token = refreshed
+
+    async def _token_request(
+        self,
+        session: aiohttp.ClientSession,
+        data: dict[str, str],
+    ) -> dict[str, Any] | None:
+        try:
+            async with session.post(
+                ENKI_OIDC_URL,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data=data,
+            ) as response:
+                if response.status == 401:
+                    return None
+                if response.status != 200:
+                    raise EnkiConnectionError(f"Authentication failed: HTTP {response.status}")
+                return await response.json()
+        except aiohttp.ClientError as err:
+            raise EnkiConnectionError(f"Cannot reach Enki auth: {err}") from err

--- a/custom_components/enki/capabilities.py
+++ b/custom_components/enki/capabilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from .const import DEVICE_TYPE_FANS, DEVICE_TYPE_INVERTERS, DEVICE_TYPE_LIGHTS
@@ -23,117 +24,153 @@ def possible_values_dict(possible_values: dict[str, Any] | None) -> dict[str, An
     return {}
 
 
-def supports_light_state(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
-    return (
-        "change_light_state" in capabilities
-        or "check_light_state" in capabilities
-        or "change_light_state" in possible_values
-        or "check_light_state" in possible_values
-    )
+def _supports(capabilities: set[str], possible_values: dict[str, Any], *names: str) -> bool:
+    """True when any capability name appears in capabilities or possibleValues."""
+    return any(name in capabilities or name in possible_values for name in names)
 
 
-def supports_electrical_power(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
-    return (
-        "switch_electrical_power" in capabilities
-        or "check_electrical_power" in capabilities
-        or "switch_electrical_power" in possible_values
-        or "check_electrical_power" in possible_values
-    )
+@dataclass(frozen=True, slots=True)
+class EnkiCapabilityProfile:
+    """Read-only view of what a physical Enki node can do.
 
+    Built from referentiel metadata (authoritative for commands) and optional
+    BFF dashboard fields (used for multi-endpoint outlets and solar tiles).
+    """
 
-def supports_fan_speed(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
-    return (
-        "change_fan_speed" in capabilities
-        or "check_fan_speed" in capabilities
-        or "change_fan_speed" in possible_values
-        or "check_fan_speed" in possible_values
-    )
+    device_type: str
+    capabilities: frozenset[str]
+    possible_values: dict[str, Any]
+    bff_device_type: str = ""
+    main_change_capability_id: str | None = None
+    main_change_capability_endpoints: tuple[int, ...] = ()
+    power_production: float | None = None
 
+    @classmethod
+    def from_device(cls, device: EnkiDevice) -> EnkiCapabilityProfile:
+        """Build a profile snapshot from a discovered device."""
+        endpoints: list[int] = []
+        for endpoint in device.main_change_capability_endpoints:
+            if isinstance(endpoint, int):
+                endpoints.append(endpoint)
+            elif isinstance(endpoint, dict):
+                endpoint_id = endpoint.get("id")
+                if isinstance(endpoint_id, int):
+                    endpoints.append(endpoint_id)
+        return cls(
+            device_type=device.device_type,
+            capabilities=frozenset(capabilities_set(device.capabilities)),
+            possible_values=possible_values_dict(device.possible_values),
+            bff_device_type=device.bff_device_type,
+            main_change_capability_id=device.main_change_capability_id,
+            main_change_capability_endpoints=tuple(sorted(set(endpoints))),
+            power_production=device.power_production,
+        )
 
-def supports_fan_rotation(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
-    return (
-        "change_fan_rotation_direction" in capabilities
-        or "check_fan_rotation_direction" in capabilities
-        or "change_fan_rotation_direction" in possible_values
-        or "check_fan_rotation_direction" in possible_values
-    )
+    # --- capability probes -------------------------------------------------
 
+    @property
+    def supports_light_state(self) -> bool:
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "change_light_state",
+            "check_light_state",
+        )
 
-def supports_airflow_mode(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
-    return (
-        "change_airflow_mode" in capabilities
-        or "check_airflow_mode" in capabilities
-        or "change_airflow_mode" in possible_values
-        or "check_airflow_mode" in possible_values
-    )
+    @property
+    def supports_electrical_power(self) -> bool:
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "switch_electrical_power",
+            "check_electrical_power",
+        )
 
+    @property
+    def supports_fan_speed(self) -> bool:
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "change_fan_speed",
+            "check_fan_speed",
+        )
 
-def supports_power_production(capabilities: set[str]) -> bool:
-    return "check_power_production" in capabilities
+    @property
+    def supports_fan_rotation(self) -> bool:
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "change_fan_rotation_direction",
+            "check_fan_rotation_direction",
+        )
 
+    @property
+    def supports_airflow_mode(self) -> bool:
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "change_airflow_mode",
+            "check_airflow_mode",
+        )
 
-def device_capabilities(device: EnkiDevice) -> set[str]:
-    return capabilities_set(device.capabilities)
+    @property
+    def supports_power_production(self) -> bool:
+        return "check_power_production" in self.capabilities
 
+    # --- HA platform classification ----------------------------------------
 
-def device_possible_values(device: EnkiDevice) -> dict[str, Any]:
-    return possible_values_dict(device.possible_values)
+    @property
+    def is_fan(self) -> bool:
+        """Ceiling fans and VMC nodes (airflow-prod API)."""
+        if self.device_type == DEVICE_TYPE_FANS:
+            return True
+        return self.supports_fan_speed or self.supports_fan_rotation or self.supports_airflow_mode
 
+    @property
+    def is_light_controllable(self) -> bool:
+        """Lights, dimmers, fan kits, and power-only outlets."""
+        if self.device_type == DEVICE_TYPE_LIGHTS:
+            return True
+        if self.is_fan:
+            return self.supports_light_state
+        return self.supports_light_state or self.supports_electrical_power
 
-def is_fan_device(device: EnkiDevice) -> bool:
-    """Detect fans from capabilities (Inspire, Cadix, Radix, VMC, …)."""
-    if device.device_type == DEVICE_TYPE_FANS:
-        return True
-    caps = device_capabilities(device)
-    possible = device_possible_values(device)
-    return (
-        supports_fan_speed(caps, possible)
-        or supports_fan_rotation(caps, possible)
-        or supports_airflow_mode(caps, possible)
-    )
+    @property
+    def is_inverter(self) -> bool:
+        """Solar inverters with live production on the BFF dashboard."""
+        if self.device_type in {DEVICE_TYPE_INVERTERS, "inverters"}:
+            return self.power_production is not None
+        return self.supports_power_production and self.power_production is not None
 
+    @property
+    def is_supported(self) -> bool:
+        return self.is_fan or self.is_light_controllable or self.is_inverter
 
-def is_light_controllable(device: EnkiDevice) -> bool:
-    """Lights, dimmers, and switch/outlet nodes exposed as HA lights."""
-    if device.device_type == DEVICE_TYPE_LIGHTS:
-        return True
-    caps = device_capabilities(device)
-    possible = device_possible_values(device)
-    if is_fan_device(device):
-        return supports_light_state(caps, possible)
-    return supports_light_state(caps, possible) or supports_electrical_power(caps, possible)
+    @property
+    def uses_power_api_only(self) -> bool:
+        """Pure switches/outlets (e.g. Edisio) without the lighting API."""
+        return self.supports_electrical_power and not self.supports_light_state
 
+    @property
+    def fan_max_speed(self) -> int | None:
+        """Max non-off speed step from referentiel possibleValues."""
+        speed_meta = self.possible_values.get("change_fan_speed") or self.possible_values.get(
+            "check_fan_speed"
+        )
+        if isinstance(speed_meta, dict):
+            speed_range = speed_meta.get("range")
+            if isinstance(speed_range, dict):
+                raw_max = speed_range.get("max")
+                if isinstance(raw_max, (int, float)) and raw_max > 0:
+                    return max(1, int(round(raw_max)))
+        return None
 
-def is_inverter_device(device: EnkiDevice) -> bool:
-    """Solar inverters reporting live production via the BFF dashboard."""
-    if device.device_type in {DEVICE_TYPE_INVERTERS, "inverters"}:
-        return device.power_production is not None
-    caps = device_capabilities(device)
-    return supports_power_production(caps) and device.power_production is not None
-
-
-def device_is_supported(device: EnkiDevice) -> bool:
-    return is_fan_device(device) or is_light_controllable(device) or is_inverter_device(device)
-
-
-def device_uses_power_api_only(device: EnkiDevice) -> bool:
-    """Pure switches/outlets (e.g. Edisio) without the lighting API."""
-    caps = device_capabilities(device)
-    possible = device_possible_values(device)
-    return supports_electrical_power(caps, possible) and not supports_light_state(caps, possible)
-
-
-def fan_max_speed(device: EnkiDevice) -> int | None:
-    """Read max fan speed from referentiel possibleValues."""
-    possible = device_possible_values(device)
-    speed_meta = possible.get("change_fan_speed") or possible.get("check_fan_speed")
-    if isinstance(speed_meta, dict):
-        speed_range = speed_meta.get("range")
-        if isinstance(speed_range, dict):
-            raw_max = speed_range.get("max")
-            if isinstance(raw_max, (int, float)) and raw_max > 0:
-                return max(1, int(round(raw_max)))
-    return None
+    @property
+    def power_switch_endpoints(self) -> list[int]:
+        """BFF endpoints when mainChangeCapability is switch_electrical_power."""
+        if self.main_change_capability_id != "switch_electrical_power":
+            return []
+        return list(self.main_change_capability_endpoints)
 
 
 def parse_bff_power(description: dict[str, Any] | None) -> float | None:
@@ -149,18 +186,79 @@ def parse_bff_power(description: dict[str, Any] | None) -> float | None:
         return None
 
 
+# --- Backward-compatible module functions (used by tests and legacy imports) ---
+
+
+def supports_light_state(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return _supports(capabilities, possible_values, "change_light_state", "check_light_state")
+
+
+def supports_electrical_power(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return _supports(
+        capabilities,
+        possible_values,
+        "switch_electrical_power",
+        "check_electrical_power",
+    )
+
+
+def supports_fan_speed(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return _supports(capabilities, possible_values, "change_fan_speed", "check_fan_speed")
+
+
+def supports_fan_rotation(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return _supports(
+        capabilities,
+        possible_values,
+        "change_fan_rotation_direction",
+        "check_fan_rotation_direction",
+    )
+
+
+def supports_airflow_mode(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    return _supports(
+        capabilities,
+        possible_values,
+        "change_airflow_mode",
+        "check_airflow_mode",
+    )
+
+
+def supports_power_production(capabilities: set[str]) -> bool:
+    return "check_power_production" in capabilities
+
+
+def device_capabilities(device: EnkiDevice) -> set[str]:
+    return set(device.profile.capabilities)
+
+
+def device_possible_values(device: EnkiDevice) -> dict[str, Any]:
+    return device.profile.possible_values
+
+
+def is_fan_device(device: EnkiDevice) -> bool:
+    return device.profile.is_fan
+
+
+def is_light_controllable(device: EnkiDevice) -> bool:
+    return device.profile.is_light_controllable
+
+
+def is_inverter_device(device: EnkiDevice) -> bool:
+    return device.profile.is_inverter
+
+
+def device_is_supported(device: EnkiDevice) -> bool:
+    return device.profile.is_supported
+
+
+def device_uses_power_api_only(device: EnkiDevice) -> bool:
+    return device.profile.uses_power_api_only
+
+
+def fan_max_speed(device: EnkiDevice) -> int | None:
+    return device.profile.fan_max_speed
+
+
 def main_change_capability_endpoints(device: EnkiDevice) -> list[int]:
-    """Return BFF endpoints for mainChangeCapability=switch_electrical_power."""
-    if device.main_change_capability_id != "switch_electrical_power":
-        return []
-
-    endpoint_ids: set[int] = set()
-    for endpoint in device.main_change_capability_endpoints:
-        if isinstance(endpoint, int):
-            endpoint_ids.add(endpoint)
-        elif isinstance(endpoint, dict):
-            endpoint_id = endpoint.get("id")
-            if isinstance(endpoint_id, int):
-                endpoint_ids.add(endpoint_id)
-
-    return sorted(endpoint_ids)
+    return device.profile.power_switch_endpoints

--- a/custom_components/enki/config_flow.py
+++ b/custom_components/enki/config_flow.py
@@ -15,6 +15,7 @@ from .api import EnkiAPI
 from .const import (
     CONF_SCAN_INTERVAL,
     CONF_TELEMETRY,
+    CONF_TELEMETRY_ONBOARDING,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LOGGER,
@@ -59,12 +60,8 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
                 LOGGER.exception("Unexpected error during Enki config flow")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=f"Enki – {user_input[CONF_USERNAME]}",
-                    data=user_input,
-                )
+                self.context["credentials"] = user_input
+                return await self.async_step_telemetry()
 
         return self.async_show_form(
             step_id="user",
@@ -75,6 +72,37 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
+        )
+
+    async def async_step_telemetry(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Explain opt-in telemetry and let the user choose before finishing setup."""
+        credentials = self.context.get("credentials")
+        if not credentials:
+            return await self.async_step_user()
+
+        if user_input is not None:
+            await self.async_set_unique_id(credentials[CONF_USERNAME].lower())
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=f"Enki – {credentials[CONF_USERNAME]}",
+                data=credentials,
+                options={
+                    CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+                    CONF_TELEMETRY: user_input[CONF_TELEMETRY],
+                    CONF_TELEMETRY_ONBOARDING: True,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="telemetry",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_TELEMETRY, default=False): selector.BooleanSelector(),
+                }
+            ),
         )
 
     async def async_step_reconfigure(
@@ -120,7 +148,7 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class EnkiOptionsFlow(OptionsFlow):
-    """Options flow for polling interval."""
+    """Options flow for polling interval and telemetry."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         self._config_entry = config_entry
@@ -130,7 +158,12 @@ class EnkiOptionsFlow(OptionsFlow):
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            options = {
+                **dict(self._config_entry.options),
+                CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
+                CONF_TELEMETRY: user_input[CONF_TELEMETRY],
+            }
+            return self.async_create_entry(title="", data=options)
 
         current_interval = self._config_entry.options.get(
             CONF_SCAN_INTERVAL,

--- a/custom_components/enki/const.py
+++ b/custom_components/enki/const.py
@@ -9,6 +9,7 @@ NAME = "Enki"
 
 CONF_SCAN_INTERVAL = "scan_interval"
 CONF_TELEMETRY = "telemetry"
+CONF_TELEMETRY_ONBOARDING = "telemetry_onboarding_shown"
 
 DEFAULT_SCAN_INTERVAL = 30
 MIN_SCAN_INTERVAL = 10

--- a/custom_components/enki/device_state.py
+++ b/custom_components/enki/device_state.py
@@ -1,0 +1,124 @@
+"""Typed accessors for Enki API last-reported device fields."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class EnkiDeviceState:
+    """Read-only view of ``EnkiDevice.last_reported_value``.
+
+    Centralises field names returned by different Enki micro-services so
+    platform code does not scatter string keys across entities.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: dict[str, Any] | None) -> None:
+        self._data = data if isinstance(data, dict) else {}
+
+    @property
+    def raw(self) -> dict[str, Any]:
+        """Underlying dict (same object as on the device — updates are live)."""
+        return self._data
+
+    @property
+    def fan_speed(self) -> int | None:
+        value = self._data.get("fan_speed")
+        return int(value) if value is not None else None
+
+    @property
+    def airflow_mode(self) -> str | None:
+        value = self._data.get("airflow_mode")
+        return str(value) if isinstance(value, str) else None
+
+    @property
+    def airflow_rotation(self) -> str | None:
+        value = self._data.get("airflow_rotation")
+        return str(value) if isinstance(value, str) else None
+
+    @property
+    def airflow_rotation_supported(self) -> bool:
+        return bool(self._data.get("airflow_rotation_supported"))
+
+    @property
+    def light_power(self) -> str | None:
+        """Fan kit on/off — reported by lighting-prod, not power-prod."""
+        value = self._data.get("light_power")
+        if isinstance(value, str):
+            return value
+        return self.global_power
+
+    @property
+    def global_power(self) -> str | None:
+        value = self._data.get("power")
+        return str(value) if isinstance(value, str) else None
+
+    @property
+    def electrical_power(self) -> str | None:
+        value = self._data.get("electrical_power")
+        return str(value) if isinstance(value, str) else None
+
+    @property
+    def brightness(self) -> float | None:
+        value = self._data.get("brightness")
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
+
+    @property
+    def color_temperature(self) -> str | None:
+        value = self._data.get("colorTemperature")
+        return str(value) if isinstance(value, str) else None
+
+    @property
+    def power_production(self) -> float | None:
+        value = self._data.get("power_production")
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
+
+    @property
+    def electrical_endpoints(self) -> list[dict[str, Any]]:
+        endpoints = self._data.get("electrical_endpoints")
+        if isinstance(endpoints, list):
+            return [endpoint for endpoint in endpoints if isinstance(endpoint, dict)]
+        return []
+
+    def endpoint_power(self, endpoint_id: int) -> str | None:
+        """Power state for one electrical endpoint (multi-gang switches)."""
+        for endpoint in self.electrical_endpoints:
+            if endpoint.get("id") != endpoint_id:
+                continue
+            last_reported = endpoint.get("lastReportedValue")
+            if isinstance(last_reported, str):
+                return last_reported
+            if isinstance(last_reported, dict):
+                power = last_reported.get("power")
+                if isinstance(power, str):
+                    return power
+        return None
+
+    def light_endpoints_have_mixed_power(self, endpoint_ids: list[int]) -> bool:
+        """True when BFF endpoints disagree on ON/OFF (Siroco+ multi-light bug).
+
+        Enki ignores turn_on when global power is already ON but endpoints differ.
+        Sending OFF first forces a clean ON transition for all light endpoints.
+        """
+        if len(endpoint_ids) <= 1:
+            return False
+
+        power_values: set[str] = set()
+        for endpoint in self.electrical_endpoints:
+            if endpoint.get("id") not in endpoint_ids:
+                continue
+            last_reported = endpoint.get("lastReportedValue")
+            if isinstance(last_reported, str) and last_reported in {"ON", "OFF"}:
+                power_values.add(last_reported)
+            elif isinstance(last_reported, dict):
+                power = last_reported.get("power")
+                if power in {"ON", "OFF"}:
+                    power_values.add(power)
+            if len(power_values) > 1:
+                return True
+        return False

--- a/custom_components/enki/entity.py
+++ b/custom_components/enki/entity.py
@@ -41,6 +41,7 @@ class EnkiEntity(CoordinatorEntity[EnkiCoordinator]):
 
     @property
     def device_info(self) -> DeviceInfo:
+        """Group entities by physical node (node_id + serial for HA registry)."""
         metadata = self._device.last_reported_value
         return DeviceInfo(
             identifiers={(DOMAIN, self._device.node_id)},

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -18,7 +18,6 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from .capabilities import fan_max_speed, is_fan_device
 from .const import DOMAIN, FAN_SPEED_MAX
 from .coordinator import EnkiCoordinator
 from .entity import EnkiEntity
@@ -40,7 +39,7 @@ async def async_setup_entry(
     async_add_entities(
         EnkiFanEntity(coordinator, device)
         for device in coordinator.data or []
-        if is_fan_device(device)
+        if device.profile.is_fan
     )
 
 
@@ -56,7 +55,7 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         self._ordered_speeds = self._build_ordered_speeds(device)
 
     def _build_ordered_speeds(self, device: EnkiDevice) -> list[int]:
-        max_speed = fan_max_speed(device) or FAN_SPEED_MAX
+        max_speed = device.profile.fan_max_speed or FAN_SPEED_MAX
         return list(range(1, max_speed + 1))
 
     @property
@@ -78,28 +77,26 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
     def preset_mode(self) -> str | None:
         if not self._supports_preset_mode():
             return None
-        mode = self._device.last_reported_value.get("airflow_mode")
+        mode = self._device.reported.airflow_mode
         if mode in self._preset_modes:
             return mode
         return None
 
     @property
     def is_on(self) -> bool:
-        speed = self._device.last_reported_value.get("fan_speed")
+        speed = self._device.reported.fan_speed
         if speed is not None:
-            return int(speed) > 0
-        power = self._device.last_reported_value.get("electrical_power")
-        return isinstance(power, str) and power == "ON"
+            return speed > 0
+        return self._device.reported.electrical_power == "ON"
 
     @property
     def percentage(self) -> int | None:
-        speed = self._device.last_reported_value.get("fan_speed")
+        speed = self._device.reported.fan_speed
         if speed is None:
             return None
-        speed_value = int(speed)
-        if speed_value <= 0:
+        if speed <= 0:
             return 0
-        return ordered_list_item_to_percentage(self._ordered_speeds, speed_value)
+        return ordered_list_item_to_percentage(self._ordered_speeds, speed)
 
     @property
     def speed_count(self) -> int:
@@ -108,7 +105,7 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
     @property
     def current_direction(self) -> str | None:
         """forward = été (brise descendante), reverse = hiver (déstratification)."""
-        return self._device.last_reported_value.get("airflow_rotation")
+        return self._device.reported.airflow_rotation
 
     async def async_set_direction(self, direction: str) -> None:
         if direction not in {DIRECTION_FORWARD, DIRECTION_REVERSE}:
@@ -138,7 +135,7 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         if preset_mode is not None and self._supports_preset_mode():
             await self.async_set_preset_mode(preset_mode)
 
-        if self._device.last_reported_value.get("fan_speed") is None:
+        if self._device.reported.fan_speed is None:
             if percentage is None or percentage > 0:
                 await self.coordinator.api.async_switch_electrical_power(
                     self._device.home_id,
@@ -155,11 +152,11 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         if percentage is not None and percentage > 0:
             speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
         else:
-            speed = max(1, self._device.last_reported_value.get("fan_speed", 0) or 1)
+            speed = max(1, self._device.reported.fan_speed or 1)
         await self._set_speed(speed)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        if self._device.last_reported_value.get("fan_speed") is None:
+        if self._device.reported.fan_speed is None:
             await self.coordinator.api.async_switch_electrical_power(
                 self._device.home_id,
                 self._device.node_id,
@@ -186,12 +183,12 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         self.coordinator.update_cached_value(node_id, "fan_speed", speed)
 
     def _supports_direction(self) -> bool:
-        if self._device.last_reported_value.get("airflow_rotation_supported"):
+        if self._device.reported.airflow_rotation_supported:
             return True
         return device_supports_fan_rotation(self._device)
 
     def _supports_preset_mode(self) -> bool:
         return infer_airflow_mode_supported(
             self._device,
-            self._device.last_reported_value.get("airflow_mode"),
+            self._device.reported.airflow_mode,
         )

--- a/custom_components/enki/fan_helpers.py
+++ b/custom_components/enki/fan_helpers.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from .const import (
     AIRFLOW_MODE_BREEZE,
     AIRFLOW_MODE_MANUAL,
@@ -13,27 +11,12 @@ from .const import (
 from .models import EnkiDevice
 
 
-def _capability_set(device: EnkiDevice) -> set[str]:
-    return {capability for capability in device.capabilities if isinstance(capability, str)}
-
-
-def _possible_values(device: EnkiDevice) -> dict[str, Any]:
-    return device.possible_values if isinstance(device.possible_values, dict) else {}
-
-
 def device_supports_airflow_mode(device: EnkiDevice) -> bool:
-    capabilities = _capability_set(device)
-    possible = _possible_values(device)
-    return (
-        "change_airflow_mode" in capabilities
-        or "check_airflow_mode" in capabilities
-        or "change_airflow_mode" in possible
-        or "check_airflow_mode" in possible
-    )
+    return device.profile.supports_airflow_mode
 
 
 def airflow_modes_from_metadata(device: EnkiDevice) -> list[str]:
-    possible = _possible_values(device)
+    possible = device.profile.possible_values
     meta = possible.get("change_airflow_mode") or possible.get("check_airflow_mode")
     if isinstance(meta, dict):
         values = meta.get("values")

--- a/custom_components/enki/fan_rotation_helpers.py
+++ b/custom_components/enki/fan_rotation_helpers.py
@@ -2,25 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from .models import EnkiDevice
 
 
-def _capability_set(device: EnkiDevice) -> set[str]:
-    return {capability for capability in device.capabilities if isinstance(capability, str)}
-
-
-def _possible_values(device: EnkiDevice) -> dict[str, Any]:
-    return device.possible_values if isinstance(device.possible_values, dict) else {}
-
-
 def device_supports_fan_rotation(device: EnkiDevice) -> bool:
-    capabilities = _capability_set(device)
-    possible = _possible_values(device)
-    return (
-        "change_fan_rotation_direction" in capabilities
-        or "check_fan_rotation_direction" in capabilities
-        or "change_fan_rotation_direction" in possible
-        or "check_fan_rotation_direction" in possible
-    )
+    return device.profile.supports_fan_rotation

--- a/custom_components/enki/helpers.py
+++ b/custom_components/enki/helpers.py
@@ -94,7 +94,12 @@ def merge_light_state_payload(
     current: dict[str, Any],
     changes: dict[str, Any],
 ) -> dict[str, Any]:
-    """Build a change-light-state body from the last reported value and requested changes."""
+    """Build a change-light-state body from the last reported value and requested changes.
+
+    Enki requires the full lastReportedValue object on every POST. When turning ON,
+    the API also expects ``power: ON`` even if the caller only asked for brightness
+    or color temperature — otherwise Siroco+ kits ignore the command (#71).
+    """
     payload = dict(current)
     if changes.get("power") == "OFF":
         payload.update(changes)

--- a/custom_components/enki/http_client.py
+++ b/custom_components/enki/http_client.py
@@ -1,0 +1,211 @@
+"""Thin HTTP transport for Enki micro-service APIs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+from .auth import EnkiAuthSession
+from .const import (
+    ENKI_AIRFLOW_API_KEY,
+    ENKI_BASE_URL,
+    ENKI_BFF_API_KEY,
+    ENKI_HOME_API_KEY,
+    ENKI_LIGHTS_API_KEY,
+    ENKI_NODE_API_KEY,
+    ENKI_POWER_API_KEY,
+    ENKI_REFERENTIEL_API_KEY,
+    REFERENTIEL_VERSION,
+)
+from .exceptions import EnkiApiNotFoundError, EnkiConnectionError
+from .helpers import is_command_success_status
+
+
+class EnkiHttpClient:
+    """Authenticated requests against Enki cloud micro-services.
+
+    Each Enki domain (lighting, airflow, power, …) uses a separate API key
+    and sometimes a ``homeId`` header — this class centralises that wiring.
+    """
+
+    _API_KEYS = {
+        "home": ENKI_HOME_API_KEY,
+        "bff": ENKI_BFF_API_KEY,
+        "node": ENKI_NODE_API_KEY,
+        "referentiel": ENKI_REFERENTIEL_API_KEY,
+        "lighting": ENKI_LIGHTS_API_KEY,
+        "airflow": ENKI_AIRFLOW_API_KEY,
+        "power": ENKI_POWER_API_KEY,
+    }
+
+    def __init__(self, auth: EnkiAuthSession, session: aiohttp.ClientSession) -> None:
+        self._auth = auth
+        self._session = session
+
+    @property
+    def session(self) -> aiohttp.ClientSession:
+        return self._session
+
+    async def ensure_token(self) -> None:
+        await self._auth.ensure_valid(self._session)
+
+    def _headers(self, service: str, home_id: str | None = None) -> dict[str, str]:
+        extra: dict[str, str] = {"X-Gateway-APIKey": self._API_KEYS[service]}
+        if home_id is not None:
+            extra["homeId"] = home_id
+        return self._auth.auth_headers(extra)
+
+    async def get_json(
+        self,
+        service: str,
+        path: str,
+        *,
+        home_id: str | None = None,
+        params: dict[str, Any] | None = None,
+        not_found_ok: bool = False,
+    ) -> dict[str, Any]:
+        """GET returning parsed JSON; raises on unexpected status."""
+        await self.ensure_token()
+        url = f"{ENKI_BASE_URL}{path}"
+        async with self._session.get(
+            url,
+            headers=self._headers(service, home_id),
+            params=params,
+        ) as response:
+            if response.status == 404 and not_found_ok:
+                return {}
+            if response.status == 404:
+                raise EnkiApiNotFoundError(f"GET {path} not found", status=404)
+            if response.status != 200:
+                raise EnkiConnectionError(f"GET {path} failed: HTTP {response.status}")
+            payload = await response.json()
+            return payload if isinstance(payload, dict) else {}
+
+    async def post_command(
+        self,
+        service: str,
+        path: str,
+        *,
+        home_id: str | None = None,
+        params: dict[str, Any] | None = None,
+        json: Any = None,
+        not_found_ok: bool = False,
+    ) -> None:
+        """POST a command endpoint; accepts HTTP 202/204 as success."""
+        await self.ensure_token()
+        url = f"{ENKI_BASE_URL}{path}"
+        async with self._session.post(
+            url,
+            headers=self._headers(service, home_id),
+            params=params,
+            json=json,
+        ) as response:
+            if response.status == 404 and not_found_ok:
+                raise EnkiApiNotFoundError(f"POST {path} not found", status=404)
+            if not is_command_success_status(response.status):
+                raise EnkiConnectionError(
+                    f"POST {path} failed: HTTP {response.status}",
+                    status=response.status,
+                )
+
+    async def get_homes(self) -> list[str]:
+        data = await self.get_json("home", "/api-enki-home-prod/v1/homes")
+        return [home["id"] for home in data.get("items", [])]
+
+    async def get_dashboard(self, home_id: str) -> dict[str, Any]:
+        return await self.get_json(
+            "bff",
+            f"/api-enki-mobile-bff-prod/v1/dashboard/homes/{home_id}?hasGroups=true",
+        )
+
+    async def get_node(self, home_id: str, node_id: str) -> dict[str, Any]:
+        return await self.get_json(
+            "node",
+            f"/api-enki-node-agg-prod/v1/nodes/{node_id}",
+            home_id=home_id,
+        )
+
+    async def get_referentiel_device(self, device_id: str) -> dict[str, Any]:
+        """Referentiel metadata; ESDK fan nodes may return 404."""
+        return await self.get_json(
+            "referentiel",
+            (
+                f"/api-enki-referentiel-agg-prod/v1/devices/{device_id}"
+                f"?version={REFERENTIEL_VERSION}"
+            ),
+            not_found_ok=True,
+        )
+
+    # --- domain-specific shortcuts -------------------------------------------
+
+    async def get_light_state(self, home_id: str, node_id: str) -> dict[str, Any]:
+        return await self.get_json(
+            "lighting",
+            f"/api-enki-lighting-prod/v1/lighting/{node_id}/check-light-state",
+            home_id=home_id,
+        )
+
+    async def change_light_state(
+        self,
+        home_id: str,
+        node_id: str,
+        payload: dict[str, Any],
+    ) -> None:
+        await self.post_command(
+            "lighting",
+            f"/api-enki-lighting-prod/v1/lighting/{node_id}/change-light-state",
+            home_id=home_id,
+            json=payload,
+        )
+
+    async def get_electrical_power(self, home_id: str, node_id: str) -> dict[str, Any]:
+        return await self.get_json(
+            "power",
+            f"/api-enki-power-prod/v1/power/{node_id}/check-electrical-power",
+            home_id=home_id,
+            not_found_ok=True,
+        )
+
+    async def switch_electrical_power(
+        self,
+        home_id: str,
+        node_id: str,
+        value: str,
+        *,
+        endpoint: int | None = None,
+    ) -> None:
+        params = {"endpoints": endpoint} if endpoint is not None else None
+        await self.post_command(
+            "power",
+            f"/api-enki-power-prod/v1/power/{node_id}/switch-electrical-power",
+            home_id=home_id,
+            params=params,
+            json={"value": value},
+        )
+
+    async def airflow_get(
+        self,
+        home_id: str,
+        node_id: str,
+        action: str,
+    ) -> dict[str, Any]:
+        return await self.get_json(
+            "airflow",
+            f"/api-enki-airflow-prod/v1/airflow/{node_id}/{action}",
+            home_id=home_id,
+        )
+
+    async def airflow_post(
+        self,
+        home_id: str,
+        node_id: str,
+        action: str,
+        value: Any,
+    ) -> None:
+        await self.post_command(
+            "airflow",
+            f"/api-enki-airflow-prod/v1/airflow/{node_id}/{action}",
+            home_id=home_id,
+            json={"value": value},
+        )

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -4,29 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP_KELVIN,
-    ColorMode,
-    LightEntity,
-)
+from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.components.light.const import DEFAULT_MAX_KELVIN, DEFAULT_MIN_KELVIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .capabilities import capabilities_set as device_capabilities_set
-from .capabilities import (
-    device_uses_power_api_only,
-    is_fan_device,
-    is_light_controllable,
-    main_change_capability_endpoints,
-    supports_light_state,
-)
-from .capabilities import possible_values_dict as device_possible_values
 from .const import DOMAIN
 from .coordinator import EnkiCoordinator
 from .entity import EnkiEntity
+from .light_base import EnkiLightBehaviorMixin
 from .models import EnkiDevice
 
 
@@ -46,13 +33,14 @@ def _build_light_entities(
     coordinator: EnkiCoordinator,
     device: EnkiDevice,
 ) -> list[LightEntity]:
-    if not is_light_controllable(device):
+    profile = device.profile
+    if not profile.is_light_controllable:
         return []
 
-    if is_fan_device(device):
+    if profile.is_fan:
         return [EnkiFanLightEntity(coordinator, device)]
 
-    endpoint_ids = main_change_capability_endpoints(device)
+    endpoint_ids = profile.power_switch_endpoints
     if endpoint_ids:
         return [
             EnkiLightEntity(
@@ -64,11 +52,11 @@ def _build_light_entities(
             for index, endpoint_id in enumerate(endpoint_ids)
         ]
 
-    translation_key = "outlet" if device_uses_power_api_only(device) else "light"
+    translation_key = "outlet" if profile.uses_power_api_only else "light"
     return [EnkiLightEntity(coordinator, device, suffix="light", translation_key=translation_key)]
 
 
-class EnkiFanLightEntity(EnkiEntity, LightEntity):
+class EnkiFanLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
     """Light kit on an ESDK ceiling fan (api-enki-lighting-prod)."""
 
     _attr_translation_key = "fan_light"
@@ -77,126 +65,62 @@ class EnkiFanLightEntity(EnkiEntity, LightEntity):
     _attr_min_color_temp_kelvin = 2748
     _attr_max_color_temp_kelvin = 6500
     _brightness_max = 100
+    _color_temp_values: list[int] = []
 
     def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-light"
-        possible = device_possible_values(device.possible_values)
-        brightness_range = possible.get("change_brightness", {}).get("range", {})
-        self._brightness_max = brightness_range.get("max", 100)
-        values = possible.get("change_color_temperature", {}).get("values", [])
-        if values:
-            self._color_temp_values = [int(value.strip("TK")) for value in values]
-        else:
-            self._color_temp_values = []
+        possible = device.profile.possible_values
+        self._brightness_max = self._parse_brightness_max(possible)
+        self._color_temp_values = self._parse_color_temp_values(possible)
 
     @property
     def is_on(self) -> bool:
-        return self._device.last_reported_value.get("light_power") == "ON"
+        return self._device.reported.light_power == "ON"
 
     @property
     def brightness(self) -> int | None:
-        raw = self._device.last_reported_value.get("brightness")
+        raw = self._device.reported.brightness
         return round(raw * 255 / self._brightness_max) if raw is not None else None
 
     @property
     def color_temp_kelvin(self) -> int | None:
-        raw = self._device.last_reported_value.get("colorTemperature")
+        raw = self._device.reported.color_temperature
         return int(raw.strip("TK")) if raw else None
 
-    def _closest_color_temp(self, target: int) -> str:
-        best = min(self._color_temp_values, key=lambda value: abs(value - target))
-        return f"T{best}K"
-
-    def _light_endpoints_have_mixed_power(self) -> bool:
-        endpoint_ids = main_change_capability_endpoints(self._device)
-        if len(endpoint_ids) <= 1:
-            return False
-        endpoints = self._device.last_reported_value.get("electrical_endpoints")
-        if not isinstance(endpoints, list):
-            return False
-        power_values: set[str] = set()
-        for endpoint in endpoints:
-            if not isinstance(endpoint, dict) or endpoint.get("id") not in endpoint_ids:
-                continue
-            last_reported = endpoint.get("lastReportedValue")
-            if isinstance(last_reported, str) and last_reported in {"ON", "OFF"}:
-                power_values.add(last_reported)
-            if len(power_values) > 1:
-                return True
-        return False
-
-    async def _mixed_endpoint_workaround(self) -> None:
-        if self._light_endpoints_have_mixed_power():
-            await self.coordinator.api.async_change_light_state(
-                self._device.home_id,
-                self._device.node_id,
-                {"power": "OFF"},
-            )
-
-    def _build_turn_on_changes(self, kwargs: dict[str, Any]) -> dict[str, Any]:
-        changes: dict[str, Any] = {"power": "ON"}
-        if ATTR_BRIGHTNESS in kwargs:
-            changes["brightness"] = round(
-                kwargs[ATTR_BRIGHTNESS] * self._brightness_max / 255,
-                2,
-            )
-        if ATTR_COLOR_TEMP_KELVIN in kwargs:
-            if self._color_temp_values:
-                changes["colorTemperature"] = self._closest_color_temp(
-                    kwargs[ATTR_COLOR_TEMP_KELVIN]
-                )
-            else:
-                changes["colorTemperature"] = f"T{kwargs[ATTR_COLOR_TEMP_KELVIN]}K"
-        elif ATTR_BRIGHTNESS not in kwargs:
-            last_brightness = self._device.last_reported_value.get("brightness")
-            if isinstance(last_brightness, (int, float)) and last_brightness > 0:
-                changes["brightness"] = last_brightness
-        return changes
-
     async def async_turn_on(self, **kwargs: Any) -> None:
-        home_id = self._device.home_id
-        node_id = self._device.node_id
         await self._mixed_endpoint_workaround()
-        changes = self._build_turn_on_changes(kwargs)
-        await self.coordinator.api.async_change_light_state(home_id, node_id, changes)
-        self._apply_light_cache(node_id, changes)
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        home_id = self._device.home_id
-        node_id = self._device.node_id
+        changes = self._build_turn_on_changes(kwargs, restore_last_brightness=True)
         await self.coordinator.api.async_change_light_state(
-            home_id,
-            node_id,
-            {"power": "OFF"},
+            self._device.home_id,
+            self._device.node_id,
+            changes,
         )
-        self._cache_light_off(node_id)
-
-    def _apply_light_cache(self, node_id: str, changes: dict[str, Any]) -> None:
-        self._cache_light_on(node_id)
+        self._cache_global_light_on(self.coordinator)
         if "brightness" in changes:
-            self.coordinator.update_cached_value(node_id, "brightness", changes["brightness"])
+            self.coordinator.update_cached_value(self.node_id, "brightness", changes["brightness"])
         if "colorTemperature" in changes:
             self.coordinator.update_cached_value(
-                node_id,
+                self.node_id,
                 "colorTemperature",
                 changes["colorTemperature"],
             )
 
-    def _cache_light_on(self, node_id: str) -> None:
-        self.coordinator.update_cached_value(node_id, "light_power", "ON")
-        self.coordinator.update_cached_value(node_id, "power", "ON")
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.api.async_change_light_state(
+            self._device.home_id,
+            self._device.node_id,
+            {"power": "OFF"},
+        )
+        self._cache_global_light_off(self.coordinator)
 
-    def _cache_light_off(self, node_id: str) -> None:
-        self.coordinator.update_cached_value(node_id, "light_power", "OFF")
-        self.coordinator.update_cached_value(node_id, "power", "OFF")
 
-
-class EnkiLightEntity(EnkiEntity, LightEntity):
+class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
     """Standard Enki light, dimmer, or switch/outlet node."""
 
     _attr_translation_key = "light"
     _brightness_max = 100
+    _color_temp_values: list[int] = []
 
     def __init__(
         self,
@@ -211,17 +135,17 @@ class EnkiLightEntity(EnkiEntity, LightEntity):
         self._endpoint_id = endpoint_id
         self._attr_translation_key = translation_key
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-{suffix}"
-        self._color_temp_values: list[int] = []
-        caps = device_capabilities_set(device.capabilities)
-        possible = device_possible_values(device.possible_values)
-        self._supports_light_state = supports_light_state(caps, possible)
+
+        profile = device.profile
+        caps = profile.capabilities
+        possible = profile.possible_values
+        self._supports_light_state = profile.supports_light_state
         modes: set[ColorMode] = set()
 
         if "change_color_temperature" in caps:
             modes.add(ColorMode.COLOR_TEMP)
-            values = possible.get("change_color_temperature", {}).get("values", [])
-            if values:
-                self._color_temp_values = [int(value.strip("TK")) for value in values]
+            self._color_temp_values = self._parse_color_temp_values(possible)
+            if self._color_temp_values:
                 self._attr_min_color_temp_kelvin = min(self._color_temp_values)
                 self._attr_max_color_temp_kelvin = max(self._color_temp_values)
             else:
@@ -230,10 +154,9 @@ class EnkiLightEntity(EnkiEntity, LightEntity):
 
         if "change_brightness" in caps:
             modes.add(ColorMode.BRIGHTNESS)
-            brightness_range = possible.get("change_brightness", {}).get("range", {})
-            self._brightness_max = brightness_range.get("max", 100)
+            self._brightness_max = self._parse_brightness_max(possible)
 
-        if not modes and "switch_electrical_power" in caps:
+        if not modes and profile.supports_electrical_power:
             modes.add(ColorMode.ONOFF)
 
         self._attr_supported_color_modes = modes or {ColorMode.ONOFF}
@@ -246,100 +169,27 @@ class EnkiLightEntity(EnkiEntity, LightEntity):
 
     @property
     def is_on(self) -> bool:
+        reported = self._device.reported
         if self._endpoint_id is not None:
-            endpoints = self._device.last_reported_value.get("electrical_endpoints")
-            if isinstance(endpoints, list):
-                for endpoint in endpoints:
-                    if not isinstance(endpoint, dict):
-                        continue
-                    if endpoint.get("id") != self._endpoint_id:
-                        continue
-                    last_reported = endpoint.get("lastReportedValue")
-                    if isinstance(last_reported, str):
-                        return last_reported == "ON"
-                    if isinstance(last_reported, dict):
-                        power = last_reported.get("power")
-                        return power == "ON" if power is not None else None
+            power = reported.endpoint_power(self._endpoint_id)
+            return power == "ON" if power is not None else False
 
-        power = self._device.last_reported_value.get("power")
-        if power is not None:
-            return power == "ON"
+        if reported.global_power is not None:
+            return reported.global_power == "ON"
 
-        electrical_power = self._device.last_reported_value.get("electrical_power")
-        return isinstance(electrical_power, str) and electrical_power == "ON"
+        return reported.electrical_power == "ON"
 
     @property
     def brightness(self) -> int | None:
-        raw = self._device.last_reported_value.get("brightness")
+        raw = self._device.reported.brightness
         if raw is None:
             return None
         return round(raw * 255 / self._brightness_max)
 
     @property
     def color_temp_kelvin(self) -> int | None:
-        raw = self._device.last_reported_value.get("colorTemperature")
+        raw = self._device.reported.color_temperature
         return int(raw.strip("TK")) if raw else None
-
-    def _closest_color_temp(self, target: int) -> str:
-        best = min(self._color_temp_values, key=lambda value: abs(value - target))
-        return f"T{best}K"
-
-    def _light_endpoint_ids(self) -> list[int]:
-        return main_change_capability_endpoints(self._device)
-
-    def _light_endpoints_have_mixed_power(self) -> bool:
-        endpoint_ids = self._light_endpoint_ids()
-        if len(endpoint_ids) <= 1:
-            return False
-
-        endpoints = self._device.last_reported_value.get("electrical_endpoints")
-        if not isinstance(endpoints, list):
-            return False
-
-        power_values: set[str] = set()
-        for endpoint in endpoints:
-            if not isinstance(endpoint, dict):
-                continue
-            if endpoint.get("id") not in endpoint_ids:
-                continue
-            last_reported = endpoint.get("lastReportedValue")
-            if isinstance(last_reported, str) and last_reported in {"ON", "OFF"}:
-                power_values.add(last_reported)
-            elif isinstance(last_reported, dict):
-                power = last_reported.get("power")
-                if power in {"ON", "OFF"}:
-                    power_values.add(power)
-            if len(power_values) > 1:
-                return True
-        return False
-
-    def _update_light_endpoint_cache(self, power: str) -> None:
-        for endpoint_id in self._light_endpoint_ids():
-            self.coordinator.update_endpoint_power(self._device.node_id, endpoint_id, power)
-
-    async def _mixed_endpoint_workaround(self) -> None:
-        if self._light_endpoints_have_mixed_power():
-            await self.coordinator.api.async_change_light_state(
-                self._device.home_id,
-                self._device.node_id,
-                {"power": "OFF"},
-            )
-
-    def _build_turn_on_changes(self, kwargs: dict[str, Any]) -> dict[str, Any]:
-        changes: dict[str, Any] = {"power": "ON"}
-        if ATTR_BRIGHTNESS in kwargs:
-            changes["brightness"] = round(
-                kwargs[ATTR_BRIGHTNESS] * self._brightness_max / 255,
-                2,
-            )
-        if ATTR_COLOR_TEMP_KELVIN in kwargs:
-            if self._color_temp_values:
-                changes["colorTemperature"] = self._closest_color_temp(
-                    kwargs[ATTR_COLOR_TEMP_KELVIN]
-                )
-            else:
-                changes["colorTemperature"] = f"T{kwargs[ATTR_COLOR_TEMP_KELVIN]}K"
-        return changes
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         home_id = self._device.home_id

--- a/custom_components/enki/light_base.py
+++ b/custom_components/enki/light_base.py
@@ -1,0 +1,90 @@
+"""Shared lighting behaviour for Enki light entities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_TEMP_KELVIN
+
+from .coordinator import EnkiCoordinator
+from .entity import EnkiEntity
+
+
+class EnkiLightBehaviorMixin:
+    """Mixin for entities driving api-enki-lighting-prod.
+
+    Subclasses must inherit :class:`EnkiEntity` so ``coordinator``, ``_device``,
+    and ``node_id`` are available.
+    """
+
+    _brightness_max: int
+    _color_temp_values: list[int]
+
+    def _closest_color_temp(self, target: int) -> str:
+        best = min(self._color_temp_values, key=lambda value: abs(value - target))
+        return f"T{best}K"
+
+    def _light_endpoint_ids(self: EnkiEntity) -> list[int]:
+        return self._device.profile.power_switch_endpoints
+
+    def _light_endpoints_have_mixed_power(self: EnkiEntity) -> bool:
+        return self._device.reported.light_endpoints_have_mixed_power(self._light_endpoint_ids())
+
+    async def _mixed_endpoint_workaround(self: EnkiEntity) -> None:
+        """Force OFF before ON when multi-light endpoints disagree (Siroco+)."""
+        if self._light_endpoints_have_mixed_power():
+            await self.coordinator.api.async_change_light_state(
+                self._device.home_id,
+                self._device.node_id,
+                {"power": "OFF"},
+            )
+
+    def _build_turn_on_changes(
+        self: EnkiEntity,
+        kwargs: dict[str, Any],
+        *,
+        restore_last_brightness: bool = False,
+    ) -> dict[str, Any]:
+        """Build a single change-light-state payload from HA service kwargs."""
+        changes: dict[str, Any] = {"power": "ON"}
+        if ATTR_BRIGHTNESS in kwargs:
+            changes["brightness"] = round(
+                kwargs[ATTR_BRIGHTNESS] * self._brightness_max / 255,
+                2,
+            )
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            if self._color_temp_values:
+                changes["colorTemperature"] = self._closest_color_temp(
+                    kwargs[ATTR_COLOR_TEMP_KELVIN]
+                )
+            else:
+                changes["colorTemperature"] = f"T{kwargs[ATTR_COLOR_TEMP_KELVIN]}K"
+        elif restore_last_brightness and ATTR_BRIGHTNESS not in kwargs:
+            last_brightness = self._device.reported.brightness
+            if last_brightness is not None and last_brightness > 0:
+                changes["brightness"] = last_brightness
+        return changes
+
+    def _cache_global_light_on(self: EnkiEntity, coordinator: EnkiCoordinator) -> None:
+        coordinator.update_cached_value(self.node_id, "light_power", "ON")
+        coordinator.update_cached_value(self.node_id, "power", "ON")
+
+    def _cache_global_light_off(self: EnkiEntity, coordinator: EnkiCoordinator) -> None:
+        coordinator.update_cached_value(self.node_id, "light_power", "OFF")
+        coordinator.update_cached_value(self.node_id, "power", "OFF")
+
+    def _update_light_endpoint_cache(self: EnkiEntity, power: str) -> None:
+        for endpoint_id in self._light_endpoint_ids():
+            self.coordinator.update_endpoint_power(self._device.node_id, endpoint_id, power)
+
+    @staticmethod
+    def _parse_color_temp_values(possible_values: dict[str, Any]) -> list[int]:
+        values = possible_values.get("change_color_temperature", {}).get("values", [])
+        if not values:
+            return []
+        return [int(value.strip("TK")) for value in values]
+
+    @staticmethod
+    def _parse_brightness_max(possible_values: dict[str, Any], default: int = 100) -> int:
+        brightness_range = possible_values.get("change_brightness", {}).get("range", {})
+        return int(brightness_range.get("max", default))

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.1.2"
+  "version": "1.1.3"
 }

--- a/custom_components/enki/models.py
+++ b/custom_components/enki/models.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .capabilities import EnkiCapabilityProfile
+    from .device_state import EnkiDeviceState
 
 
 @dataclass(slots=True)
@@ -29,6 +33,20 @@ class EnkiDevice:
     def is_active(self) -> bool:
         """Return True when the node is enabled and not deactivated."""
         return self.is_enabled and self.state != "DEACTIVATED"
+
+    @property
+    def profile(self) -> EnkiCapabilityProfile:
+        """Capability snapshot used for platform selection and API probing."""
+        from .capabilities import EnkiCapabilityProfile
+
+        return EnkiCapabilityProfile.from_device(self)
+
+    @property
+    def reported(self) -> EnkiDeviceState:
+        """Typed accessor for live API fields cached on the coordinator."""
+        from .device_state import EnkiDeviceState
+
+        return EnkiDeviceState(self.last_reported_value)
 
 
 @dataclass(slots=True)

--- a/custom_components/enki/sensor.py
+++ b/custom_components/enki/sensor.py
@@ -12,8 +12,6 @@ from homeassistant.const import UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .capabilities import capabilities_set as device_capabilities_set
-from .capabilities import is_inverter_device, supports_power_production
 from .const import DOMAIN
 from .coordinator import EnkiCoordinator
 from .entity import EnkiEntity
@@ -34,11 +32,10 @@ async def async_setup_entry(
 
 
 def _has_power_production_sensor(device: EnkiDevice) -> bool:
+    profile = device.profile
     if device.power_production is None:
         return False
-    if is_inverter_device(device):
-        return True
-    return supports_power_production(device_capabilities_set(device.capabilities))
+    return profile.is_inverter or profile.supports_power_production
 
 
 class EnkiPowerProductionSensor(EnkiEntity, SensorEntity):
@@ -57,7 +54,7 @@ class EnkiPowerProductionSensor(EnkiEntity, SensorEntity):
     def native_value(self) -> float | None:
         value = self._device.power_production
         if value is None:
-            value = self._device.last_reported_value.get("power_production")
+            value = self._device.reported.power_production
         if value is None:
             return None
         try:

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -15,6 +15,13 @@
           "username": "Email",
           "password": "Password"
         }
+      },
+      "telemetry": {
+        "title": "Help extend Enki support",
+        "description": "Optional opt-in: when a new or unsupported device is detected on your account, Home Assistant can notify you with a **pre-filled GitHub link** (anonymized profile: type, model, capabilities).\n\nNothing is sent automatically — you decide whether to open the link. This helps prioritize heaters, shutters, sockets, and other hardware.\n\nYou can change this anytime under **Enki → Configure**.",
+        "data": {
+          "telemetry": "Notify me about new devices (recommended)"
+        }
       }
     },
     "error": {

--- a/custom_components/enki/telemetry_nudge.py
+++ b/custom_components/enki/telemetry_nudge.py
@@ -1,0 +1,148 @@
+"""One-time telemetry opt-in nudge for legacy installs (pre-1.0.6)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components import persistent_notification
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import CONF_TELEMETRY, CONF_TELEMETRY_ONBOARDING, DOMAIN, LOGGER
+
+STORAGE_VERSION = 1
+TELEMETRY_NUDGE_LEGACY_VERSION = "1.0.6"
+NOTIFICATION_ID_PREFIX = f"{DOMAIN}_telemetry_nudge"
+
+
+def parse_version(version: str) -> tuple[int, ...]:
+    """Parse a semver-like string into comparable integer parts."""
+    parts: list[int] = []
+    for segment in version.replace("-", ".").split("."):
+        if segment.isdigit():
+            parts.append(int(segment))
+        elif segment:
+            break
+    return tuple(parts or [0])
+
+
+def version_is_before(version: str, reference: str) -> bool:
+    """Return True when version sorts strictly before reference."""
+    left = parse_version(version)
+    right = parse_version(reference)
+    length = max(len(left), len(right))
+    return left + (0,) * (length - len(left)) < right + (0,) * (length - len(right))
+
+
+class EnkiTelemetryNudge:
+    """Show a single settings notification encouraging telemetry for legacy users."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._store = Store[dict[str, Any]](
+            hass,
+            STORAGE_VERSION,
+            f"{DOMAIN}.install_meta.{entry.entry_id}",
+        )
+
+    async def async_handle_setup(self) -> None:
+        """Record install metadata and maybe show the legacy nudge once."""
+        meta = await self._load_meta()
+
+        if self._entry.options.get(CONF_TELEMETRY):
+            await self._dismiss_notification()
+            if not meta.get("telemetry_nudge_dismissed"):
+                meta["telemetry_nudge_dismissed"] = True
+                await self._save_meta(meta)
+            return
+
+        if self._entry.options.get(CONF_TELEMETRY_ONBOARDING):
+            meta.setdefault("first_seen_version", await self._integration_version())
+            meta["telemetry_nudge_dismissed"] = True
+            await self._save_meta(meta)
+            return
+
+        if meta.get("telemetry_nudge_dismissed"):
+            return
+
+        if not meta.get("first_seen_version"):
+            meta["first_seen_version"] = "legacy"
+            await self._save_meta(meta)
+
+        if not self._should_nudge_legacy(meta):
+            return
+
+        await self._show_notification()
+        meta["telemetry_nudge_dismissed"] = True
+        await self._save_meta(meta)
+        LOGGER.debug(
+            "Showed one-time telemetry nudge for Enki entry %s",
+            self._entry.entry_id,
+        )
+
+    def _should_nudge_legacy(self, meta: dict[str, Any]) -> bool:
+        first_seen = str(meta.get("first_seen_version", "legacy"))
+        if first_seen == "legacy":
+            return True
+        return version_is_before(first_seen, TELEMETRY_NUDGE_LEGACY_VERSION)
+
+    async def _show_notification(self) -> None:
+        title, message = _nudge_copy(self._hass, self._entry.entry_id)
+        await persistent_notification.async_create(
+            self._hass,
+            title=title,
+            message=message,
+            notification_id=f"{NOTIFICATION_ID_PREFIX}_{self._entry.entry_id}",
+        )
+
+    async def _dismiss_notification(self) -> None:
+        await persistent_notification.async_dismiss(
+            self._hass,
+            f"{NOTIFICATION_ID_PREFIX}_{self._entry.entry_id}",
+        )
+
+    async def _load_meta(self) -> dict[str, Any]:
+        return dict(await self._store.async_load() or {})
+
+    async def _save_meta(self, meta: dict[str, Any]) -> None:
+        await self._store.async_save(meta)
+
+    async def _integration_version(self) -> str:
+        from . import __version__
+
+        return __version__
+
+
+def _nudge_copy(hass: HomeAssistant, entry_id: str) -> tuple[str, str]:
+    configure_url = f"/config/integrations/configure/{entry_id}"
+    if hass.config.language.startswith("fr"):
+        return (
+            "Enki — accélérez le support de nouveaux appareils",
+            (
+                "Activez la **télémétrie opt-in** pour être averti lorsqu'un appareil "
+                "Enki non supporté est détecté chez vous.\n\n"
+                "Données **anonymisées** (type, modèle, capabilities) — "
+                "aucun envoi automatique, seulement un lien GitHub pré-rempli "
+                "si vous le souhaitez.\n\n"
+                "Cela aide à prioriser radiateurs, volets, prises et autres matériels.\n\n"
+                f"[Ouvrir les options Enki]({configure_url})"
+            ),
+        )
+    return (
+        "Enki — help prioritize new device support",
+        (
+            "Turn on **opt-in telemetry** to get notified when an unsupported Enki "
+            "device is detected on your account.\n\n"
+            "**Anonymized** data only (type, model, capabilities) — "
+            "nothing is sent automatically; you get a pre-filled GitHub link if you choose.\n\n"
+            "This helps prioritize heaters, shutters, sockets, and other hardware.\n\n"
+            f"[Open Enki options]({configure_url})"
+        ),
+    )
+
+
+async def async_handle_telemetry_nudge(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Entry point called once per successful setup."""
+    await EnkiTelemetryNudge(hass, entry).async_handle_setup()

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -15,6 +15,13 @@
           "username": "Email",
           "password": "Password"
         }
+      },
+      "telemetry": {
+        "title": "Help extend Enki support",
+        "description": "Optional opt-in: when a new or unsupported device is detected on your account, Home Assistant can notify you with a **pre-filled GitHub link** (anonymized profile: type, model, capabilities).\n\nNothing is sent automatically — you decide whether to open the link. This helps prioritize heaters, shutters, sockets, and other hardware.\n\nYou can change this anytime under **Enki → Configure**.",
+        "data": {
+          "telemetry": "Notify me about new devices (recommended)"
+        }
       }
     },
     "error": {

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -15,6 +15,13 @@
           "username": "E-mail",
           "password": "Mot de passe"
         }
+      },
+      "telemetry": {
+        "title": "Aidez à étendre le support Enki",
+        "description": "Option facultative : lorsqu’un appareil nouveau ou non supporté est détecté sur votre compte, Home Assistant peut vous avertir avec un **lien GitHub pré-rempli** (profil anonymisé : type, modèle, capabilities).\n\nRien n’est envoyé automatiquement — vous choisissez d’ouvrir le lien ou non. Cela aide à prioriser radiateurs, volets, prises et autres matériels.\n\nModifiable à tout moment via **Enki → Configurer**.",
+        "data": {
+          "telemetry": "M’avertir des nouveaux appareils (recommandé)"
+        }
       }
     },
     "error": {

--- a/tests/unit/test_api_auth.py
+++ b/tests/unit/test_api_auth.py
@@ -26,7 +26,7 @@ async def test_connect_success() -> None:
         )
         api = EnkiAPI("user@example.com", "secret")
         await api.async_connect()
-        assert api._access_token == "token-abc"
+        assert api._auth.access_token == "token-abc"
         await api.async_close()
 
 
@@ -75,7 +75,7 @@ async def test_connect_stores_refresh_token() -> None:
         )
         api = EnkiAPI("user@example.com", "secret")
         await api.async_connect()
-        assert api._refresh_token == "refresh-xyz"
+        assert api._auth._refresh_token == "refresh-xyz"
         await api.async_close()
 
 
@@ -93,14 +93,14 @@ async def test_ensure_token_uses_refresh_before_password() -> None:
             },
         )
         api = EnkiAPI("user@example.com", "secret")
-        api._access_token = "expired"
-        api._refresh_token = "old-refresh"
-        api._token_expires_at = time.time() - 10
+        api._auth._access_token = "expired"
+        api._auth._refresh_token = "old-refresh"
+        api._auth._token_expires_at = time.time() - 10
 
         await api._ensure_token()
 
-        assert api._access_token == "refreshed-token"
-        assert api._refresh_token == "new-refresh"
+        assert api._auth.access_token == "refreshed-token"
+        assert api._auth._refresh_token == "new-refresh"
         await api.async_close()
 
 
@@ -119,11 +119,11 @@ async def test_ensure_token_falls_back_to_password_when_refresh_fails() -> None:
             },
         )
         api = EnkiAPI("user@example.com", "secret")
-        api._access_token = "expired"
-        api._refresh_token = "bad-refresh"
-        api._token_expires_at = time.time() - 10
+        api._auth._access_token = "expired"
+        api._auth._refresh_token = "bad-refresh"
+        api._auth._token_expires_at = time.time() - 10
 
         await api._ensure_token()
 
-        assert api._access_token == "password-token"
+        assert api._auth.access_token == "password-token"
         await api.async_close()

--- a/tests/unit/test_device_state.py
+++ b/tests/unit/test_device_state.py
@@ -1,0 +1,36 @@
+"""Unit tests for EnkiDeviceState accessors."""
+
+from __future__ import annotations
+
+from enki.device_state import EnkiDeviceState
+
+
+def test_endpoint_power_reads_string_value() -> None:
+    state = EnkiDeviceState(
+        {
+            "electrical_endpoints": [
+                {"id": 2, "lastReportedValue": "ON"},
+                {"id": 3, "lastReportedValue": "OFF"},
+            ]
+        }
+    )
+    assert state.endpoint_power(2) == "ON"
+    assert state.endpoint_power(3) == "OFF"
+
+
+def test_light_endpoints_have_mixed_power() -> None:
+    state = EnkiDeviceState(
+        {
+            "electrical_endpoints": [
+                {"id": 2, "lastReportedValue": "ON"},
+                {"id": 3, "lastReportedValue": "OFF"},
+            ]
+        }
+    )
+    assert state.light_endpoints_have_mixed_power([2, 3]) is True
+    assert state.light_endpoints_have_mixed_power([2]) is False
+
+
+def test_fan_kit_light_power_prefers_light_power_field() -> None:
+    state = EnkiDeviceState({"light_power": "OFF", "power": "ON"})
+    assert state.light_power == "OFF"

--- a/tests/unit/test_fan_airflow_mode.py
+++ b/tests/unit/test_fan_airflow_mode.py
@@ -12,12 +12,13 @@ from enki.const import AIRFLOW_MODE_BREEZE
 @pytest.mark.asyncio
 async def test_set_airflow_mode_uses_change_airflow_mode() -> None:
     api = EnkiAPI("user", "pass")
-    api._ensure_token = AsyncMock()  # type: ignore[method-assign]
-    api._airflow_post = AsyncMock()  # type: ignore[method-assign]
+    http = AsyncMock()
+    http.airflow_post = AsyncMock()
+    api._get_http = AsyncMock(return_value=http)  # type: ignore[method-assign]
 
     await api.async_set_airflow_mode("home", "node", AIRFLOW_MODE_BREEZE)
 
-    api._airflow_post.assert_awaited_once_with(
+    http.airflow_post.assert_awaited_once_with(
         "home",
         "node",
         "change-airflow-mode",

--- a/tests/unit/test_fan_rotation_probe.py
+++ b/tests/unit/test_fan_rotation_probe.py
@@ -7,14 +7,16 @@ from unittest.mock import AsyncMock
 import pytest
 from enki.api import EnkiAPI
 from enki.const import DIRECTION_FORWARD
+from enki.exceptions import EnkiConnectionError
 
 
 @pytest.mark.asyncio
 async def test_get_fan_rotation_ignores_http_500_on_probe() -> None:
     api = EnkiAPI("user", "pass")
-    api._try_airflow_get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    http = AsyncMock()
+    http.airflow_get = AsyncMock(side_effect=EnkiConnectionError("500"))
 
-    rotation, supported = await api._get_fan_rotation("home", "node")
+    rotation, supported = await api._read_fan_rotation(http, "home", "node")
 
     assert rotation is None
     assert supported is False
@@ -23,26 +25,26 @@ async def test_get_fan_rotation_ignores_http_500_on_probe() -> None:
 @pytest.mark.asyncio
 async def test_get_fan_rotation_reads_fan_rotation_direction() -> None:
     api = EnkiAPI("user", "pass")
-    api._try_airflow_get = AsyncMock(  # type: ignore[method-assign]
-        return_value={"lastReportedValue": "CLOCKWISE"}
-    )
+    http = AsyncMock()
+    http.airflow_get = AsyncMock(return_value={"lastReportedValue": "CLOCKWISE"})
 
-    rotation, supported = await api._get_fan_rotation("home", "node")
+    rotation, supported = await api._read_fan_rotation(http, "home", "node")
 
     assert rotation == DIRECTION_FORWARD
     assert supported is True
-    api._try_airflow_get.assert_awaited_once_with("home", "node", "check-fan-rotation-direction")
+    http.airflow_get.assert_awaited_once_with("home", "node", "check-fan-rotation-direction")
 
 
 @pytest.mark.asyncio
 async def test_set_fan_rotation_uses_change_fan_rotation_direction() -> None:
     api = EnkiAPI("user", "pass")
-    api._ensure_token = AsyncMock()  # type: ignore[method-assign]
-    api._airflow_post = AsyncMock()  # type: ignore[method-assign]
+    http = AsyncMock()
+    http.airflow_post = AsyncMock()
+    api._get_http = AsyncMock(return_value=http)  # type: ignore[method-assign]
 
     await api.async_set_fan_rotation("home", "node", DIRECTION_FORWARD)
 
-    api._airflow_post.assert_awaited_once_with(
+    http.airflow_post.assert_awaited_once_with(
         "home",
         "node",
         "change-fan-rotation-direction",

--- a/tests/unit/test_telemetry_nudge.py
+++ b/tests/unit/test_telemetry_nudge.py
@@ -1,0 +1,118 @@
+"""Unit tests for the one-time telemetry nudge for legacy installs."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from enki.const import CONF_TELEMETRY, CONF_TELEMETRY_ONBOARDING
+from enki.telemetry_nudge import (
+    EnkiTelemetryNudge,
+    parse_version,
+    version_is_before,
+)
+
+
+def test_version_is_before() -> None:
+    assert version_is_before("1.0.5", "1.0.6") is True
+    assert version_is_before("1.0.6", "1.0.6") is False
+    assert version_is_before("1.1.0", "1.0.6") is False
+
+
+def test_parse_version_with_suffix() -> None:
+    assert parse_version("1.0.6-beta") == (1, 0, 6)
+
+
+@pytest.mark.asyncio
+async def test_nudge_skipped_when_telemetry_enabled() -> None:
+    hass = MagicMock()
+    hass.config.language = "fr"
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.options = {CONF_TELEMETRY: True}
+
+    nudge = EnkiTelemetryNudge(hass, entry)
+    nudge._store.async_load = AsyncMock(return_value={})  # type: ignore[method-assign]
+    nudge._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "enki.telemetry_nudge.persistent_notification.async_create",
+            new_callable=AsyncMock,
+        ) as notify,
+        patch(
+            "enki.telemetry_nudge.persistent_notification.async_dismiss",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await nudge.async_handle_setup()
+        notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_nudge_skipped_after_onboarding_step() -> None:
+    hass = MagicMock()
+    hass.config.language = "en"
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.options = {CONF_TELEMETRY: False, CONF_TELEMETRY_ONBOARDING: True}
+
+    nudge = EnkiTelemetryNudge(hass, entry)
+    nudge._store.async_load = AsyncMock(return_value={})  # type: ignore[method-assign]
+    nudge._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "enki.telemetry_nudge.persistent_notification.async_create",
+        new_callable=AsyncMock,
+    ) as notify:
+        await nudge.async_handle_setup()
+        notify.assert_not_awaited()
+        nudge._store.async_save.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_nudge_shown_once_for_legacy_install() -> None:
+    hass = MagicMock()
+    hass.config.language = "fr"
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.options = {CONF_TELEMETRY: False}
+
+    nudge = EnkiTelemetryNudge(hass, entry)
+    nudge._store.async_load = AsyncMock(return_value={})  # type: ignore[method-assign]
+    nudge._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "enki.telemetry_nudge.persistent_notification.async_create",
+        new_callable=AsyncMock,
+    ) as notify:
+        await nudge.async_handle_setup()
+        notify.assert_awaited_once()
+        message = notify.await_args.kwargs["message"]
+        assert "Configurer" in message or "options" in message.lower()
+
+        nudge._store.async_load = AsyncMock(  # type: ignore[method-assign]
+            return_value={"telemetry_nudge_dismissed": True, "first_seen_version": "legacy"}
+        )
+        await nudge.async_handle_setup()
+        notify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_nudge_dismissed_when_telemetry_turned_on() -> None:
+    hass = MagicMock()
+    hass.config.language = "en"
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.options = {CONF_TELEMETRY: True}
+
+    nudge = EnkiTelemetryNudge(hass, entry)
+    nudge._store.async_load = AsyncMock(return_value={})  # type: ignore[method-assign]
+    nudge._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "enki.telemetry_nudge.persistent_notification.async_dismiss",
+        new_callable=AsyncMock,
+    ) as dismiss:
+        await nudge.async_handle_setup()
+        dismiss.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Add optional telemetry onboarding step after login in config flow
- Show a one-time notification for legacy installs (< 1.0.6) when telemetry is disabled
- OOP refactor: EnkiAuthSession, EnkiHttpClient, EnkiCapabilityProfile, EnkiDeviceState, light mixin
- 57 unit tests

Re-opened after stacked merge closed PR #10 base branch.

## Test plan
- [x] `pytest tests/unit/` — 57 passed
- [x] CI green