### PR TITLE
fix: harden discovery, polling, and multi-endpoint control

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -150,14 +150,17 @@ class EnkiAPI:
         possible_values = device_info.get("possibleValues", {})
         power_production = parse_bff_power(item.get("description"))
 
+        title = item.get("title") or {}
+        device_name = title.get("label") or node_id
+
         skeleton = EnkiDevice(
             home_id=home_id,
             device_id=device_id,
             node_id=node_id,
-            device_name=item["title"]["label"],
+            device_name=device_name,
             device_type=device_type,
-            is_enabled=item["isEnabled"],
-            state=item["state"],
+            is_enabled=item.get("isEnabled", True),
+            state=item.get("state", "ACTIVE"),
             capabilities=capabilities,
             possible_values=possible_values,
             bff_device_type=bff_type,
@@ -187,7 +190,7 @@ class EnkiAPI:
         )
 
         last_reported: dict[str, Any] = {}
-        if item["isEnabled"]:
+        if item.get("isEnabled", True):
             last_reported = await self._refresh_device_state(http, skeleton, node_info)
 
         if not supported:
@@ -203,10 +206,10 @@ class EnkiAPI:
                 home_id=home_id,
                 device_id=device_id,
                 node_id=node_id,
-                device_name=item["title"]["label"],
+                device_name=device_name,
                 device_type=device_type,
-                is_enabled=item["isEnabled"],
-                state=item["state"],
+                is_enabled=item.get("isEnabled", True),
+                state=item.get("state", "ACTIVE"),
                 capabilities=capabilities,
                 possible_values=possible_values,
                 last_reported_value={**node_info, **last_reported},
@@ -307,23 +310,37 @@ class EnkiAPI:
         home_id: str,
         node_id: str,
     ) -> dict[str, Any]:
-        speed_data = await http.airflow_get(home_id, node_id, "check-fan-speed")
-        mode_data = await http.airflow_get(home_id, node_id, "check-airflow-mode")
-        rotation, rotation_supported = await self._read_fan_rotation(http, home_id, node_id)
-        light_state = await http.get_light_state(home_id, node_id)
-        last_reported = light_state.get("lastReportedValue", {})
-        light_power = last_reported.get("power", "OFF")
+        state: dict[str, Any] = {}
 
-        state: dict[str, Any] = {
-            "fan_speed": speed_data["lastReportedValue"],
-            "airflow_mode": mode_data["lastReportedValue"],
-            "airflow_rotation": rotation,
-            "airflow_rotation_supported": rotation_supported,
-            "light_power": light_power,
-            "brightness": last_reported.get("brightness"),
-            "colorTemperature": last_reported.get("colorTemperature"),
-            "power": last_reported.get("power"),
-        }
+        try:
+            speed_data = await http.airflow_get(home_id, node_id, "check-fan-speed")
+            if "lastReportedValue" in speed_data:
+                state["fan_speed"] = speed_data["lastReportedValue"]
+        except EnkiConnectionError as err:
+            LOGGER.debug("Fan speed skipped for node %s: %s", node_id, err)
+
+        try:
+            mode_data = await http.airflow_get(home_id, node_id, "check-airflow-mode")
+            if "lastReportedValue" in mode_data:
+                state["airflow_mode"] = mode_data["lastReportedValue"]
+        except EnkiConnectionError as err:
+            LOGGER.debug("Airflow mode skipped for node %s: %s", node_id, err)
+
+        rotation, rotation_supported = await self._read_fan_rotation(http, home_id, node_id)
+        state["airflow_rotation"] = rotation
+        state["airflow_rotation_supported"] = rotation_supported
+
+        try:
+            light_state = await http.get_light_state(home_id, node_id)
+            last_reported = light_state.get("lastReportedValue", {})
+            if isinstance(last_reported, dict):
+                state["light_power"] = last_reported.get("power", "OFF")
+                state["brightness"] = last_reported.get("brightness")
+                state["colorTemperature"] = last_reported.get("colorTemperature")
+                state["power"] = last_reported.get("power")
+        except EnkiConnectionError as err:
+            LOGGER.debug("Fan light state skipped for node %s: %s", node_id, err)
+
         try:
             power_details = await http.get_electrical_power(home_id, node_id)
             state["electrical_power"] = power_details.get("lastReportedValue")
@@ -415,10 +432,12 @@ class EnkiAPI:
         home_id: str,
         node_id: str,
         value: str,
+        *,
+        endpoint: int | None = None,
     ) -> None:
-        """Switch global electrical power (sockets, outlets without lighting API)."""
+        """Switch electrical power globally or for one BFF endpoint."""
         http = await self._get_http()
-        await http.switch_electrical_power(home_id, node_id, value)
+        await http.switch_electrical_power(home_id, node_id, value, endpoint=endpoint)
 
     async def async_set_fan_rotation(
         self,

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 from typing import Any
 
@@ -48,7 +49,14 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         except EnkiConnectionError as err:
             raise UpdateFailed(f"Cannot reach Enki cloud: {err}") from err
         else:
-            await self._telemetry.async_report(self.api.discovery_records)
+            try:
+                await self._telemetry.async_report(self.api.discovery_records)
+            except Exception as err:  # noqa: BLE001 — telemetry must never break polling
+                LOGGER.warning(
+                    "Enki telemetry skipped after discovery error: %s",
+                    err,
+                    exc_info=LOGGER.isEnabledFor(logging.DEBUG),
+                )
             return devices
 
     def get_device_by_node(self, node_id: str) -> EnkiDevice | None:

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -10,6 +10,7 @@ from ..const import (
     DEVICE_TYPE_FANS,
     DEVICE_TYPE_INVERTERS,
     DEVICE_TYPE_LIGHTS,
+    ENKI_ACCESS_MOTORIZATION_API_KEY,
 )
 from .models import EnkiDevice
 
@@ -252,6 +253,8 @@ class EnkiCapabilityProfile:
     @property
     def is_cover(self) -> bool:
         """Roller shutters and similar motorizations (beta)."""
+        if not ENKI_ACCESS_MOTORIZATION_API_KEY:
+            return False
         if self.device_type in {DEVICE_TYPE_ACCESS_MOTORIZATION, "access_and_motorizations"}:
             return self.supports_shutter_position or self.supports_shutter_opening
         return self.supports_shutter_position

--- a/custom_components/enki/domain/profile.py
+++ b/custom_components/enki/domain/profile.py
@@ -84,7 +84,7 @@ def profile_to_export_dict(
         "model": record.model,
         "firmware_version": record.firmware_version,
         "supported_by_integration": record.supported_by_integration,
-        "capabilities": sorted(record.capabilities),
+        "capabilities": sorted(record.capabilities or []),
         "possible_values": record.possible_values,
         "integration_version": integration_version,
         "ha_version": ha_version,
@@ -103,7 +103,7 @@ def profile_fingerprint(export_dict: dict[str, Any]) -> str:
         "capabilities": export_dict.get("capabilities"),
         "possible_values": export_dict.get("possible_values"),
     }
-    payload = json.dumps(stable, sort_keys=True, separators=(",", ":"))
+    payload = json.dumps(stable, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 

--- a/custom_components/enki/entity.py
+++ b/custom_components/enki/entity.py
@@ -30,7 +30,11 @@ class EnkiEntity(CoordinatorEntity[EnkiCoordinator]):
 
     @property
     def available(self) -> bool:
-        return self.coordinator.last_update_success and self._device.is_active
+        if not self.coordinator.last_update_success:
+            return False
+        if self.coordinator.get_device_by_node(self.node_id) is None:
+            return False
+        return self._device.is_active
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -196,8 +196,13 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
         node_id = self._device.node_id
 
         if not self._supports_light_state:
-            await self.coordinator.api.async_switch_electrical_power(home_id, node_id, "ON")
-            self.coordinator.update_cached_value(node_id, "electrical_power", "ON")
+            await self.coordinator.api.async_switch_electrical_power(
+                home_id,
+                node_id,
+                "ON",
+                endpoint=self._endpoint_id,
+            )
+            self._cache_electrical_power("ON")
             return
 
         await self._mixed_endpoint_workaround()
@@ -212,15 +217,20 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
                 "colorTemperature",
                 changes["colorTemperature"],
             )
-        self._update_light_endpoint_cache("ON")
+        self._update_light_endpoint_cache("ON", self._endpoint_id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         home_id = self._device.home_id
         node_id = self._device.node_id
 
         if not self._supports_light_state:
-            await self.coordinator.api.async_switch_electrical_power(home_id, node_id, "OFF")
-            self.coordinator.update_cached_value(node_id, "electrical_power", "OFF")
+            await self.coordinator.api.async_switch_electrical_power(
+                home_id,
+                node_id,
+                "OFF",
+                endpoint=self._endpoint_id,
+            )
+            self._cache_electrical_power("OFF")
             return
 
         await self.coordinator.api.async_change_light_state(
@@ -229,4 +239,12 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
             {"power": "OFF"},
         )
         self.coordinator.update_cached_value(node_id, "power", "OFF")
-        self._update_light_endpoint_cache("OFF")
+        self._update_light_endpoint_cache("OFF", self._endpoint_id)
+
+    def _cache_electrical_power(self, power: str) -> None:
+        node_id = self._device.node_id
+        if self._endpoint_id is not None:
+            self.coordinator.update_endpoint_power(node_id, self._endpoint_id, power)
+            return
+        self.coordinator.update_cached_value(node_id, "electrical_power", power)
+        self.coordinator.update_cached_value(node_id, "power", power)

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.3.2"
+  "version": "1.3.3"
 }

--- a/custom_components/enki/platforms/light/behavior.py
+++ b/custom_components/enki/platforms/light/behavior.py
@@ -73,9 +73,16 @@ class EnkiLightBehaviorMixin:
         coordinator.update_cached_value(self.node_id, "light_power", "OFF")
         coordinator.update_cached_value(self.node_id, "power", "OFF")
 
-    def _update_light_endpoint_cache(self: EnkiEntity, power: str) -> None:
-        for endpoint_id in self._light_endpoint_ids():
+    def _update_light_endpoint_cache(
+        self: EnkiEntity,
+        power: str,
+        endpoint_id: int | None = None,
+    ) -> None:
+        if endpoint_id is not None:
             self.coordinator.update_endpoint_power(self._device.node_id, endpoint_id, power)
+            return
+        for gang_id in self._light_endpoint_ids():
+            self.coordinator.update_endpoint_power(self._device.node_id, gang_id, power)
 
     @staticmethod
     def _parse_color_temp_values(possible_values: dict[str, Any]) -> list[int]:

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -55,37 +55,30 @@ class EnkiTelemetryReporter:
                 continue
 
             reported.add(fingerprint)
+            await self._save_reported(reported)
             new_count += 1
-            await self._notify_new_profile(export_dict, fingerprint)
+            self._notify_new_profile(export_dict, fingerprint)
 
         if new_count == 0:
             return
 
-        await self._save_reported(reported)
         LOGGER.info(
             "Notified about %s new Enki device profile(s) (opt-in telemetry)",
             new_count,
         )
 
-    async def _notify_new_profile(self, export_dict: dict[str, Any], fingerprint: str) -> None:
+    def _notify_new_profile(self, export_dict: dict[str, Any], fingerprint: str) -> None:
         device_type = export_dict.get("device_type", "unknown")
-        model = export_dict.get("model") or "inconnu"
+        model = export_dict.get("model") or "unknown"
         issue_url = build_github_new_issue_url(export_dict, fingerprint)
         supported = export_dict.get("supported_by_integration")
-
-        if supported:
-            title = "Enki — nouveau profil d'appareil"
-            message = (
-                f"Profil détecté : **{device_type}** ({model}).\n\n"
-                "Données anonymisées — rien n'est envoyé sans votre action.\n\n"
-                f"[Ouvrir une issue GitHub pré-remplie]({issue_url})"
-            )
-        else:
-            title = "Enki — appareil non supporté"
-            message = (
-                f"Type **{device_type}** ({model}) n'est pas encore géré par l'intégration.\n\n"
-                f"[Proposer le support sur GitHub]({issue_url})"
-            )
+        title, message = _profile_notification_copy(
+            self._hass,
+            device_type=str(device_type),
+            model=str(model),
+            issue_url=issue_url,
+            supported=bool(supported),
+        )
 
         persistent_notification.async_create(
             self._hass,
@@ -110,3 +103,47 @@ class EnkiTelemetryReporter:
         from .. import __version__
 
         return __version__
+
+
+def _profile_notification_copy(
+    hass: HomeAssistant,
+    *,
+    device_type: str,
+    model: str,
+    issue_url: str,
+    supported: bool,
+) -> tuple[str, str]:
+    if hass.config.language.startswith("fr"):
+        if supported:
+            return (
+                "Enki — nouveau profil d'appareil",
+                (
+                    f"Profil détecté : **{device_type}** ({model}).\n\n"
+                    "Données anonymisées — rien n'est envoyé sans votre action.\n\n"
+                    f"[Ouvrir une issue GitHub pré-remplie]({issue_url})"
+                ),
+            )
+        return (
+            "Enki — appareil non supporté",
+            (
+                f"Type **{device_type}** ({model}) n'est pas encore géré par l'intégration.\n\n"
+                f"[Proposer le support sur GitHub]({issue_url})"
+            ),
+        )
+
+    if supported:
+        return (
+            "Enki — new device profile",
+            (
+                f"Profile detected: **{device_type}** ({model}).\n\n"
+                "Anonymized data only — nothing is sent without your action.\n\n"
+                f"[Open a pre-filled GitHub issue]({issue_url})"
+            ),
+        )
+    return (
+        "Enki — unsupported device",
+        (
+            f"Type **{device_type}** ({model}) is not supported by the integration yet.\n\n"
+            f"[Request support on GitHub]({issue_url})"
+        ),
+    )

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -40,17 +40,26 @@ class EnkiTelemetryReporter:
             return
 
         reported = await self._load_reported()
-        integration_version = await self._integration_version()
-        ha_version = self._hass.config.version
+        integration_version = _integration_version()
+        ha_version = _ha_version(self._hass)
 
         new_count = 0
         for record in records:
-            export_dict = profile_to_export_dict(
-                record,
-                integration_version=integration_version,
-                ha_version=ha_version,
-            )
-            fingerprint = profile_fingerprint(export_dict)
+            try:
+                export_dict = profile_to_export_dict(
+                    record,
+                    integration_version=integration_version,
+                    ha_version=ha_version,
+                )
+                fingerprint = profile_fingerprint(export_dict)
+            except (TypeError, ValueError) as err:
+                LOGGER.warning(
+                    "Skipping telemetry for profile %s: %s",
+                    getattr(record, "device_type", "unknown"),
+                    err,
+                )
+                continue
+
             if fingerprint in reported:
                 continue
 
@@ -91,18 +100,26 @@ class EnkiTelemetryReporter:
         if self._reported is not None:
             return self._reported
         data = await self._store.async_load() or {}
-        fingerprints = data.get("fingerprints", [])
-        self._reported = {str(item) for item in fingerprints}
+        fingerprints = data.get("fingerprints") or []
+        if not isinstance(fingerprints, list):
+            fingerprints = []
+        self._reported = {str(item) for item in fingerprints if item}
         return self._reported
 
     async def _save_reported(self, reported: set[str]) -> None:
         self._reported = reported
         await self._store.async_save({"fingerprints": sorted(reported)})
 
-    async def _integration_version(self) -> str:
-        from .. import __version__
 
-        return __version__
+def _integration_version() -> str:
+    from .. import __version__
+
+    return __version__
+
+
+def _ha_version(hass: HomeAssistant) -> str:
+    version = getattr(hass.config, "version", None)
+    return str(version) if version is not None else "unknown"
 
 
 def _profile_notification_copy(
@@ -113,7 +130,8 @@ def _profile_notification_copy(
     issue_url: str,
     supported: bool,
 ) -> tuple[str, str]:
-    if hass.config.language.startswith("fr"):
+    language = getattr(hass.config, "language", None) or "en"
+    if language.startswith("fr"):
         if supported:
             return (
                 "Enki — nouveau profil d'appareil",

--- a/tests/unit/test_shutter.py
+++ b/tests/unit/test_shutter.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from enki.domain.capabilities import is_cover_device
 from enki.domain.models import EnkiDevice
 from enki.domain.state import EnkiDeviceState
 from enki.lib.shutter import normalize_shutter_position, shutter_opening_is_closed
+
+_COVER_DEVICE_KWARGS = {
+    "home_id": "h",
+    "device_id": "d",
+    "node_id": "n",
+    "device_name": "VR Salon",
+    "device_type": "access_and_motorizations",
+    "is_enabled": True,
+    "state": "ACTIVE",
+    "capabilities": ["change_shutter_position", "check_shutter_position"],
+}
 
 
 def test_normalize_shutter_position() -> None:
@@ -21,17 +34,15 @@ def test_shutter_opening_is_closed() -> None:
 
 
 def test_is_cover_device_from_capabilities() -> None:
-    device = EnkiDevice(
-        home_id="h",
-        device_id="d",
-        node_id="n",
-        device_name="VR Salon",
-        device_type="access_and_motorizations",
-        is_enabled=True,
-        state="ACTIVE",
-        capabilities=["change_shutter_position", "check_shutter_position"],
-    )
-    assert is_cover_device(device) is True
+    with patch("enki.domain.capabilities.ENKI_ACCESS_MOTORIZATION_API_KEY", "test-key"):
+        device = EnkiDevice(**_COVER_DEVICE_KWARGS)
+        assert is_cover_device(device) is True
+
+
+def test_is_cover_device_requires_motorization_key() -> None:
+    with patch("enki.domain.capabilities.ENKI_ACCESS_MOTORIZATION_API_KEY", ""):
+        device = EnkiDevice(**_COVER_DEVICE_KWARGS)
+        assert is_cover_device(device) is False
 
 
 def test_device_state_shutter_fields() -> None:

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -52,17 +52,10 @@ async def test_telemetry_notifies_new_profile() -> None:
     reporter._store.async_load = AsyncMock(return_value={"fingerprints": []})  # type: ignore[method-assign]
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
-    version_patch = patch(
-        "enki.telemetry.reporter.EnkiTelemetryReporter._integration_version",
-        AsyncMock(return_value="1.0.7"),
-    )
-    with (
-        patch(
-            "enki.telemetry.reporter.persistent_notification.async_create",
-            new_callable=MagicMock,
-        ) as notify,
-        version_patch,
-    ):
+    with patch(
+        "enki.telemetry.reporter.persistent_notification.async_create",
+        new_callable=MagicMock,
+    ) as notify:
         await reporter.async_report([_record()])
         notify.assert_called_once()
         reporter._store.async_save.assert_awaited()
@@ -83,17 +76,31 @@ async def test_telemetry_dedupes_fingerprint() -> None:
     reporter._store.async_load = AsyncMock(return_value={"fingerprints": []})  # type: ignore[method-assign]
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
-    version_patch = patch(
-        "enki.telemetry.reporter.EnkiTelemetryReporter._integration_version",
-        AsyncMock(return_value="1.0.7"),
-    )
-    with (
-        patch(
-            "enki.telemetry.reporter.persistent_notification.async_create",
-            new_callable=MagicMock,
-        ) as notify,
-        version_patch,
-    ):
+    with patch(
+        "enki.telemetry.reporter.persistent_notification.async_create",
+        new_callable=MagicMock,
+    ) as notify:
         await reporter.async_report([_record()])
+        await reporter.async_report([_record()])
+        notify.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_tolerates_corrupt_storage() -> None:
+    hass = MagicMock()
+    hass.config.version = "2024.12.0"
+    hass.config.language = "en"
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.options = {CONF_TELEMETRY: True}
+
+    reporter = EnkiTelemetryReporter(hass, entry)
+    reporter._store.async_load = AsyncMock(return_value={"fingerprints": None})  # type: ignore[method-assign]
+    reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "enki.telemetry.reporter.persistent_notification.async_create",
+        new_callable=MagicMock,
+    ) as notify:
         await reporter.async_report([_record()])
         notify.assert_called_once()

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -65,6 +65,7 @@ async def test_telemetry_notifies_new_profile() -> None:
     ):
         await reporter.async_report([_record()])
         notify.assert_called_once()
+        reporter._store.async_save.assert_awaited()
         message = notify.call_args.kwargs["message"]
         assert "github.com" in message
         assert "equation_radiator" in message


### PR DESCRIPTION
## Summary

- **Fan polling** — `_read_fan_state` reads each airflow/light field independently; one failing node no longer breaks the whole coordinator refresh
- **Multi-gang outlets** — `switch-electrical-power` now passes the BFF endpoint id; cache updates only the targeted circuit
- **Entity availability** — entities go unavailable when their node disappears from Enki discovery (no more stale state)
- **BFF discovery** — safe parsing of dashboard items (`title`, `isEnabled`, `state`) avoids `KeyError` on partial payloads
- **Telemetry** — fingerprints persisted before notification; FR/EN copy follows `hass.config.language`
- **Cover beta** — shutter entities are not created when `ENKI_ACCESS_MOTORIZATION_API_KEY` is empty (still visible in diagnostics/telemetry as unsupported)

## Test plan

- [x] `ruff check .`
- [x] `pytest tests/unit` (67 passed)
- [ ] Reload Enki integration on a live HA instance
- [ ] Multi-gang Edisio outlet: toggle one circuit, verify siblings stay unchanged until poll
- [ ] Remove a device from Enki app → entity becomes unavailable after refresh