### PR TITLE
feat(light): add RGB (HS) color support for Enki bulbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Mêmes identifiants que l’**application mobile Enki**. La box Enki doit déjà
 | Statut | Appareil | Fonctionnalités |
 |--------|----------|-------------------|
 | ✅ Supporté | Ventilateurs Inspire (Siroco+, Cadix, …) | ventilateur, lumière kit, vitesse, sens, modes |
-| ✅ Supporté | Luminaires Enki (Eglo, Lexman, …) | ON/OFF, luminosité, blanc variable |
+| ✅ Supporté | Luminaires Enki (Eglo, Lexman, …) | ON/OFF, luminosité, blanc variable, couleur RGB (HS) |
 | ✅ Supporté | Prises / interrupteurs (Edisio, …) | ON/OFF |
 | ✅ Supporté | Panneaux solaires Envertech-Lexman | production (W) |
 | ✅ Supporté | Capteurs mouvement / ouverture (Lexman, …) | binary_sensor |

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -510,6 +510,23 @@ class EnkiAPI:
         )
         await http.change_light_state(home_id, node_id, payload)
 
+    async def async_change_light_color(
+        self,
+        home_id: str,
+        node_id: str,
+        hue: float,
+        saturation: float,
+    ) -> None:
+        """Set an HS colour and switch the bulb into colour mode."""
+        http = await self._get_http()
+        current = await http.get_light_state(home_id, node_id)
+        payload = merge_light_state_payload(
+            current.get("lastReportedValue", {}),
+            {"colorMode": "hs", "hue": hue, "saturation": saturation},
+        )
+        payload.pop("colorTemperature", None)
+        await http.change_light_state(home_id, node_id, payload)
+
     async def async_change_light_state_field(
         self,
         home_id: str,

--- a/custom_components/enki/domain/state.py
+++ b/custom_components/enki/domain/state.py
@@ -83,6 +83,19 @@ class EnkiDeviceState:
         return str(value) if isinstance(value, str) else None
 
     @property
+    def hue(self) -> float | None:
+        return _as_float(self._data.get("hue"))
+
+    @property
+    def saturation(self) -> float | None:
+        return _as_float(self._data.get("saturation"))
+
+    @property
+    def color_mode(self) -> str | None:
+        value = self._data.get("colorMode")
+        return str(value) if isinstance(value, str) else None
+
+    @property
     def power_production(self) -> float | None:
         value = self._data.get("power_production")
         if isinstance(value, (int, float)):

--- a/custom_components/enki/lib/conversion.py
+++ b/custom_components/enki/lib/conversion.py
@@ -90,6 +90,41 @@ def direction_to_enki_rotation(direction: str) -> str:
     return mapped
 
 
+def select_light_color_modes(
+    *, has_hs: bool, has_color_temp: bool, has_brightness: bool
+) -> set[str]:
+    """Pick the Home Assistant ``supported_color_modes`` set for an Enki light.
+
+    Home Assistant forbids combining ``brightness`` or ``onoff`` with any real
+    color mode (a color mode already implies brightness control), but it *does*
+    allow combining ``hs`` and ``color_temp`` (a colour bulb that also does
+    tunable white). Return the most capable valid set of ``ColorMode`` *value*
+    strings.
+    """
+    color_modes: set[str] = set()
+    if has_hs:
+        color_modes.add("hs")
+    if has_color_temp:
+        color_modes.add("color_temp")
+    if color_modes:
+        return color_modes
+    if has_brightness:
+        return {"brightness"}
+    return {"onoff"}
+
+
+def hs_to_enki(hue: float, saturation: float) -> tuple[float, float]:
+    """Convert HA HS (hue 0–360, sat 0–100) to Enki normalized 0–1 floats."""
+    return round(hue / 360, 2), round(saturation / 100, 2)
+
+
+def enki_to_hs(hue: Any, saturation: Any) -> tuple[float, float] | None:
+    """Convert Enki normalized hue/saturation to HA HS. None if either is missing."""
+    if hue is None or saturation is None:
+        return None
+    return round(float(hue) * 360, 2), round(float(saturation) * 100, 2)
+
+
 def merge_light_state_payload(
     current: dict[str, Any],
     changes: dict[str, Any],
@@ -106,6 +141,8 @@ def merge_light_state_payload(
         return payload
     payload["power"] = "ON"
     payload.update(changes)
+    if "colorTemperature" in changes:
+        payload["colorMode"] = "ct"
     return payload
 
 

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.light import ColorMode, LightEntity
+from homeassistant.components.light import ATTR_HS_COLOR, ColorMode, LightEntity
 from homeassistant.components.light.const import DEFAULT_MAX_KELVIN, DEFAULT_MIN_KELVIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -14,6 +14,7 @@ from .const import DOMAIN
 from .coordinator import EnkiCoordinator
 from .domain.models import EnkiDevice
 from .entity import EnkiEntity
+from .lib.conversion import enki_to_hs, hs_to_enki, select_light_color_modes
 from .platforms.light.behavior import EnkiLightBehaviorMixin
 
 
@@ -152,6 +153,9 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
                 self._attr_min_color_temp_kelvin = DEFAULT_MIN_KELVIN
                 self._attr_max_color_temp_kelvin = DEFAULT_MAX_KELVIN
 
+        if "change_hue" in caps and "change_saturation" in caps:
+            modes.add(ColorMode.HS)
+
         if "change_brightness" in caps:
             modes.add(ColorMode.BRIGHTNESS)
             self._brightness_max = self._parse_brightness_max(possible)
@@ -159,13 +163,17 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
         if not modes and profile.supports_electrical_power:
             modes.add(ColorMode.ONOFF)
 
-        self._attr_supported_color_modes = modes or {ColorMode.ONOFF}
-        if ColorMode.COLOR_TEMP in modes:
-            self._attr_color_mode = ColorMode.COLOR_TEMP
-        elif ColorMode.BRIGHTNESS in modes:
-            self._attr_color_mode = ColorMode.BRIGHTNESS
-        else:
-            self._attr_color_mode = ColorMode.ONOFF
+        supported = {
+            ColorMode(value)
+            for value in select_light_color_modes(
+                has_hs=ColorMode.HS in modes,
+                has_color_temp=ColorMode.COLOR_TEMP in modes,
+                has_brightness=ColorMode.BRIGHTNESS in modes,
+            )
+        }
+        self._attr_supported_color_modes = supported or {ColorMode.ONOFF}
+        if len(self._attr_supported_color_modes) == 1:
+            self._attr_color_mode = next(iter(self._attr_supported_color_modes))
 
     @property
     def is_on(self) -> bool:
@@ -191,6 +199,32 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
         raw = self._device.reported.color_temperature
         return int(raw.strip("TK")) if raw else None
 
+    @property
+    def hs_color(self) -> tuple[float, float] | None:
+        if (
+            self._attr_supported_color_modes is None
+            or ColorMode.HS not in self._attr_supported_color_modes
+        ):
+            return None
+        reported = self._device.reported
+        return enki_to_hs(reported.hue, reported.saturation)
+
+    @property
+    def color_mode(self) -> ColorMode | None:
+        if self._attr_color_mode is not None:
+            return self._attr_color_mode
+        reported = self._device.reported
+        mode = reported.color_mode
+        if mode == "hs":
+            return ColorMode.HS
+        if mode == "ct":
+            return ColorMode.COLOR_TEMP
+        if reported.color_temperature:
+            return ColorMode.COLOR_TEMP
+        if ColorMode.HS in (self._attr_supported_color_modes or set()):
+            return ColorMode.HS
+        return None
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         home_id = self._device.home_id
         node_id = self._device.node_id
@@ -205,6 +239,17 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
             self._cache_electrical_power("ON")
             return
 
+        if ATTR_HS_COLOR in kwargs:
+            hue, saturation = hs_to_enki(*kwargs[ATTR_HS_COLOR])
+            await self.coordinator.api.async_change_light_color(home_id, node_id, hue, saturation)
+            self.coordinator.update_cached_value(node_id, "hue", hue)
+            self.coordinator.update_cached_value(node_id, "saturation", saturation)
+            self.coordinator.update_cached_value(node_id, "colorMode", "hs")
+            self.coordinator.update_cached_value(node_id, "colorTemperature", None)
+            self.coordinator.update_cached_value(node_id, "power", "ON")
+            self._update_light_endpoint_cache("ON", self._endpoint_id)
+            return
+
         await self._mixed_endpoint_workaround()
         changes = self._build_turn_on_changes(kwargs)
         await self.coordinator.api.async_change_light_state(home_id, node_id, changes)
@@ -217,6 +262,7 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
                 "colorTemperature",
                 changes["colorTemperature"],
             )
+            self.coordinator.update_cached_value(node_id, "colorMode", "ct")
         self._update_light_endpoint_cache("ON", self._endpoint_id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.3.3"
+  "version": "1.4.0"
 }

--- a/custom_components/enki/platforms/light/behavior.py
+++ b/custom_components/enki/platforms/light/behavior.py
@@ -59,6 +59,7 @@ class EnkiLightBehaviorMixin:
                 )
             else:
                 changes["colorTemperature"] = f"T{kwargs[ATTR_COLOR_TEMP_KELVIN]}K"
+            changes["colorMode"] = "ct"
         elif restore_last_brightness and ATTR_BRIGHTNESS not in kwargs:
             last_brightness = self._device.reported.brightness
             if last_brightness is not None and last_brightness > 0:

--- a/docs/API.md
+++ b/docs/API.md
@@ -102,6 +102,13 @@ Gateway key: `ENKI_ACCESS_MOTORIZATION_API_KEY` in `const.py`. Capture procedure
 | On/off | `power` | `"ON"` / `"OFF"` |
 | Brightness | `brightness` | float, device-specific max (often `100`) |
 | Colour temperature | `colorTemperature` | `"T3500K"` style strings |
+| Hue (RGB bulbs) | `hue` | normalized float `0.0`–`1.0` (HA hue ÷ 360) |
+| Saturation (RGB bulbs) | `saturation` | normalized float `0.0`–`1.0` (HA sat ÷ 100) |
+
+RGB bulbs (e.g. Lexman) advertise `change_hue` + `change_saturation` and map to
+HA's `ColorMode.HS`. When the bulb also advertises `change_color_temperature`,
+the integration exposes both `hs` and `color_temp`; the reported `colorMode`
+field (`hs` vs `ct`) indicates which mode is active.
 
 ## Future device families (not implemented yet)
 

--- a/tests/unit/test_fan_light_state.py
+++ b/tests/unit/test_fan_light_state.py
@@ -26,6 +26,13 @@ def test_merge_light_state_payload_brightness_update_keeps_on() -> None:
     assert payload["brightness"] == 0.8
 
 
+def test_merge_light_state_payload_color_temp_sets_ct_mode() -> None:
+    current = {"power": "ON", "colorMode": "hs", "hue": 0.5, "saturation": 0.8}
+    payload = merge_light_state_payload(current, {"colorTemperature": "T3500K"})
+    assert payload["colorMode"] == "ct"
+    assert payload["colorTemperature"] == "T3500K"
+
+
 def test_fan_light_power_from_lighting_last_reported() -> None:
     last_reported = {"power": "OFF", "brightness": 0.2}
     assert last_reported.get("power", "OFF") == "OFF"

--- a/tests/unit/test_light_color_mode.py
+++ b/tests/unit/test_light_color_mode.py
@@ -1,0 +1,66 @@
+"""Unit tests for Enki light supported-color-mode selection and HS conversion."""
+
+from __future__ import annotations
+
+from enki.lib.conversion import enki_to_hs, hs_to_enki, select_light_color_modes
+
+
+def test_color_temp_wins_over_brightness() -> None:
+    assert select_light_color_modes(
+        has_hs=False, has_color_temp=True, has_brightness=True
+    ) == {"color_temp"}
+
+
+def test_color_temp_only() -> None:
+    assert select_light_color_modes(
+        has_hs=False, has_color_temp=True, has_brightness=False
+    ) == {"color_temp"}
+
+
+def test_brightness_only() -> None:
+    assert select_light_color_modes(
+        has_hs=False, has_color_temp=False, has_brightness=True
+    ) == {"brightness"}
+
+
+def test_onoff_fallback() -> None:
+    assert select_light_color_modes(
+        has_hs=False, has_color_temp=False, has_brightness=False
+    ) == {"onoff"}
+
+
+def test_hs_and_color_temp_combine() -> None:
+    assert select_light_color_modes(
+        has_hs=True, has_color_temp=True, has_brightness=True
+    ) == {"hs", "color_temp"}
+
+
+def test_hs_only_drops_brightness() -> None:
+    assert select_light_color_modes(
+        has_hs=True, has_color_temp=False, has_brightness=True
+    ) == {"hs"}
+
+
+def test_hs_to_enki_normalizes() -> None:
+    assert hs_to_enki(0, 0) == (0.0, 0.0)
+    assert hs_to_enki(360, 100) == (1.0, 1.0)
+    assert hs_to_enki(180, 50) == (0.5, 0.5)
+
+
+def test_enki_to_hs_denormalizes() -> None:
+    assert enki_to_hs(0.0, 0.0) == (0.0, 0.0)
+    assert enki_to_hs(1.0, 1.0) == (360.0, 100.0)
+    assert enki_to_hs(0.5, 0.5) == (180.0, 50.0)
+
+
+def test_enki_to_hs_missing_returns_none() -> None:
+    assert enki_to_hs(None, 0.5) is None
+    assert enki_to_hs(0.5, None) is None
+
+
+def test_hs_roundtrip() -> None:
+    hue, sat = hs_to_enki(210, 80)
+    result = enki_to_hs(hue, sat)
+    assert result is not None
+    assert abs(result[0] - 210) <= 4
+    assert abs(result[1] - 80) <= 1

--- a/tests/unit/test_light_color_mode.py
+++ b/tests/unit/test_light_color_mode.py
@@ -6,39 +6,40 @@ from enki.lib.conversion import enki_to_hs, hs_to_enki, select_light_color_modes
 
 
 def test_color_temp_wins_over_brightness() -> None:
-    assert select_light_color_modes(
-        has_hs=False, has_color_temp=True, has_brightness=True
-    ) == {"color_temp"}
+    assert select_light_color_modes(has_hs=False, has_color_temp=True, has_brightness=True) == {
+        "color_temp"
+    }
 
 
 def test_color_temp_only() -> None:
-    assert select_light_color_modes(
-        has_hs=False, has_color_temp=True, has_brightness=False
-    ) == {"color_temp"}
+    assert select_light_color_modes(has_hs=False, has_color_temp=True, has_brightness=False) == {
+        "color_temp"
+    }
 
 
 def test_brightness_only() -> None:
-    assert select_light_color_modes(
-        has_hs=False, has_color_temp=False, has_brightness=True
-    ) == {"brightness"}
+    assert select_light_color_modes(has_hs=False, has_color_temp=False, has_brightness=True) == {
+        "brightness"
+    }
 
 
 def test_onoff_fallback() -> None:
-    assert select_light_color_modes(
-        has_hs=False, has_color_temp=False, has_brightness=False
-    ) == {"onoff"}
+    assert select_light_color_modes(has_hs=False, has_color_temp=False, has_brightness=False) == {
+        "onoff"
+    }
 
 
 def test_hs_and_color_temp_combine() -> None:
-    assert select_light_color_modes(
-        has_hs=True, has_color_temp=True, has_brightness=True
-    ) == {"hs", "color_temp"}
+    assert select_light_color_modes(has_hs=True, has_color_temp=True, has_brightness=True) == {
+        "hs",
+        "color_temp",
+    }
 
 
 def test_hs_only_drops_brightness() -> None:
-    assert select_light_color_modes(
-        has_hs=True, has_color_temp=False, has_brightness=True
-    ) == {"hs"}
+    assert select_light_color_modes(has_hs=True, has_color_temp=False, has_brightness=True) == {
+        "hs"
+    }
 
 
 def test_hs_to_enki_normalizes() -> None:


### PR DESCRIPTION
## Summary

- Add `ColorMode.HS` for bulbs with `change_hue` + `change_saturation` (Lexman RGB, etc.)
- Support HS + tunable white on the same entity with dynamic `color_mode` from Enki's `colorMode` field (`hs` vs `ct`)
- Fix invalid HA mode sets (`{brightness, color_temp}`) via `select_light_color_modes()`
- Ported from [DevSkyLex/enki-integration-hass](https://github.com/DevSkyLex/enki-integration-hass) onto the refactored codebase (v1.4.0)

## Changes

- `lib/conversion.py` — `select_light_color_modes`, `hs_to_enki`, `enki_to_hs`, `colorMode=ct` on temp changes
- `api/client.py` — `async_change_light_color()` drops `colorTemperature` when switching to HS
- `light.py` — HS properties, colour commands, cache updates
- `domain/state.py` — `hue`, `saturation`, `color_mode` accessors
- 11 new unit tests (79 total)

## Test plan

- [x] `pytest tests/unit/` — 79 passed
- [x] `ruff check custom_components/enki tests/unit`
- [ ] Manual: Lexman RGB bulb — set colour, switch to tunable white, verify both modes in HA
- [ ] Manual: tunable-white-only bulb — no regression on brightness / color temp