### PR TITLE
fix(telemetry): skip notifications for fully supported profiles

### DIFF
--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -225,6 +225,24 @@ class EnkiCapabilityProfile:
             "check_siren_global_state",
         )
 
+    @property
+    def supports_color_temperature(self) -> bool:
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "change_color_temperature",
+            "check_color_temperature",
+        )
+
+    @property
+    def supports_brightness_control(self) -> bool:
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "change_brightness",
+            "check_brightness",
+        ) or self.supports_light_state
+
     # --- HA platform classification ----------------------------------------
 
     @property

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -1,0 +1,86 @@
+"""Decide whether an opt-in telemetry notification is useful."""
+
+from __future__ import annotations
+
+from .capabilities import EnkiCapabilityProfile
+from .models import EnkiDiscoveryRecord
+
+# Device lifecycle / admin — not exposed as Home Assistant entities.
+_TELEMETRY_IGNORED_CAPABILITIES = frozenset(
+    {
+        "change_esdk_certificate",
+        "check_certificate_renewal_confirmation",
+        "check_current_firmware_version",
+        "check_esdk_certificate_renewal",
+        "execute_generic_ota_command",
+        "ota_inventory",
+    }
+)
+
+# Map referentiel capability names to EnkiCapabilityProfile probes.
+_CAPABILITY_PROBES: dict[str, str] = {
+    "activate_contact_detection": "supports_contact_detection_activation",
+    "activate_vibration_detection": "supports_vibration_detection_activation",
+    "change_airflow_mode": "supports_airflow_mode",
+    "change_brightness": "supports_brightness_control",
+    "change_color_temperature": "supports_color_temperature",
+    "change_fan_rotation_direction": "supports_fan_rotation",
+    "change_fan_speed": "supports_fan_speed",
+    "change_light_state": "supports_light_state",
+    "change_shutter_position": "supports_shutter_position",
+    "change_vibration_sensibility_level": "supports_vibration_sensibility",
+    "check_airflow_mode": "supports_airflow_mode",
+    "check_battery_health": "supports_battery_health",
+    "check_brightness": "supports_brightness_control",
+    "check_color_temperature": "supports_color_temperature",
+    "check_contact_detection_activation": "supports_contact_detection_activation",
+    "check_contact_sensor_state": "supports_contact_sensor",
+    "check_current_humidity": "supports_current_humidity",
+    "check_current_temperature": "supports_current_temperature",
+    "check_electrical_power": "supports_electrical_power",
+    "check_fan_rotation_direction": "supports_fan_rotation",
+    "check_fan_speed": "supports_fan_speed",
+    "check_light_state": "supports_light_state",
+    "check_motion_detection": "supports_motion_detection",
+    "check_motion_detector_state": "supports_motion_detection",
+    "check_power_production": "supports_power_production",
+    "check_shutter_opening": "supports_shutter_opening",
+    "check_shutter_position": "supports_shutter_position",
+    "check_siren_global_state": "supports_siren",
+    "check_vibration_detection": "supports_vibration_detection",
+    "check_vibration_detection_activation": "supports_vibration_detection_activation",
+    "check_vibration_sensibility_level": "supports_vibration_sensibility",
+    "switch_electrical_power": "supports_electrical_power",
+    "switch_siren_status": "supports_siren",
+}
+
+
+def profile_from_record(record: EnkiDiscoveryRecord) -> EnkiCapabilityProfile:
+    return EnkiCapabilityProfile(
+        device_type=record.device_type,
+        capabilities=frozenset(record.capabilities or []),
+        possible_values=record.possible_values or {},
+        bff_device_type=record.bff_device_type or "",
+    )
+
+
+def capability_is_covered(capability: str, profile: EnkiCapabilityProfile) -> bool:
+    """Return True when the integration implements this capability or it is admin-only."""
+    if capability in _TELEMETRY_IGNORED_CAPABILITIES:
+        return True
+    probe_name = _CAPABILITY_PROBES.get(capability)
+    if probe_name is None:
+        return False
+    return bool(getattr(profile, probe_name))
+
+
+def discovery_record_needs_telemetry(record: EnkiDiscoveryRecord) -> bool:
+    """Return True when the user should be nudged to open a GitHub issue."""
+    if not record.supported_by_integration:
+        return True
+
+    profile = profile_from_record(record)
+    for capability in record.capabilities or []:
+        if not capability_is_covered(capability, profile):
+            return True
+    return False

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.3.3"
+  "version": "1.3.4"
 }

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -16,6 +16,7 @@ from ..domain.profile import (
     profile_fingerprint,
     profile_to_export_dict,
 )
+from ..domain.telemetry_coverage import discovery_record_needs_telemetry
 
 STORAGE_VERSION = 1
 
@@ -65,6 +66,10 @@ class EnkiTelemetryReporter:
 
             reported.add(fingerprint)
             await self._save_reported(reported)
+
+            if not discovery_record_needs_telemetry(record):
+                continue
+
             new_count += 1
             self._notify_new_profile(export_dict, fingerprint)
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -16,13 +16,15 @@ Export JSON local : profils anonymisés (type, fabricant, capabilities). À join
 
 > M’avertir des nouveaux appareils (lien issue GitHub)
 
-Quand un **nouveau** profil est détecté (empreinte unique) :
+Quand un **nouveau** profil est détecté (empreinte unique) **et qu'il manque du support** (appareil non géré ou capabilities non implémentées) :
 
 1. Une **notification persistante** apparaît dans Home Assistant
 2. Le lien ouvre GitHub avec titre et description **pré-remplis**
 3. Vous **validez** la création de l’issue — rien n’est envoyé sans ce clic
 
 **Jamais inclus :** e-mail, mot de passe, homeId, nodeId, noms de pièces.
+
+**Pas de notification** si l'appareil est déjà entièrement supporté (ex. variante de ventilateur Inspire déjà couverte).
 
 ## Pour les contributeurs
 

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -86,6 +86,45 @@ async def test_telemetry_dedupes_fingerprint() -> None:
 
 
 @pytest.mark.asyncio
+async def test_telemetry_skips_fully_supported_profile() -> None:
+    hass = MagicMock()
+    hass.config.version = "2024.12.0"
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.options = {CONF_TELEMETRY: True}
+
+    record = build_discovery_record(
+        device_type="ceiling_fans",
+        bff_device_type="ceiling_fans",
+        capabilities=[
+            "change_fan_speed",
+            "check_fan_speed",
+            "change_light_state",
+            "check_light_state",
+            "switch_electrical_power",
+            "check_electrical_power",
+        ],
+        possible_values={},
+        manufacturer="Inspire",
+        model="AD_TCFL_1",
+        firmware_version="2.21.0",
+        supported_by_integration=True,
+    )
+
+    reporter = EnkiTelemetryReporter(hass, entry)
+    reporter._store.async_load = AsyncMock(return_value={"fingerprints": []})  # type: ignore[method-assign]
+    reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "enki.telemetry.reporter.persistent_notification.async_create",
+        new_callable=MagicMock,
+    ) as notify:
+        await reporter.async_report([record])
+        notify.assert_not_called()
+        reporter._store.async_save.assert_awaited()
+
+
+@pytest.mark.asyncio
 async def test_telemetry_tolerates_corrupt_storage() -> None:
     hass = MagicMock()
     hass.config.version = "2024.12.0"

--- a/tests/unit/test_telemetry_coverage.py
+++ b/tests/unit/test_telemetry_coverage.py
@@ -1,0 +1,88 @@
+"""Unit tests for telemetry coverage decisions."""
+
+from __future__ import annotations
+
+from enki.domain.profile import build_discovery_record
+from enki.domain.telemetry_coverage import (
+    capability_is_covered,
+    discovery_record_needs_telemetry,
+    profile_from_record,
+)
+
+# Capabilities from issue #14 — Inspire AD_TCFL_1 ceiling fan (already fully supported).
+_CEILING_FAN_CAPABILITIES = [
+    "change_airflow_mode",
+    "change_brightness",
+    "change_color_temperature",
+    "change_esdk_certificate",
+    "change_fan_rotation_direction",
+    "change_fan_speed",
+    "change_light_state",
+    "check_airflow_mode",
+    "check_certificate_renewal_confirmation",
+    "check_current_firmware_version",
+    "check_electrical_power",
+    "check_esdk_certificate_renewal",
+    "check_fan_rotation_direction",
+    "check_fan_speed",
+    "check_light_state",
+    "execute_generic_ota_command",
+    "ota_inventory",
+    "switch_electrical_power",
+]
+
+
+def _ceiling_fan_record(*, supported: bool = True):
+    return build_discovery_record(
+        device_type="ceiling_fans",
+        bff_device_type="ceiling_fans",
+        capabilities=_CEILING_FAN_CAPABILITIES,
+        possible_values={
+            "change_airflow_mode": {"values": ["BREEZE", "MANUAL"]},
+            "change_color_temperature": {"values": ["T3500K", "T4000K"]},
+            "change_fan_rotation_direction": {"values": ["CLOCKWISE", "COUNTERCLOCKWISE"]},
+        },
+        manufacturer="Inspire",
+        model="AD_TCFL_1",
+        firmware_version="2.21.0",
+        supported_by_integration=supported,
+    )
+
+
+def test_ceiling_fan_profile_does_not_need_telemetry() -> None:
+    record = _ceiling_fan_record()
+    assert discovery_record_needs_telemetry(record) is False
+
+
+def test_unsupported_device_still_needs_telemetry() -> None:
+    record = build_discovery_record(
+        device_type="equation_radiator",
+        bff_device_type="radiators",
+        capabilities=["check_temperature"],
+        possible_values={},
+        manufacturer="equation",
+        model="neo",
+        firmware_version=None,
+        supported_by_integration=False,
+    )
+    assert discovery_record_needs_telemetry(record) is True
+
+
+def test_supported_device_with_unknown_capability_needs_telemetry() -> None:
+    record = build_discovery_record(
+        device_type="ceiling_fans",
+        bff_device_type="ceiling_fans",
+        capabilities=["change_fan_speed", "check_fan_speed", "change_setpoint"],
+        possible_values={},
+        manufacturer="Inspire",
+        model="future_fan",
+        firmware_version="1.0.0",
+        supported_by_integration=True,
+    )
+    assert discovery_record_needs_telemetry(record) is True
+
+
+def test_admin_capabilities_are_ignored() -> None:
+    profile = profile_from_record(_ceiling_fan_record())
+    assert capability_is_covered("ota_inventory", profile) is True
+    assert capability_is_covered("change_esdk_certificate", profile) is True


### PR DESCRIPTION
## Summary

- Ne plus afficher de notification télémétrie quand l'appareil est **déjà supporté** et que **toutes les capabilities utilisateur** sont implémentées (OTA/certificats ignorés)
- Empreinte toujours sauvegardée en silence pour éviter de re-vérifier à chaque poll
- Cas #14 (Inspire AD_TCFL_1) : plus de notif / issue inutile

## Test plan

- [x] 73 tests unitaires passent
- [x] Profil ventilateur issue #14 → pas de notification
- [x] Radiateur non supporté → notification conservée
- [x] Appareil supporté avec capability inconnue → notification conservée