### PR TITLE
fix(ci): resolve ruff lint failures

### DIFF
--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
     ColorMode,
     LightEntity,

--- a/custom_components/enki/notifications.py
+++ b/custom_components/enki/notifications.py
@@ -7,12 +7,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
+from .exceptions import EnkiConnectionError
 
 _DOCUMENTATION_URL = "https://github.com/cyrilcolinet/enki-integration-hass"
 _ISSUE_TRACKER = f"{_DOCUMENTATION_URL}/issues"
-
-
-from .exceptions import EnkiConnectionError
 
 
 def notify_for_connection_error(notifier: EnkiNotifier, err: EnkiConnectionError) -> None:
@@ -98,15 +96,17 @@ def _auth_copy(
         title = "Enki — connexion refusée"
         if gateway_hint:
             body = (
-                "L'API Enki a rejeté la requête (HTTP 401). Vérifiez votre **email et mot de passe** "
-                "Enki, ou mettez à jour les clés gateway si l'app mobile a changé de version.\n\n"
+                "L'API Enki a rejeté la requête (HTTP 401). "
+                "Vérifiez votre **email et mot de passe** Enki, ou mettez à jour les clés "
+                "gateway si l'app mobile a changé de version.\n\n"
                 f"[Reconfigurer Enki]({configure_url}) · "
                 f"[Documentation]({_DOCUMENTATION_URL})"
             )
         else:
             body = (
-                "Identifiants Enki invalides ou session expirée. Utilisez le même **email et mot de passe** "
-                "que l'application mobile Leroy Merlin Enki.\n\n"
+                "Identifiants Enki invalides ou session expirée. "
+                "Utilisez le même **email et mot de passe** que l'application mobile "
+                "Leroy Merlin Enki.\n\n"
                 f"[Reconfigurer Enki]({configure_url})"
             )
         return title, body
@@ -133,8 +133,9 @@ def _gateway_copy(hass: HomeAssistant) -> tuple[str, str]:
         return (
             "Enki — clé API gateway refusée",
             (
-                "L'API Enki a répondu **HTTP 403** : une clé gateway (micro-service) est probablement "
-                "obsolète. Cela arrive quand l'application Enki est mise à jour.\n\n"
+                "L'API Enki a répondu **HTTP 403** : une clé gateway (micro-service) "
+                "est probablement obsolète. Cela arrive quand l'application Enki est "
+                "mise à jour.\n\n"
                 "Mettez à jour les clés via `scripts/extract_gateway_keys.py` ou consultez "
                 f"[la documentation]({_DOCUMENTATION_URL}).\n\n"
                 f"[Signaler un problème]({_ISSUE_TRACKER})"
@@ -158,7 +159,8 @@ def _connection_copy(hass: HomeAssistant) -> tuple[str, str]:
             "Enki — cloud inaccessible",
             (
                 "Impossible de joindre le cloud Enki (réseau, timeout ou erreur serveur). "
-                "Les entités ne seront pas mises à jour tant que la connexion n'est pas rétablie.\n\n"
+                "Les entités ne seront pas mises à jour tant que la connexion "
+                "n'est pas rétablie.\n\n"
                 "Vérifiez votre connexion Internet et les logs Home Assistant (`enki`)."
             ),
         )

--- a/scripts/extract_gateway_keys.py
+++ b/scripts/extract_gateway_keys.py
@@ -18,9 +18,9 @@ import re
 import subprocess
 import sys
 from collections import Counter
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CONST_PY = REPO_ROOT / "custom_components" / "enki" / "const.py"
@@ -145,9 +145,7 @@ def decompile_class(apk_path: Path, class_name: str, jadx_dir: Path) -> str:
         if not path.is_file():
             return ""
         text = path.read_text(encoding="utf-8", errors="replace")
-        if any(marker in text for marker in INCOMPLETE_MARKERS) and not KEY_LITERAL.search(
-            text
-        ):
+        if any(marker in text for marker in INCOMPLETE_MARKERS) and not KEY_LITERAL.search(text):
             return ""
         return text
 
@@ -208,14 +206,12 @@ def parse_bindings(di_sources: Iterable[Path]) -> list[ServiceBinding]:
             slug = g3c.group(1)
             if slug in seen:
                 continue
-            iface_match = re.search(rf"\.f\((\w+)\.class\)", line)
+            iface_match = re.search(r"\.f\((\w+)\.class\)", line)
             if not iface_match and bindings:
                 continue
             iface = iface_match.group(1) if iface_match else ""
             wrappers = tuple(
-                name
-                for name in WRAPPER_PATTERN.findall(line)
-                if name not in SKIP_WRAPPERS
+                name for name in WRAPPER_PATTERN.findall(line) if name not in SKIP_WRAPPERS
             )
             bindings.append(ServiceBinding(slug, iface, wrappers, source.name))
             seen.add(slug)
@@ -223,9 +219,7 @@ def parse_bindings(di_sources: Iterable[Path]) -> list[ServiceBinding]:
     return bindings
 
 
-def load_wrapper_source(
-    wrapper: str, apk_path: Path, jadx_dir: Path
-) -> str:
+def load_wrapper_source(wrapper: str, apk_path: Path, jadx_dir: Path) -> str:
     path = jadx_dir / "sources" / "defpackage" / f"{wrapper}.java"
     if path.is_file():
         return path.read_text(encoding="utf-8", errors="replace")
@@ -268,7 +262,8 @@ def keys_for_iface_in_sources(sources_dir: Path, iface: str) -> Counter[str]:
         return counts
     for path in sources_dir.glob("*.java"):
         try:
-            counts.update(keys_near_iface(path.read_text(encoding="utf-8", errors="replace"), iface))
+            text = path.read_text(encoding="utf-8", errors="replace")
+            counts.update(keys_near_iface(text, iface))
         except OSError:
             continue
     return counts
@@ -365,7 +360,7 @@ def apply_to_const(
     *,
     update_known: bool = False,
 ) -> list[str]:
-    const_keys = read_const_keys()
+    read_const_keys()
     changes: list[str] = []
     lines = CONST_PY.read_text(encoding="utf-8").splitlines(keepends=True)
 
@@ -457,7 +452,7 @@ def main() -> int:
         key, detail = extracted[symbol]
         if current or not key:
             continue
-        print(f"  {symbol} = \"{key}\"  # {detail}")
+        print(f'  {symbol} = "{key}"  # {detail}')
 
     print("\n=== All services ===")
     for svc in ENKI_MICRO_SERVICES:

--- a/scripts/fetch_gateway_keys.py
+++ b/scripts/fetch_gateway_keys.py
@@ -71,9 +71,7 @@ async def fetch_settings(username: str, password: str) -> dict:
                     f"Non-JSON response from mobile-config: {exc}\n{body[:500]}"
                 ) from exc
             if not isinstance(payload, dict):
-                raise RuntimeError(
-                    f"Unexpected mobile-config payload type: {type(payload)!r}"
-                )
+                raise RuntimeError(f"Unexpected mobile-config payload type: {type(payload)!r}")
             return payload
 
 

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from enki.exceptions import EnkiConnectionError
 from enki.notifications import EnkiNotifier, notify_for_connection_error
 
@@ -20,7 +19,10 @@ def notifier() -> tuple[MagicMock, EnkiNotifier]:
 
 
 @patch("enki.notifications.persistent_notification.async_create")
-def test_notify_auth_failed(mock_create: MagicMock, notifier: tuple[MagicMock, EnkiNotifier]) -> None:
+def test_notify_auth_failed(
+    mock_create: MagicMock,
+    notifier: tuple[MagicMock, EnkiNotifier],
+) -> None:
     hass, n = notifier
     n.notify_auth_failed()
     mock_create.assert_called_once()


### PR DESCRIPTION
## Summary
- Fix ruff lint errors blocking CI on main (import order, line length, unused imports, formatting)
- No functional changes

## Test plan
- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `pytest tests/unit -v`