### PR TITLE
fix: routage API ventilateur et lumières kit (v1.6.3)

### DIFF
--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -99,6 +99,8 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         speed = self._device.reported.fan_speed
         if speed is not None:
             return speed > 0
+        if self._device.profile.supports_fan_speed:
+            return False
         return self._device.reported.electrical_power == "ON"
 
     @property
@@ -147,40 +149,41 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         if preset_mode is not None and self._supports_preset_mode():
             await self.async_set_preset_mode(preset_mode)
 
-        if self._device.reported.fan_speed is None:
-            if percentage is None or percentage > 0:
-                await self.coordinator.api.async_switch_electrical_power(
-                    self._device.home_id,
-                    self._device.node_id,
-                    "ON",
-                )
-                self.coordinator.update_cached_value(
-                    self._device.node_id,
-                    "electrical_power",
-                    "ON",
-                )
+        if self._device.profile.supports_fan_speed:
+            if percentage is not None and percentage > 0:
+                speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
+            else:
+                speed = max(1, self._device.reported.fan_speed or 1)
+            await self._set_speed(speed)
             return
 
-        if percentage is not None and percentage > 0:
-            speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
-        else:
-            speed = max(1, self._device.reported.fan_speed or 1)
-        await self._set_speed(speed)
-
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        if self._device.reported.fan_speed is None:
+        if percentage is None or percentage > 0:
             await self.coordinator.api.async_switch_electrical_power(
                 self._device.home_id,
                 self._device.node_id,
-                "OFF",
+                "ON",
             )
             self.coordinator.update_cached_value(
                 self._device.node_id,
                 "electrical_power",
-                "OFF",
+                "ON",
             )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        if self._device.profile.supports_fan_speed:
+            await self._set_speed(0)
             return
-        await self._set_speed(0)
+
+        await self.coordinator.api.async_switch_electrical_power(
+            self._device.home_id,
+            self._device.node_id,
+            "OFF",
+        )
+        self.coordinator.update_cached_value(
+            self._device.node_id,
+            "electrical_power",
+            "OFF",
+        )
 
     async def async_set_percentage(self, percentage: int) -> None:
         if percentage == 0:

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -99,9 +99,6 @@ class EnkiFanLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
 
     @property
     def is_on(self) -> bool:
-        if self._endpoint_id is not None:
-            power = self._device.reported.endpoint_power(self._endpoint_id)
-            return power == "ON" if power is not None else False
         return self._device.reported.light_power == "ON"
 
     @property
@@ -221,8 +218,10 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
             power = reported.endpoint_power(self._endpoint_id)
             return power == "ON" if power is not None else False
 
-        if reported.global_power is not None:
-            return reported.global_power == "ON"
+        if self._supports_light_state:
+            if reported.global_power is not None:
+                return reported.global_power == "ON"
+            return False
 
         return reported.electrical_power == "ON"
 

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.2"
+  "version": "1.6.3"
 }

--- a/custom_components/enki/platforms/light/behavior.py
+++ b/custom_components/enki/platforms/light/behavior.py
@@ -37,7 +37,8 @@ class EnkiLightBehaviorMixin:
             return False
         profile = self._device.profile
         if profile.is_fan:
-            return endpoint_id in profile.fan_light_endpoints
+            # Fan light kits are driven by api-enki-lighting-prod, not power-prod.
+            return False
         return len(profile.power_switch_endpoints) > 1
 
     def _simple_light_turn_on(self, kwargs: dict[str, Any]) -> bool:

--- a/scripts/enki_bootstrap.py
+++ b/scripts/enki_bootstrap.py
@@ -79,7 +79,6 @@ def bootstrap(*modules: str) -> None:
         "enki.lib",
         "enki.platforms",
         "enki.platforms.light",
-        "enki.telemetry",
     ):
         _ensure_package(pkg)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,71 @@ _HA_STUBS = [
     "homeassistant.components.diagnostics",
     "homeassistant.components.persistent_notification",
     "homeassistant.components.sensor",
+    "homeassistant.util",
 ]
 
 for module_name in _HA_STUBS:
     sys.modules.setdefault(module_name, MagicMock())
+
+
+class _HaEntity:
+    """Minimal HA Entity stand-in for unit tests."""
+
+
+class _CoordinatorEntity(_HaEntity):
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+    def __class_getitem__(cls, _item):
+        return cls
+
+
+class _FanEntity(_HaEntity):
+    pass
+
+
+class _FanEntityFeature:
+    SET_SPEED = 1
+    TURN_ON = 2
+    TURN_OFF = 4
+    DIRECTION = 8
+    PRESET_MODE = 16
+
+
+_update_coordinator = sys.modules["homeassistant.helpers.update_coordinator"]
+_update_coordinator.CoordinatorEntity = _CoordinatorEntity
+
+_fan = sys.modules["homeassistant.components.fan"]
+_fan.FanEntity = _FanEntity
+_fan.FanEntityFeature = _FanEntityFeature
+_fan.DIRECTION_FORWARD = "forward"
+_fan.DIRECTION_REVERSE = "reverse"
+
+_core = sys.modules["homeassistant.core"]
+_core.callback = lambda fn: fn
+
+_device_registry = sys.modules["homeassistant.helpers.device_registry"]
+_device_registry.DeviceInfo = dict
+
+
+def _ordered_list_item_to_percentage(speeds: list[int], speed: int) -> int:
+    if not speeds:
+        return 0
+    try:
+        index = speeds.index(speed)
+    except ValueError:
+        return 0
+    return round((index + 1) * 100 / len(speeds))
+
+
+def _percentage_to_ordered_list_item(speeds: list[int], percentage: int) -> int:
+    if not speeds or percentage <= 0:
+        return 0
+    index = max(0, min(len(speeds) - 1, round(percentage * len(speeds) / 100) - 1))
+    return speeds[index]
+
+
+_percentage = MagicMock()
+_percentage.ordered_list_item_to_percentage = _ordered_list_item_to_percentage
+_percentage.percentage_to_ordered_list_item = _percentage_to_ordered_list_item
+sys.modules["homeassistant.util.percentage"] = _percentage

--- a/tests/unit/test_api_routing.py
+++ b/tests/unit/test_api_routing.py
@@ -1,0 +1,138 @@
+"""Guard against routing fan lights or lighting-capable nodes to power-prod."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.domain.models import EnkiDevice
+from enki.fan import EnkiFanEntity
+from enki.platforms.light.behavior import EnkiLightBehaviorMixin
+
+
+def _ceiling_fan(**overrides) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "AD_TCFL_1",
+        "node_id": "node-fan",
+        "device_name": "Ventilateur",
+        "device_type": "ceiling_fans",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [
+            "change_fan_speed",
+            "check_fan_speed",
+            "change_light_state",
+            "check_light_state",
+            "switch_electrical_power",
+            "check_electrical_power",
+        ],
+        "main_change_capability_id": "switch_electrical_power",
+        "main_change_capability_endpoints": [1, 2, 3],
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+class _LightBehaviorStub(EnkiLightBehaviorMixin):
+    _brightness_max = 100
+    _color_temp_values: list[int] = []
+
+    def __init__(self, device: EnkiDevice) -> None:
+        self._device = device
+
+
+def test_fan_light_endpoints_never_use_power_api() -> None:
+    stub = _LightBehaviorStub(_ceiling_fan())
+    assert stub._uses_endpoint_power(2) is False
+    assert stub._uses_endpoint_power(3) is False
+
+
+def test_multi_gang_switch_uses_endpoint_power() -> None:
+    device = EnkiDevice(
+        home_id="home-1",
+        device_id="edisio",
+        node_id="node-switch",
+        device_name="Prise",
+        device_type="switches",
+        is_enabled=True,
+        state="ACTIVE",
+        capabilities=["switch_electrical_power", "check_electrical_power"],
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[2, 3],
+    )
+    stub = _LightBehaviorStub(device)
+    assert stub._uses_endpoint_power(2) is True
+
+
+def test_fan_is_on_ignores_electrical_power_when_speed_supported() -> None:
+    coordinator = MagicMock()
+    coordinator.api.async_set_fan_speed = AsyncMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    entity = EnkiFanEntity(
+        coordinator,
+        _ceiling_fan(last_reported_value={"electrical_power": "ON"}),
+    )
+    assert entity.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_fan_turn_on_uses_airflow_when_speed_state_missing() -> None:
+    coordinator = MagicMock()
+    coordinator.api.async_set_fan_speed = AsyncMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    entity = EnkiFanEntity(coordinator, _ceiling_fan())
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 1)
+    coordinator.api.async_switch_electrical_power.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fan_turn_off_uses_airflow_when_speed_state_missing() -> None:
+    coordinator = MagicMock()
+    coordinator.api.async_set_fan_speed = AsyncMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    entity = EnkiFanEntity(coordinator, _ceiling_fan())
+
+    await entity.async_turn_off()
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 0)
+    coordinator.api.async_switch_electrical_power.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fan_turn_on_falls_back_to_power_without_fan_speed_capability() -> None:
+    device = EnkiDevice(
+        home_id="home-1",
+        device_id="simple_fan",
+        node_id="node-1",
+        device_name="Fan",
+        device_type="ceiling_fans",
+        is_enabled=True,
+        state="ACTIVE",
+        capabilities=[
+            "switch_electrical_power",
+            "check_electrical_power",
+            "change_airflow_mode",
+            "check_airflow_mode",
+        ],
+    )
+    coordinator = MagicMock()
+    coordinator.api.async_set_fan_speed = AsyncMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    entity = EnkiFanEntity(coordinator, device)
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1",
+        "node-1",
+        "ON",
+    )
+    coordinator.api.async_set_fan_speed.assert_not_called()

--- a/tests/unit/test_extract_apk_check.py
+++ b/tests/unit/test_extract_apk_check.py
@@ -5,11 +5,23 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from enki_bootstrap import bootstrap, load_module  # noqa: E402
 from extract_gateway_keys import check_against_repo, read_const_keys  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_enki_import_stubs() -> None:
+    """enki_bootstrap registers partial package stubs; drop them after each test."""
+    before = set(sys.modules)
+    yield
+    for key in list(sys.modules):
+        if (key == "enki" or key.startswith("enki.")) and key not in before:
+            del sys.modules[key]
 
 
 def _wired_repo_extract() -> dict[str, tuple[str | None, str]]:


### PR DESCRIPTION
## Résumé

Corrige le routage des commandes Enki lorsque l'état pollé est absent ou incomplet :

- **Ventilateur** : `turn_on` / `turn_off` utilisent `change-fan-speed` (airflow-prod) dès que `change_fan_speed` est dans le référentiel, au lieu de basculer sur `switch-electrical-power` (403 sur Inspire AD_TCFL_1).
- **Lumière kit ventilateur** : les endpoints multi-circuits passent toujours par `change-light-state` (lighting-prod), jamais power-prod.
- **État ON/OFF** : ne plus déduire l'état moteur/lumière depuis `electrical_power` quand `fan_speed` ou `power` lighting est inconnu.

Tests unitaires ajoutés (`test_api_routing.py`) + durcissement conftest / enki_bootstrap pour les tests entity.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs / tooling
- [ ] Refactor

## Checklist

- [x] `ruff check .` et `ruff format --check .` passent
- [x] `pytest tests/unit` passe
- [x] Traductions FR/EN mises à jour si l'UI change
- [x] Pas de secret / identifiant personnel dans le diff

## Issues liées

Fixes #27
Fixes #28
Fixes #29

## Test plan

- [ ] Mettre à jour l'intégration sur HA avec cette branche
- [ ] Allumer/éteindre le ventilateur **Ventilateur** (AD TCFL 1, Salon) — plus de HTTP 403
- [ ] Vérifier que la lumière kit répond toujours (ON/OFF, brightness)
- [ ] Si Siroco+ multi-lumières : tester chaque entité lumière