### PR TITLE
[CLOSED - do not merge] fix(fan): routage moteur Air Fort via power API quand airflow renvoie 403

### DIFF
--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -35,6 +35,11 @@ def _supports(capabilities: set[str], possible_values: dict[str, Any], *names: s
     return any(name in capabilities or name in possible_values for name in names)
 
 
+def _can_change(capabilities: set[str], possible_values: dict[str, Any], name: str) -> bool:
+    """True when a change_* / switch_* capability is advertised for writes."""
+    return name in capabilities or name in possible_values
+
+
 @dataclass(frozen=True, slots=True)
 class EnkiCapabilityProfile:
     """Read-only view of what a physical Enki node can do.
@@ -109,6 +114,16 @@ class EnkiCapabilityProfile:
             "change_fan_speed",
             "check_fan_speed",
         )
+
+    @property
+    def can_change_fan_speed(self) -> bool:
+        """True when the node accepts POST change-fan-speed (not read-only check)."""
+        return _can_change(self.capabilities, self.possible_values, "change_fan_speed")
+
+    @property
+    def controls_fan_speed_via_airflow(self) -> bool:
+        """True when speed writes should use api-enki-airflow-prod."""
+        return self.can_change_fan_speed and self.fan_max_speed is not None
 
     @property
     def supports_fan_rotation(self) -> bool:

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -18,7 +18,8 @@ from homeassistant.util.percentage import (
     percentage_to_ordered_list_item,
 )
 
-from .const import DOMAIN, FAN_SPEED_MAX
+from .const import DOMAIN, FAN_ENDPOINT, FAN_SPEED_MAX
+from .exceptions import EnkiConnectionError
 from .coordinator import EnkiCoordinator
 from .domain.models import EnkiDevice
 from .entity import EnkiEntity
@@ -57,12 +58,16 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         self._ordered_speeds = self._build_ordered_speeds(device)
 
     def _build_ordered_speeds(self, device: EnkiDevice) -> list[int]:
-        max_speed = device.profile.fan_max_speed or FAN_SPEED_MAX
+        max_speed = device.profile.fan_max_speed
+        if max_speed is None:
+            return list(range(1, FAN_SPEED_MAX + 1))
         return list(range(1, max_speed + 1))
 
     @property
     def supported_features(self) -> FanEntityFeature:
-        features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if self._controls_fan_speed_via_airflow():
+            features |= FanEntityFeature.SET_SPEED
         if self._supports_direction():
             features |= FanEntityFeature.DIRECTION
         if self._supports_preset_mode():
@@ -101,6 +106,11 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
             return speed > 0
         if self._device.profile.supports_fan_speed:
             return False
+        motor_endpoint = self._fan_motor_endpoint()
+        if motor_endpoint is not None:
+            endpoint_power = self._device.reported.endpoint_power(motor_endpoint)
+            if endpoint_power is not None:
+                return endpoint_power == "ON"
         return self._device.reported.electrical_power == "ON"
 
     @property
@@ -149,7 +159,7 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         if preset_mode is not None and self._supports_preset_mode():
             await self.async_set_preset_mode(preset_mode)
 
-        if self._device.profile.supports_fan_speed:
+        if self._controls_fan_speed_via_airflow():
             if percentage is not None and percentage > 0:
                 speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
             else:
@@ -158,44 +168,59 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
             return
 
         if percentage is None or percentage > 0:
-            await self.coordinator.api.async_switch_electrical_power(
-                self._device.home_id,
-                self._device.node_id,
-                "ON",
-            )
-            self.coordinator.update_cached_value(
-                self._device.node_id,
-                "electrical_power",
-                "ON",
-            )
+            await self._switch_fan_motor_power("ON")
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        if self._device.profile.supports_fan_speed:
+        if self._controls_fan_speed_via_airflow():
             await self._set_speed(0)
             return
 
-        await self.coordinator.api.async_switch_electrical_power(
-            self._device.home_id,
-            self._device.node_id,
-            "OFF",
-        )
-        self.coordinator.update_cached_value(
-            self._device.node_id,
-            "electrical_power",
-            "OFF",
-        )
+        await self._switch_fan_motor_power("OFF")
 
     async def async_set_percentage(self, percentage: int) -> None:
         if percentage == 0:
             await self.async_turn_off()
+            return
+        if not self._controls_fan_speed_via_airflow():
+            await self.async_turn_on(percentage=percentage)
             return
         await self._set_speed(percentage_to_ordered_list_item(self._ordered_speeds, percentage))
 
     async def _set_speed(self, speed: int) -> None:
         home_id = self._device.home_id
         node_id = self._device.node_id
-        await self.coordinator.api.async_set_fan_speed(home_id, node_id, speed)
+        try:
+            await self.coordinator.api.async_set_fan_speed(home_id, node_id, speed)
+        except EnkiConnectionError as err:
+            if err.status == 403 and self._device.profile.supports_electrical_power:
+                await self._switch_fan_motor_power("ON" if speed > 0 else "OFF")
+                self.coordinator.update_cached_value(node_id, "fan_speed", speed)
+                return
+            raise
         self.coordinator.update_cached_value(node_id, "fan_speed", speed)
+
+    def _controls_fan_speed_via_airflow(self) -> bool:
+        return self._device.profile.controls_fan_speed_via_airflow
+
+    def _fan_motor_endpoint(self) -> int | None:
+        endpoints = self._device.profile.power_switch_endpoints
+        if FAN_ENDPOINT in endpoints:
+            return FAN_ENDPOINT
+        return None
+
+    async def _switch_fan_motor_power(self, power: str) -> None:
+        node_id = self._device.node_id
+        endpoint = self._fan_motor_endpoint()
+        await self.coordinator.api.async_switch_electrical_power(
+            self._device.home_id,
+            node_id,
+            power,
+            endpoint=endpoint,
+        )
+        if endpoint is not None:
+            self.coordinator.update_endpoint_power(node_id, endpoint, power)
+            return
+        self.coordinator.update_cached_value(node_id, "electrical_power", power)
 
     def _supports_direction(self) -> bool:
         if self._device.reported.airflow_rotation_supported:

--- a/tests/unit/test_api_routing.py
+++ b/tests/unit/test_api_routing.py
@@ -27,6 +27,7 @@ def _ceiling_fan(**overrides) -> EnkiDevice:
             "switch_electrical_power",
             "check_electrical_power",
         ],
+        "possible_values": {"change_fan_speed": {"range": {"min": 0, "max": 6}}},
         "main_change_capability_id": "switch_electrical_power",
         "main_change_capability_endpoints": [1, 2, 3],
     }
@@ -126,6 +127,7 @@ async def test_fan_turn_on_falls_back_to_power_without_fan_speed_capability() ->
     coordinator.api.async_set_fan_speed = AsyncMock()
     coordinator.api.async_switch_electrical_power = AsyncMock()
     coordinator.update_cached_value = MagicMock()
+    coordinator.update_endpoint_power = MagicMock()
     entity = EnkiFanEntity(coordinator, device)
 
     await entity.async_turn_on()
@@ -134,5 +136,74 @@ async def test_fan_turn_on_falls_back_to_power_without_fan_speed_capability() ->
         "home-1",
         "node-1",
         "ON",
+        endpoint=None,
     )
     coordinator.api.async_set_fan_speed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fan_turn_on_uses_power_with_motor_endpoint_when_speed_is_read_only() -> None:
+    device = EnkiDevice(
+        home_id="home-1",
+        device_id="air_fort",
+        node_id="node-air-fort",
+        device_name="Ventilateur",
+        device_type="ceiling_fans",
+        is_enabled=True,
+        state="ACTIVE",
+        capabilities=[
+            "check_fan_speed",
+            "switch_electrical_power",
+            "check_electrical_power",
+            "change_light_state",
+            "check_light_state",
+        ],
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[1, 2],
+        possible_values={"check_fan_speed": {"range": {"min": 0, "max": 6}}},
+    )
+    coordinator = MagicMock()
+    coordinator.api.async_set_fan_speed = AsyncMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    coordinator.update_endpoint_power = MagicMock()
+    entity = EnkiFanEntity(coordinator, device)
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1",
+        "node-air-fort",
+        "ON",
+        endpoint=1,
+    )
+    coordinator.api.async_set_fan_speed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fan_set_speed_falls_back_to_power_on_airflow_403() -> None:
+    from enki.exceptions import EnkiConnectionError
+
+    coordinator = MagicMock()
+    coordinator.api.async_set_fan_speed = AsyncMock(
+        side_effect=EnkiConnectionError("forbidden", status=403, service="airflow"),
+    )
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    coordinator.update_endpoint_power = MagicMock()
+    entity = EnkiFanEntity(
+        coordinator,
+        _ceiling_fan(
+            possible_values={"change_fan_speed": {"range": {"min": 0, "max": 6}}},
+        ),
+    )
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once()
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1",
+        "node-fan",
+        "ON",
+        endpoint=1,
+    )

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -87,3 +87,19 @@ def test_fan_max_speed_from_metadata() -> None:
         possible_values={"change_fan_speed": {"range": {"min": 0, "max": 5}}},
     )
     assert fan_max_speed(device) == 5
+
+
+def test_controls_fan_speed_via_airflow_requires_change_capability_and_range() -> None:
+    read_only = _device(
+        capabilities=["check_fan_speed", "switch_electrical_power"],
+        possible_values={"check_fan_speed": {"range": {"min": 0, "max": 6}}},
+    )
+    assert read_only.profile.can_change_fan_speed is False
+    assert read_only.profile.controls_fan_speed_via_airflow is False
+
+    writable = _device(
+        capabilities=["change_fan_speed", "check_fan_speed"],
+        possible_values={"change_fan_speed": {"range": {"min": 0, "max": 6}}},
+    )
+    assert writable.profile.can_change_fan_speed is True
+    assert writable.profile.controls_fan_speed_via_airflow is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**PR annulée** — fermeture demandée par l'auteur (correctif à appliquer localement, sans merge).

## Résumé

Corrige l’erreur **HTTP 403** sur `fan.turn_on` pour les ventilateurs type **Air Fort 1** qui n’acceptent pas `POST …/change-fan-speed`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2cf0-203a-7f0f-b040-9d904835dc90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2cf0-203a-7f0f-b040-9d904835dc90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

