### PR TITLE
fix: ventilateurs Ae Toit via power-prod (v1.6.4)

### DIFF
--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -111,6 +111,13 @@ class EnkiCapabilityProfile:
         )
 
     @property
+    def supports_fan_speed_control(self) -> bool:
+        """Writable fan speed (change_fan_speed + range in referentiel metadata)."""
+        if not _supports(self.capabilities, self.possible_values, "change_fan_speed"):
+            return False
+        return self.fan_max_speed is not None
+
+    @property
     def supports_fan_rotation(self) -> bool:
         return _supports(
             self.capabilities,
@@ -460,6 +467,26 @@ class EnkiCapabilityProfile:
             return []
         return [endpoint for endpoint in self.power_switch_endpoints if endpoint != FAN_ENDPOINT]
 
+    @property
+    def fan_motor_endpoints(self) -> list[int]:
+        """Power-prod endpoints that are not light kit circuits."""
+        if self.main_change_capability_id != "switch_electrical_power":
+            return []
+        light_endpoints = set(self.fan_light_endpoints)
+        return [
+            endpoint
+            for endpoint in self.power_switch_endpoints
+            if endpoint not in light_endpoints
+        ]
+
+    @property
+    def fan_motor_endpoint(self) -> int | None:
+        """Single motor endpoint when unambiguous, else global power API."""
+        motor_endpoints = self.fan_motor_endpoints
+        if len(motor_endpoints) == 1:
+            return motor_endpoints[0]
+        return None
+
 
 # --- Backward-compatible module functions (used by tests and legacy imports) ---
 
@@ -479,6 +506,15 @@ def supports_electrical_power(capabilities: set[str], possible_values: dict[str,
 
 def supports_fan_speed(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
     return _supports(capabilities, possible_values, "change_fan_speed", "check_fan_speed")
+
+
+def supports_fan_speed_control(capabilities: set[str], possible_values: dict[str, Any]) -> bool:
+    profile = EnkiCapabilityProfile(
+        device_type=DEVICE_TYPE_FANS,
+        capabilities=frozenset(capabilities),
+        possible_values=possible_values,
+    )
+    return profile.supports_fan_speed_control
 
 
 def supports_fan_rotation(capabilities: set[str], possible_values: dict[str, Any]) -> bool:

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -474,9 +474,7 @@ class EnkiCapabilityProfile:
             return []
         light_endpoints = set(self.fan_light_endpoints)
         return [
-            endpoint
-            for endpoint in self.power_switch_endpoints
-            if endpoint not in light_endpoints
+            endpoint for endpoint in self.power_switch_endpoints if endpoint not in light_endpoints
         ]
 
     @property

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
 
 
 class EnkiFanEntity(EnkiEntity, FanEntity):
-    """Ceiling fan motor controlled via api-enki-airflow-prod."""
+    """Ceiling fan motor (airflow-prod or power-prod depending on referentiel)."""
 
     _attr_translation_key = "ceiling_fan"
 
@@ -62,7 +62,9 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
 
     @property
     def supported_features(self) -> FanEntityFeature:
-        features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+        if self._device.profile.supports_fan_speed_control:
+            features |= FanEntityFeature.SET_SPEED
         if self._supports_direction():
             features |= FanEntityFeature.DIRECTION
         if self._supports_preset_mode():
@@ -96,15 +98,26 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
 
     @property
     def is_on(self) -> bool:
-        speed = self._device.reported.fan_speed
+        profile = self._device.profile
+        reported = self._device.reported
+        speed = reported.fan_speed
         if speed is not None:
             return speed > 0
-        if self._device.profile.supports_fan_speed:
+        if profile.supports_fan_speed_control:
             return False
-        return self._device.reported.electrical_power == "ON"
+        if profile.supports_electrical_power:
+            if (motor_endpoint := profile.fan_motor_endpoint) is not None:
+                power = reported.endpoint_power(motor_endpoint)
+                if power is not None:
+                    return power == "ON"
+            if reported.electrical_power is not None:
+                return reported.electrical_power == "ON"
+        return False
 
     @property
     def percentage(self) -> int | None:
+        if not self._device.profile.supports_fan_speed_control:
+            return None
         speed = self._device.reported.fan_speed
         if speed is None:
             return None
@@ -149,7 +162,7 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         if preset_mode is not None and self._supports_preset_mode():
             await self.async_set_preset_mode(preset_mode)
 
-        if self._device.profile.supports_fan_speed:
+        if self._device.profile.supports_fan_speed_control:
             if percentage is not None and percentage > 0:
                 speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
             else:
@@ -158,34 +171,17 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
             return
 
         if percentage is None or percentage > 0:
-            await self.coordinator.api.async_switch_electrical_power(
-                self._device.home_id,
-                self._device.node_id,
-                "ON",
-            )
-            self.coordinator.update_cached_value(
-                self._device.node_id,
-                "electrical_power",
-                "ON",
-            )
+            await self._set_motor_power("ON")
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        if self._device.profile.supports_fan_speed:
+        if self._device.profile.supports_fan_speed_control:
             await self._set_speed(0)
             return
-
-        await self.coordinator.api.async_switch_electrical_power(
-            self._device.home_id,
-            self._device.node_id,
-            "OFF",
-        )
-        self.coordinator.update_cached_value(
-            self._device.node_id,
-            "electrical_power",
-            "OFF",
-        )
+        await self._set_motor_power("OFF")
 
     async def async_set_percentage(self, percentage: int) -> None:
+        if not self._device.profile.supports_fan_speed_control:
+            return
         if percentage == 0:
             await self.async_turn_off()
             return
@@ -196,6 +192,22 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         node_id = self._device.node_id
         await self.coordinator.api.async_set_fan_speed(home_id, node_id, speed)
         self.coordinator.update_cached_value(node_id, "fan_speed", speed)
+
+    async def _set_motor_power(self, power: str) -> None:
+        profile = self._device.profile
+        node_id = self._device.node_id
+        endpoint = profile.fan_motor_endpoint
+        await self.coordinator.api.async_switch_electrical_power(
+            self._device.home_id,
+            node_id,
+            power,
+            endpoint=endpoint,
+        )
+        if endpoint is not None:
+            self.coordinator.update_endpoint_power(node_id, endpoint, power)
+            return
+        self.coordinator.update_cached_value(node_id, "electrical_power", power)
+        self.coordinator.update_cached_value(node_id, "power", power)
 
     def _supports_direction(self) -> bool:
         if self._device.reported.airflow_rotation_supported:

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.3"
+  "version": "1.6.4"
 }

--- a/tests/unit/test_api_routing.py
+++ b/tests/unit/test_api_routing.py
@@ -29,6 +29,9 @@ def _ceiling_fan(**overrides) -> EnkiDevice:
         ],
         "main_change_capability_id": "switch_electrical_power",
         "main_change_capability_endpoints": [1, 2, 3],
+        "possible_values": {
+            "change_fan_speed": {"range": {"min": 0, "max": 6}},
+        },
     }
     defaults.update(overrides)
     return EnkiDevice(**defaults)
@@ -106,6 +109,45 @@ async def test_fan_turn_off_uses_airflow_when_speed_state_missing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fan_turn_on_uses_power_when_only_check_fan_speed() -> None:
+    """Ae Toit-style fans: check_fan_speed without writable range → power-prod."""
+    device = EnkiDevice(
+        home_id="home-1",
+        device_id="AE_TOIT_1",
+        node_id="6a1468f4045591224e5f1686",
+        device_name="Ventilateur",
+        device_type="ceiling_fans",
+        is_enabled=True,
+        state="ACTIVE",
+        capabilities=[
+            "check_fan_speed",
+            "switch_electrical_power",
+            "check_electrical_power",
+            "change_light_state",
+            "check_light_state",
+        ],
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[1, 2],
+    )
+    coordinator = MagicMock()
+    coordinator.api.async_set_fan_speed = AsyncMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    coordinator.update_endpoint_power = MagicMock()
+    entity = EnkiFanEntity(coordinator, device)
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1",
+        "6a1468f4045591224e5f1686",
+        "ON",
+        endpoint=1,
+    )
+    coordinator.api.async_set_fan_speed.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_fan_turn_on_falls_back_to_power_without_fan_speed_capability() -> None:
     device = EnkiDevice(
         home_id="home-1",
@@ -134,5 +176,6 @@ async def test_fan_turn_on_falls_back_to_power_without_fan_speed_capability() ->
         "home-1",
         "node-1",
         "ON",
+        endpoint=None,
     )
     coordinator.api.async_set_fan_speed.assert_not_called()

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -87,3 +87,18 @@ def test_fan_max_speed_from_metadata() -> None:
         possible_values={"change_fan_speed": {"range": {"min": 0, "max": 5}}},
     )
     assert fan_max_speed(device) == 5
+
+
+def test_supports_fan_speed_control_requires_change_and_range() -> None:
+    with_change = _device(
+        capabilities=["change_fan_speed", "check_fan_speed"],
+        possible_values={"change_fan_speed": {"range": {"min": 0, "max": 6}}},
+    )
+    check_only = _device(
+        capabilities=["check_fan_speed", "switch_electrical_power"],
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[1, 2],
+    )
+    assert with_change.profile.supports_fan_speed_control is True
+    assert check_only.profile.supports_fan_speed_control is False
+    assert check_only.profile.fan_motor_endpoint == 1


### PR DESCRIPTION
## Résumé

Distinction entre ventilateurs **multi-vitesses** (Inspire AD_TCFL_1 → `change-fan-speed`) et ventilateurs **ON/OFF** (Ae Toit 1 → `switch-electrical-power` sur l'endpoint moteur).

Le référentiel peut exposer `check_fan_speed` sans plage `change_fan_speed` writable — v1.6.3 routait à tort ces devices vers airflow (HTTP 403).

## Type

- [x] Bug fix

## Checklist

- [x] `ruff check .` et `ruff format --check .` passent
- [x] `pytest tests/unit` passe (126 tests)

## Issues liées

Fixes #38

## Test plan

- [ ] Ae Toit 1 (Chambre) : allumer/éteindre le ventilateur — plus de 403 sur airflow
- [ ] AD TCFL_1 (Salon) : vitesses 1–6 via airflow toujours OK