### PR TITLE
fix: ventilateur Ae Toit aligné sur CyrilP/hass-enki-component (v1.6.5)

### DIFF
--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -112,10 +112,8 @@ class EnkiCapabilityProfile:
 
     @property
     def supports_fan_speed_control(self) -> bool:
-        """Writable fan speed (change_fan_speed + range in referentiel metadata)."""
-        if not _supports(self.capabilities, self.possible_values, "change_fan_speed"):
-            return False
-        return self.fan_max_speed is not None
+        """True when referentiel defines a fan speed range (CyrilP/hass-enki-component)."""
+        return self.supports_fan_speed and self.fan_max_speed is not None
 
     @property
     def supports_fan_rotation(self) -> bool:

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -106,10 +106,8 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         if profile.supports_fan_speed_control:
             return False
         if profile.supports_electrical_power:
-            if (motor_endpoint := profile.fan_motor_endpoint) is not None:
-                power = reported.endpoint_power(motor_endpoint)
-                if power is not None:
-                    return power == "ON"
+            if reported.global_power is not None:
+                return reported.global_power == "ON"
             if reported.electrical_power is not None:
                 return reported.electrical_power == "ON"
         return False
@@ -194,18 +192,13 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         self.coordinator.update_cached_value(node_id, "fan_speed", speed)
 
     async def _set_motor_power(self, power: str) -> None:
-        profile = self._device.profile
+        """ON/OFF fans without speed range — global power API (CyrilP/hass-enki-component)."""
         node_id = self._device.node_id
-        endpoint = profile.fan_motor_endpoint
         await self.coordinator.api.async_switch_electrical_power(
             self._device.home_id,
             node_id,
             power,
-            endpoint=endpoint,
         )
-        if endpoint is not None:
-            self.coordinator.update_endpoint_power(node_id, endpoint, power)
-            return
         self.coordinator.update_cached_value(node_id, "electrical_power", power)
         self.coordinator.update_cached_value(node_id, "power", power)
 

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.4"
+  "version": "1.6.5"
 }

--- a/tests/unit/test_api_routing.py
+++ b/tests/unit/test_api_routing.py
@@ -133,7 +133,6 @@ async def test_fan_turn_on_uses_power_when_only_check_fan_speed() -> None:
     coordinator.api.async_set_fan_speed = AsyncMock()
     coordinator.api.async_switch_electrical_power = AsyncMock()
     coordinator.update_cached_value = MagicMock()
-    coordinator.update_endpoint_power = MagicMock()
     entity = EnkiFanEntity(coordinator, device)
 
     await entity.async_turn_on()
@@ -142,7 +141,6 @@ async def test_fan_turn_on_uses_power_when_only_check_fan_speed() -> None:
         "home-1",
         "6a1468f4045591224e5f1686",
         "ON",
-        endpoint=1,
     )
     coordinator.api.async_set_fan_speed.assert_not_called()
 
@@ -176,6 +174,5 @@ async def test_fan_turn_on_falls_back_to_power_without_fan_speed_capability() ->
         "home-1",
         "node-1",
         "ON",
-        endpoint=None,
     )
     coordinator.api.async_set_fan_speed.assert_not_called()

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -101,4 +101,3 @@ def test_supports_fan_speed_control_requires_change_and_range() -> None:
     )
     assert with_change.profile.supports_fan_speed_control is True
     assert check_only.profile.supports_fan_speed_control is False
-    assert check_only.profile.fan_motor_endpoint == 1


### PR DESCRIPTION
## Résumé

Aligne le routage ventilateur ON/OFF sur [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) :

- **Vitesses** : airflow `change-fan-speed` seulement si le référentiel définit une plage min/max (`fan_max_speed`)
- **ON/OFF binaire** (Ae Toit 1) : `switch-electrical-power` **global**, sans `?endpoints=` (v1.6.4 passait `endpoints=1` → 403)

Fixes #38

## Test plan

- [ ] Ae Toit 1 Chambre : turn_on/off OK
- [ ] AD TCFL_1 Salon : vitesses airflow inchangées