### PR TITLE
feat: enriched telemetry and English GitHub docs (v1.6.6)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-## Résumé
+## Summary
 
-<!-- Ce qui change et pourquoi -->
+<!-- What changed and why -->
 
 ## Type
 
@@ -11,15 +11,15 @@
 
 ## Checklist
 
-- [ ] `ruff check .` et `ruff format --check .` passent
-- [ ] `pytest tests/unit` passe
-- [ ] Traductions FR/EN mises à jour si l’UI change
-- [ ] Pas de secret / identifiant personnel dans le diff
+- [ ] `ruff check .` and `ruff format --check .` pass
+- [ ] `pytest tests/unit` passes
+- [ ] FR/EN translations updated if the UI changed
+- [ ] No secrets or personal identifiers in the diff
 
-## Issues liées
+## Related issues
 
 Fixes #
 
 ## Test plan
 
-<!-- Comment vérifier — matériel, étapes HA, etc. -->
+<!-- How to verify — hardware, HA steps, etc. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,37 +1,37 @@
-# Code de conduite
+# Code of Conduct
 
-## Notre engagement
+## Our pledge
 
-Nous nous engageons à faire de la participation à ce projet une expérience sans harcèlement pour tous, quel que soit l’âge, le corps, le handicap, l’origine ethnique, l’identité et l’expression de genre, le niveau d’expérience, la nationalité, l’apparence, la race, la religion ou l’identité et l’orientation sexuelles.
+We pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
-## Nos standards
+## Our standards
 
-Comportements qui contribuent à un environnement positif :
+Examples of behavior that contributes to a positive environment:
 
-- Faire preuve d’empathie et de bienveillance
-- Respecter les opinions et expériences différentes
-- Accepter les critiques constructives
-- Se concentrer sur ce qui est meilleur pour la communauté
+- Showing empathy and kindness toward others
+- Respecting differing opinions and experiences
+- Accepting constructive criticism gracefully
+- Focusing on what is best for the community
 
-Comportements inacceptables :
+Examples of unacceptable behavior:
 
-- Langage ou imagerie sexualisés, attentions ou avances non désirées
-- Trolling, insultes, attaques personnelles ou politiques
-- Harcèlement public ou privé
-- Publication d’informations privées d’autrui sans permission
+- Sexualized language or imagery, and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without permission
 
-## Responsabilités
+## Enforcement responsibilities
 
-Les mainteneurs appliquent les standards et peuvent supprimer, modifier ou rejeter contributions, issues et commentaires ne respectant pas ce code.
+Maintainers enforce these standards and may remove, edit, or reject contributions, issues, and comments that do not align with this code.
 
-## Portée
+## Scope
 
-Ce code s’applique dans l’espace du projet et lorsqu’une personne représente le projet en public.
+This code applies within project spaces and when an individual represents the project in public.
 
-## Application
+## Enforcement
 
-Signaler un abus à **cyrilcolinet** via [GitHub](https://github.com/cyrilcolinet) ou les issues privées du dépôt. Toute plainte sera examinée et traitée de façon proportionnée.
+Report abuse to **cyrilcolinet** via [GitHub](https://github.com/cyrilcolinet) or private repository issues. All complaints will be reviewed and handled proportionately.
 
 ## Attribution
 
-Adapté du [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
-# Contribuer
+# Contributing
 
-Merci de contribuer. Pour l’installation locale, les tests et la CI, voir [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+Thanks for contributing. For local setup, tests, and CI, see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
-## Avant de coder
+## Before you code
 
-1. Vérifier les [issues ouvertes](https://github.com/cyrilcolinet/enki-integration-hass/issues)
-2. Nouvel appareil Enki : **feature request** avec le résultat de `scripts/discover_devices.py` (sans mot de passe)
-3. Contexte API : [docs/API.md](docs/API.md)
-4. Clés gateway (APK) : [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) (`extract_gateway_keys.py`) · validation volets : [docs/BETA_VOLETS_KEY.md](docs/BETA_VOLETS_KEY.md)
+1. Check [open issues](https://github.com/cyrilcolinet/enki-integration-hass/issues)
+2. New Enki device: open a **feature request** with output from `scripts/discover_devices.py` (no password)
+3. API context: [docs/API.md](docs/API.md)
+4. Gateway keys (APK): [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) (`extract_gateway_keys.py`) · cover validation: [docs/BETA_VOLETS_KEY.md](docs/BETA_VOLETS_KEY.md)
 
-## Qualité attendue
+## Quality bar
 
-Avant toute PR :
+Before any PR:
 
 ```bash
 ruff check .
@@ -19,34 +19,34 @@ ruff format .
 pytest tests/unit -v
 ```
 
-La CI fait la même chose + Hassfest + HACS.
+CI runs the same checks plus Hassfest and HACS.
 
-## Organisation du code
+## Code layout
 
-- **`api/`** — auth, transport HTTP, client REST Enki
-- **`domain/`** — modèles et capacités (aucun import Home Assistant)
-- **`lib/`** — conversion et parsing purs, testables sans HA
-- **`platforms/`** — logique partagée des plateformes (pas les fichiers loader HA)
-- **`telemetry/`** — opt-in profils appareils et nudge legacy
-- **Racine** — loaders plateforme HA (`fan.py`, `light.py`, `sensor.py`, `binary_sensor.py`, `climate.py`, `cover.py`, `number.py`, `select.py`, `switch.py`) + `config_flow.py` — liste complète dans `__init__.py` → `PLATFORMS`
+- **`api/`** — auth, HTTP transport, Enki REST client
+- **`domain/`** — models and capabilities (no Home Assistant imports)
+- **`lib/`** — pure conversion and parsing, testable without HA
+- **`platforms/`** — shared platform logic (not HA loader files)
+- **`telemetry/`** — opt-in device profiles and legacy nudge
+- **Root** — HA platform loaders (`fan.py`, `light.py`, `sensor.py`, `binary_sensor.py`, `climate.py`, `cover.py`, `number.py`, `select.py`, `switch.py`) + `config_flow.py` — full list in `__init__.py` → `PLATFORMS`
 
-Imports publics via les `__init__.py` de chaque package (`from enki.api import EnkiAPI`, etc.).
+Public imports via each package `__init__.py` (`from enki.api import EnkiAPI`, etc.).
 
-## Langue
+## Language
 
-- **Code Python** (commentaires, docstrings, noms de symboles) : **anglais**
-- **Documentation Markdown** (`README.md`, `docs/`, `CONTRIBUTING.md`, …) : **français**
-- **Textes utilisateur Home Assistant** (notifications, config flow, traductions `strings.json`) : **français** (fichiers de traduction HA)
+- **Python code** (comments, docstrings, symbol names): **English**
+- **Markdown documentation** (`README.md`, `docs/`, `CONTRIBUTING.md`, …): **English**
+- **Home Assistant UI strings** (notifications, config flow, `strings.json`, translations): **French and English** via HA translation files (`translations/fr.json`, `translations/en.json`)
 
 ## Pull requests
 
-- Une PR = un sujet
-- Commit impératif (`fix:`, `feat:`, `docs:`)
-- Tests unitaires pour la logique modifiée
-- Pas de credentials dans le code ou les commits
+- One PR = one topic
+- Conventional commits (`fix:`, `feat:`, `docs:`)
+- Unit tests for changed logic
+- No credentials in code or commits
 
-Modèle : [.github/pull_request_template.md](.github/pull_request_template.md)
+Template: [.github/pull_request_template.md](.github/pull_request_template.md)
 
-## Code de conduite
+## Code of conduct
 
 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img src="https://raw.githubusercontent.com/cyrilcolinet/enki-integration-hass/main/custom_components/enki/brand/icon.png" alt="Enki" width="128" height="128">
 </p>
 
-<h1 align="center">Enki pour Home Assistant</h1>
+<h1 align="center">Enki for Home Assistant</h1>
 
 <p align="center">
-  <strong>Intégration cloud pour l’écosystème Enki / Leroy Merlin</strong><br>
-  Ventilateurs, éclairage, prises, capteurs, volets, chauffage, scénarios et plus — depuis Home Assistant, avec les mêmes identifiants que l’app mobile.
+  <strong>Cloud integration for the Enki / Leroy Merlin smart home ecosystem</strong><br>
+  Fans, lights, switches, sensors, covers, heating, scenarios, and more — from Home Assistant, using the same credentials as the mobile app.
 </p>
 
 <p align="center">
@@ -24,48 +24,48 @@
 
 <p align="center">
   <a href="#installation">Installation</a> ·
-  <a href="docs/SUPPORTED_DEVICES.md">Appareils</a> ·
-  <a href="docs/ROADMAP.md">Feuille de route</a> ·
+  <a href="docs/SUPPORTED_DEVICES.md">Devices</a> ·
+  <a href="docs/ROADMAP.md">Roadmap</a> ·
   <a href="https://github.com/cyrilcolinet/enki-integration-hass/releases">Releases</a> ·
   <a href="https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=bug.yml">Bug</a> ·
-  <a href="CONTRIBUTING.md">Contribuer</a>
+  <a href="CONTRIBUTING.md">Contributing</a>
 </p>
 
 ---
 
-## Pourquoi cette intégration ?
+## Why this integration?
 
-L’app **Enki** pilote des centaines de références (Lexman, Equation, Inspire, Edisio, Evology, Noirot, Envertech, …) via le **cloud Leroy Merlin**. Cette intégration expose ces appareils dans Home Assistant en s’appuyant sur les **capabilities API** du référentiel Enki — comme l’app mobile — et non sur une liste figée de modèles.
+The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisio, Evology, Noirot, Envertech, …) through the **Leroy Merlin cloud**. This integration exposes those devices in Home Assistant using Enki **API capabilities** from the referentiel — like the mobile app — rather than a fixed model list.
 
 | | |
 |---|---|
-| **Connexion** | E-mail + mot de passe Enki (OAuth Keycloak) |
-| **Prérequis** | Box Enki opérationnelle, appareils visibles dans l’app |
-| **Architecture** | Hub cloud (`iot_class: cloud_polling`), micro-services Enki |
-| **Détection** | Capability-first : nouveaux appareils compatibles API sans mise à jour forcée |
+| **Connection** | Enki email + password (OAuth Keycloak) |
+| **Requirements** | Working Enki hub, devices visible in the app |
+| **Architecture** | Cloud hub (`iot_class: cloud_polling`), Enki micro-services |
+| **Detection** | Capability-first: new API-compatible devices without forced updates |
 
-> **Hors périmètre :** Zigbee tiers appairé sur la box (Sonoff, Tuya, Aqara, …) → [Zigbee2MQTT](https://www.zigbee2mqtt.io/) ou ZHA. Seules les marques Enki / Leroy Merlin listées dans [`lib/enki_scope.py`](custom_components/enki/lib/enki_scope.py) sont importées.
+> **Out of scope:** third-party Zigbee paired on the hub (Sonoff, Tuya, Aqara, …) → use [Zigbee2MQTT](https://www.zigbee2mqtt.io/) or ZHA. Only Enki / Leroy Merlin brands listed in [`lib/enki_scope.py`](custom_components/enki/lib/enki_scope.py) are imported.
 
-## Fonctionnalités
+## Features
 
-| Domaine | Exemples de matériel | Entités HA |
+| Domain | Example hardware | HA entities |
 |---------|----------------------|------------|
-| Ventilation | Inspire Siroco+, Cadix, Radix, … | `fan`, `light` (kit LED) |
-| Éclairage | Eglo, Lexman, dimmables, RGB | `light` |
-| Prises & relais | Edisio, Equation ON/OFF | `light` / ON-OFF power |
-| Solaire | Envertech-Lexman | `sensor` (production W) |
-| Capteurs | Lexman, Sedea, Sonoff (Enki) | `binary_sensor`, `sensor` |
-| Sirène | Lexman | `switch` |
-| **Beta** Volets | Evology, Nodon, … | `cover` |
-| **Beta** Chauffage | Noirot, fil pilote Equation | `climate`, `select` |
-| **Beta** Fuite d’eau | Lexman | `binary_sensor`, `sensor` |
-| **Beta** Scénarios | Scénarios cloud Enki | `button` |
+| Ventilation | Inspire Siroco+, Cadix, Radix, … | `fan`, `light` (LED kit) |
+| Lighting | Eglo, Lexman, dimmables, RGB | `light` |
+| Outlets & relays | Edisio, Equation ON/OFF | `light` / ON-OFF power |
+| Solar | Envertech-Lexman | `sensor` (production W) |
+| Sensors | Lexman, Sedea, Sonoff (Enki) | `binary_sensor`, `sensor` |
+| Siren | Lexman | `switch` |
+| **Beta** Covers | Evology, Nodon, … | `cover` |
+| **Beta** Heating | Noirot, Equation pilot wire | `climate`, `select` |
+| **Beta** Water leak | Lexman | `binary_sensor`, `sensor` |
+| **Beta** Scenarios | Enki cloud scenarios | `button` |
 
-Détail par appareil : [docs/SUPPORTED_DEVICES.md](docs/SUPPORTED_DEVICES.md) · Historique : [docs/ROADMAP.md](docs/ROADMAP.md)
+Per-device detail: [docs/SUPPORTED_DEVICES.md](docs/SUPPORTED_DEVICES.md) · History: [docs/ROADMAP.md](docs/ROADMAP.md)
 
 ## Installation
 
-### HACS (recommandé)
+### HACS (recommended)
 
 <p align="center">
   <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=cyrilcolinet&repository=enki-integration-hass&category=integration">
@@ -73,59 +73,59 @@ Détail par appareil : [docs/SUPPORTED_DEVICES.md](docs/SUPPORTED_DEVICES.md) ·
   </a>
 </p>
 
-1. **HACS** → **Intégrations** → **⋮** → **Dépôts personnalisés**
-2. URL : `https://github.com/cyrilcolinet/enki-integration-hass` — catégorie **Integration**
-3. **Explorer et télécharger des dépôts** → **Enki** → **Télécharger**
-4. **Redémarrer** Home Assistant
+1. **HACS** → **Integrations** → **⋮** → **Custom repositories**
+2. URL: `https://github.com/cyrilcolinet/enki-integration-hass` — category **Integration**
+3. **Explore & download repositories** → **Enki** → **Download**
+4. **Restart** Home Assistant
 
-Store HACS global (objectif) : [docs/HACS.md](docs/HACS.md#store-hacs-par-défaut)
+Default HACS store (goal): [docs/HACS.md](docs/HACS.md#default-hacs-store)
 
-### Ajouter l’intégration
+### Add the integration
 
-1. **Paramètres** → **Appareils et services** → **Ajouter une intégration**
-2. Rechercher **Enki** — saisir e-mail et mot de passe Enki
-3. Les entités apparaissent après le premier poll (~30 s)
+1. **Settings** → **Devices & services** → **Add integration**
+2. Search for **Enki** — enter Enki email and password
+3. Entities appear after the first poll (~30 s)
 
-### Installation manuelle
+### Manual install
 
-Téléchargez une [release](https://github.com/cyrilcolinet/enki-integration-hass/releases) ou clonez ce dépôt, copiez `custom_components/enki/` dans `config/custom_components/`, redémarrez HA.
+Download a [release](https://github.com/cyrilcolinet/enki-integration-hass/releases) or clone this repo, copy `custom_components/enki/` into `config/custom_components/`, restart HA.
 
 ## Configuration
 
-**Paramètres** → **Appareils et services** → **Enki** → **Configurer**
+**Settings** → **Devices & services** → **Enki** → **Configure**
 
 | Option | Description |
 |--------|-------------|
-| Intervalle de rafraîchissement | Fréquence de poll cloud (défaut 30 s) |
-| Télémétrie (opt-in) | Notification + lien GitHub pré-rempli pour appareils inconnus ; rien n’est envoyé sans clic |
-| Reconfigurer | Changer e-mail / mot de passe |
+| Refresh interval | Cloud poll frequency (default 30 s) |
+| Telemetry (opt-in) | Notification + pre-filled GitHub link for unknown devices; nothing is sent without a click |
+| Reconfigure | Change email / password |
 
-## Dépannage
+## Troubleshooting
 
-| Symptôme | Piste |
+| Symptom | Hint |
 |----------|-------|
-| Identifiants invalides | Vérifier e-mail/mot de passe sur l’app Enki ; reconfigurer l’intégration |
-| HTTP 403 | Clé gateway obsolète après MAJ app Enki → [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) |
-| Aucun appareil | Appareil actif dans l’app, même foyer |
-| Bug | [Issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=bug.yml) + logs `enki` |
+| Invalid credentials | Verify email/password in the Enki app; reconfigure the integration |
+| HTTP 403 | Outdated gateway key after Enki app update → [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) |
+| No devices | Device active in the app, same home |
+| Bug | [Issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=bug.yml) + `enki` logs |
 
-## Ressources
+## Resources
 
 | | |
 |---|---|
-| 📋 | [Appareils supportés](docs/SUPPORTED_DEVICES.md) |
-| 🗺️ | [Feuille de route](docs/ROADMAP.md) |
-| 🛠️ | [Développement & clés APK](docs/DEVELOPMENT.md) |
-| 📡 | [Télémétrie opt-in](docs/TELEMETRY.md) |
-| 🏠 | [Support Enki](https://support.enki-home.com/) |
-| 🔗 | [Projet d’origine — CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) |
+| 📋 | [Supported devices](docs/SUPPORTED_DEVICES.md) |
+| 🗺️ | [Roadmap](docs/ROADMAP.md) |
+| 🛠️ | [Development & APK keys](docs/DEVELOPMENT.md) |
+| 📡 | [Opt-in telemetry](docs/TELEMETRY.md) |
+| 🏠 | [Enki support](https://support.enki-home.com/) |
+| 🔗 | [Original project — CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) |
 
-## Crédits & licence
+## Credits & license
 
-Intégration **communautaire**, non affiliée à Leroy Merlin, Adeo ou Enki. API cloud non officielle, susceptible d’évoluer.
+**Community** integration, not affiliated with Leroy Merlin, Adeo, or Enki. Unofficial cloud API, subject to change.
 
-- Fork de [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
-- Capteurs / sirènes : inspiration [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki)
-- Icône : [MarioCadenas/hass-enki-component](https://github.com/MarioCadenas/hass-enki-component)
+- Fork of [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
+- Sensors / siren: inspired by [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki)
+- Icon: [MarioCadenas/hass-enki-component](https://github.com/MarioCadenas/hass-enki-component)
 
-Licence [MIT](LICENSE)
+[MIT](LICENSE) license

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,23 +1,23 @@
-# Sécurité
+# Security
 
-## Signaler une vulnérabilité
+## Reporting a vulnerability
 
-**Ne pas** ouvrir d’issue publique pour un problème de sécurité.
+**Do not** open a public issue for a security problem.
 
-1. Ouvrir un [GitHub Security Advisory](https://github.com/cyrilcolinet/enki-integration-hass/security/advisories/new) (recommandé)
-2. Ou contacter le mainteneur via GitHub en privé
+1. Open a [GitHub Security Advisory](https://github.com/cyrilcolinet/enki-integration-hass/security/advisories/new) (recommended)
+2. Or contact the maintainer privately on GitHub
 
-Délai de réponse visé : 7 jours ouvrés.
+Target response time: 7 business days.
 
-## Périmètre
+## Scope
 
-- Intégration `custom_components/enki/`
-- Scripts et workflows du dépôt
+- Integration `custom_components/enki/`
+- Repository scripts and workflows
 
-Hors périmètre : l’API cloud Enki elle-même, l’application mobile, la box Enki.
+Out of scope: the Enki cloud API itself, the mobile app, the Enki hub.
 
-## Bonnes pratiques utilisateur
+## User best practices
 
-- Ne pas committer `.env` ou identifiants Enki
-- Utiliser un compte Enki dédié aux tests si possible
-- L’intégration stocke le mot de passe dans les entrées de configuration HA — protégez votre instance
+- Do not commit `.env` or Enki credentials
+- Use a dedicated Enki test account when possible
+- The integration stores the password in HA config entries — protect your instance

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -10,7 +10,12 @@ import aiohttp
 from ..const import DEVICE_TYPE_LIGHTS, LOGGER
 from ..domain.capabilities import EnkiCapabilityProfile
 from ..domain.models import EnkiDevice, EnkiDiscoveryRecord, EnkiScenario
-from ..domain.profile import build_discovery_record, integration_supports_device
+from ..domain.profile import (
+    build_discovery_record,
+    integration_supports_device,
+    profile_fingerprint,
+    profile_to_export_dict,
+)
 from ..exceptions import EnkiApiNotFoundError, EnkiConnectionError
 from ..lib.bff import parse_bff_power
 from ..lib.conversion import (
@@ -45,6 +50,8 @@ class EnkiAPI:
         self._discovery_records: list[EnkiDiscoveryRecord] = []
         self._referentiel_cache: dict[str, dict[str, Any]] = {}
         self._scenarios: tuple[EnkiScenario, ...] = ()
+        self._node_fingerprints: dict[str, str] = {}
+        self._profile_read_errors: dict[str, dict[str, str]] = {}
 
     async def async_close(self) -> None:
         """Close the underlying HTTP session."""
@@ -92,6 +99,8 @@ class EnkiAPI:
         homes = await http.get_homes()
         devices: list[EnkiDevice] = []
         self._discovery_records = []
+        self._node_fingerprints.clear()
+        self._profile_read_errors.clear()
         for home_id in homes:
             home_devices, records = await self._discover_home(http, home_id)
             devices.extend(home_devices)
@@ -101,6 +110,30 @@ class EnkiAPI:
     @property
     def discovery_records(self) -> list[EnkiDiscoveryRecord]:
         return list(self._discovery_records)
+
+    def read_errors_for_fingerprint(self, fingerprint: str) -> dict[str, str]:
+        """Anonymized API read failures from the last poll (no node or home ids)."""
+        return dict(self._profile_read_errors.get(fingerprint, {}))
+
+    def _register_node_profile(self, node_id: str, record: EnkiDiscoveryRecord) -> None:
+        export = profile_to_export_dict(record, integration_version="", ha_version="")
+        self._node_fingerprints[node_id] = profile_fingerprint(export)
+
+    def _note_read_error(
+        self,
+        node_id: str,
+        *,
+        service: str,
+        capability: str,
+        err: Exception,
+    ) -> None:
+        fingerprint = self._node_fingerprints.get(node_id)
+        if not fingerprint:
+            return
+        status = getattr(err, "status", None)
+        label = f"HTTP {status}" if status else err.__class__.__name__
+        key = f"{service}/{capability}"
+        self._profile_read_errors.setdefault(fingerprint, {})[key] = label
 
     @property
     def scenarios(self) -> tuple[EnkiScenario, ...]:
@@ -255,6 +288,7 @@ class EnkiAPI:
             firmware_version=str(firmware) if firmware else None,
             supported_by_integration=supported,
         )
+        self._register_node_profile(node_id, record)
 
         last_reported: dict[str, Any] = {}
         if item.get("isEnabled", True):
@@ -315,6 +349,12 @@ class EnkiAPI:
                     state["light_power"] = light_state["power"]
             except EnkiConnectionError as err:
                 LOGGER.debug("Light state skipped for node %s: %s", node_id, err)
+                self._note_read_error(
+                    node_id,
+                    service="lighting",
+                    capability="check-light-state",
+                    err=err,
+                )
 
         if profile.supports_electrical_power:
             try:
@@ -325,6 +365,12 @@ class EnkiAPI:
                     state["power"] = state["electrical_power"]
             except EnkiConnectionError as err:
                 LOGGER.debug("Electrical power skipped for node %s: %s", node_id, err)
+                self._note_read_error(
+                    node_id,
+                    service="power",
+                    capability="check-electrical-power",
+                    err=err,
+                )
 
         if profile.supports_electrical_consumption:
             try:
@@ -336,6 +382,12 @@ class EnkiAPI:
                         state["electrical_consumption_unit"] = unit
             except EnkiConnectionError as err:
                 LOGGER.debug("Electrical consumption skipped for node %s: %s", node_id, err)
+                self._note_read_error(
+                    node_id,
+                    service="consumption",
+                    capability="check-instant-consumption",
+                    err=err,
+                )
 
         if profile.supports_fan_speed:
             try:
@@ -343,6 +395,12 @@ class EnkiAPI:
                 state["fan_speed"] = data["lastReportedValue"]
             except EnkiConnectionError as err:
                 LOGGER.debug("Fan speed skipped for node %s: %s", node_id, err)
+                self._note_read_error(
+                    node_id,
+                    service="airflow",
+                    capability="check-fan-speed",
+                    err=err,
+                )
 
         if profile.supports_airflow_mode:
             try:
@@ -350,6 +408,12 @@ class EnkiAPI:
                 state["airflow_mode"] = data["lastReportedValue"]
             except EnkiConnectionError as err:
                 LOGGER.debug("Airflow mode skipped for node %s: %s", node_id, err)
+                self._note_read_error(
+                    node_id,
+                    service="airflow",
+                    capability="check-airflow-mode",
+                    err=err,
+                )
 
         if profile.is_inverter:
             state["power_production"] = device.power_production
@@ -387,6 +451,12 @@ class EnkiAPI:
                     node_id,
                     err,
                 )
+                self._note_read_error(
+                    node_id,
+                    service=read.transport_id,
+                    capability=read.capability,
+                    err=err,
+                )
                 return None
             if data and "lastReportedValue" in data:
                 return read.state_key, data["lastReportedValue"]
@@ -411,6 +481,12 @@ class EnkiAPI:
                 state["fan_speed"] = speed_data["lastReportedValue"]
         except EnkiConnectionError as err:
             LOGGER.debug("Fan speed skipped for node %s: %s", node_id, err)
+            self._note_read_error(
+                node_id,
+                service="airflow",
+                capability="check-fan-speed",
+                err=err,
+            )
 
         try:
             mode_data = await http.airflow_get(home_id, node_id, "check-airflow-mode")
@@ -418,6 +494,12 @@ class EnkiAPI:
                 state["airflow_mode"] = mode_data["lastReportedValue"]
         except EnkiConnectionError as err:
             LOGGER.debug("Airflow mode skipped for node %s: %s", node_id, err)
+            self._note_read_error(
+                node_id,
+                service="airflow",
+                capability="check-airflow-mode",
+                err=err,
+            )
 
         rotation, rotation_supported = await self._read_fan_rotation(http, home_id, node_id)
         state["airflow_rotation"] = rotation
@@ -433,6 +515,12 @@ class EnkiAPI:
                 state["power"] = last_reported.get("power")
         except EnkiConnectionError as err:
             LOGGER.debug("Fan light state skipped for node %s: %s", node_id, err)
+            self._note_read_error(
+                node_id,
+                service="lighting",
+                capability="check-light-state",
+                err=err,
+            )
 
         try:
             power_details = await http.get_electrical_power(home_id, node_id)
@@ -440,6 +528,12 @@ class EnkiAPI:
             state["electrical_endpoints"] = power_details.get("endpoints", [])
         except EnkiConnectionError as err:
             LOGGER.debug("Electrical power skipped for fan node %s: %s", node_id, err)
+            self._note_read_error(
+                node_id,
+                service="power",
+                capability="check-electrical-power",
+                err=err,
+            )
         return state
 
     async def _read_fan_rotation(

--- a/custom_components/enki/diagnostics.py
+++ b/custom_components/enki/diagnostics.py
@@ -10,7 +10,8 @@ from homeassistant.core import HomeAssistant
 
 from . import __version__
 from .const import CONF_TELEMETRY, CONF_USERNAME
-from .domain.profile import profile_to_export_dict
+from .domain.profile import profile_fingerprint, profile_to_export_dict
+from .domain.telemetry_enrichment import enrich_telemetry_export
 
 TO_REDACT = {CONF_USERNAME, "username", "password", "home_id", "node_id", "device_id"}
 
@@ -23,14 +24,21 @@ async def async_get_config_entry_diagnostics(
     ha_version = hass.config.version
     devices = coordinator.data or []
 
-    profiles = [
-        profile_to_export_dict(
+    profiles = []
+    for record in coordinator.api.discovery_records:
+        export = profile_to_export_dict(
             record,
             integration_version=__version__,
             ha_version=ha_version,
         )
-        for record in coordinator.api.discovery_records
-    ]
+        fingerprint = profile_fingerprint(export)
+        profiles.append(
+            enrich_telemetry_export(
+                export,
+                record,
+                api_read_errors=coordinator.api.read_errors_for_fingerprint(fingerprint) or None,
+            )
+        )
 
     payload: dict[str, Any] = {
         "integration_version": __version__,

--- a/custom_components/enki/domain/profile.py
+++ b/custom_components/enki/domain/profile.py
@@ -108,38 +108,72 @@ def profile_fingerprint(export_dict: dict[str, Any]) -> str:
 
 
 def format_github_issue_body(export_dict: dict[str, Any], fingerprint: str) -> str:
-    supported = "oui" if export_dict.get("supported_by_integration") else "non"
+    supported = "yes" if export_dict.get("supported_by_integration") else "no"
     capabilities = export_dict.get("capabilities") or []
     possible_values = export_dict.get("possible_values") or {}
 
-    cap_lines = "\n".join(f"- `{capability}`" for capability in capabilities) or "- _(aucune)_"
+    cap_lines = "\n".join(f"- `{capability}`" for capability in capabilities) or "- _(none)_"
 
-    return (
-        "## Profil appareil Enki (partage opt-in)\n\n"
-        "Données anonymisées — sans identifiant de compte ou de domicile. "
-        "Issue ouverte manuellement depuis Home Assistant.\n\n"
-        f"- **Type référentiel** : `{export_dict.get('device_type', 'unknown')}`\n"
-        f"- **Type BFF** : `{export_dict.get('bff_device_type', '')}`\n"
-        f"- **Fabricant** : {export_dict.get('manufacturer') or 'inconnu'}\n"
-        f"- **Modèle** : {export_dict.get('model') or 'inconnu'}\n"
-        f"- **Firmware** : {export_dict.get('firmware_version') or 'inconnu'}\n"
-        f"- **Supporté par l'intégration** : {supported}\n"
-        f"- **Version intégration** : `{export_dict.get('integration_version', '')}`\n"
-        f"- **Home Assistant** : `{export_dict.get('ha_version', '')}`\n"
-        f"- **Empreinte** : `{fingerprint[:16]}`\n\n"
-        "### Capabilities\n"
+    body = (
+        "## Enki device profile (opt-in share)\n\n"
+        "Anonymized data — no account or home identifiers. "
+        "Issue opened manually from Home Assistant.\n\n"
+        f"- **Referentiel type:** `{export_dict.get('device_type', 'unknown')}`\n"
+        f"- **BFF type:** `{export_dict.get('bff_device_type', '')}`\n"
+        f"- **Manufacturer:** {export_dict.get('manufacturer') or 'unknown'}\n"
+        f"- **Model:** {export_dict.get('model') or 'unknown'}\n"
+        f"- **Firmware:** {export_dict.get('firmware_version') or 'unknown'}\n"
+        f"- **Supported by integration:** {supported}\n"
+        f"- **Integration version:** `{export_dict.get('integration_version', '')}`\n"
+        f"- **Home Assistant:** `{export_dict.get('ha_version', '')}`\n"
+        f"- **Fingerprint:** `{fingerprint[:16]}`\n"
+    )
+
+    if platforms := export_dict.get("ha_platforms"):
+        platform_line = ", ".join(f"`{platform}`" for platform in platforms)
+        body += f"- **HA platforms:** {platform_line}\n"
+
+    if reason := export_dict.get("telemetry_reason"):
+        reason_text = _TELEMETRY_REASON_LABELS.get(reason, reason)
+        body += f"- **Why this report:** {reason_text}\n"
+
+    body += (
+        "\n### Capabilities\n"
         f"{cap_lines}\n\n"
         "### Possible values\n"
         f"```json\n{json.dumps(possible_values, indent=2, sort_keys=True)}\n```\n"
     )
+
+    if uncovered := export_dict.get("uncovered_capabilities"):
+        uncovered_lines = "\n".join(f"- `{capability}`" for capability in uncovered)
+        body += f"\n### Uncovered capabilities\n{uncovered_lines}\n"
+
+    if api_errors := export_dict.get("api_read_errors"):
+        error_lines = "\n".join(
+            f"- `{endpoint}` → {status}" for endpoint, status in api_errors.items()
+        )
+        body += (
+            "\n### API read errors (last poll)\n"
+            f"{error_lines}\n\n"
+            "_No node or home identifiers — attach HA diagnostics if more context is needed._\n"
+        )
+
+    return body
+
+
+_TELEMETRY_REASON_LABELS = {
+    "api_read_errors": "Cloud API returned errors while reading state",
+    "unsupported_device": "Device type not supported by the integration yet",
+    "uncovered_capabilities": "Referentiel lists capabilities not implemented yet",
+}
 
 
 def format_github_issue_title(export_dict: dict[str, Any]) -> str:
     device_type = export_dict.get("device_type", "unknown")
     model = export_dict.get("model") or "unknown"
     if export_dict.get("supported_by_integration"):
-        return f"[telemetry] Profil {device_type} — {model}"
-    return f"[telemetry] Appareil non supporté — {device_type} ({model})"
+        return f"[telemetry] Profile {device_type} — {model}"
+    return f"[telemetry] Unsupported device — {device_type} ({model})"
 
 
 _GITHUB_ISSUE_URL_MAX_LENGTH = 7500

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..lib.enki_scope import device_in_enki_scope
 from .capabilities import EnkiCapabilityProfile
 from .models import EnkiDiscoveryRecord
 
@@ -54,7 +55,41 @@ _CAPABILITY_PROBES: dict[str, str] = {
     "check_vibration_sensibility_level": "supports_vibration_sensibility",
     "switch_electrical_power": "supports_electrical_power",
     "switch_siren_status": "supports_siren",
+    "switch_pilot_wire_mode": "supports_pilot_wire",
+    "check_pilot_wire_state": "supports_pilot_wire",
+    "change_thermostat_target_temperature": "supports_thermostat",
+    "check_thermostat_target_temperature": "supports_thermostat",
+    "check_thermostat_running_state": "supports_thermostat",
+    "change_occupancy_mode": "supports_occupancy_mode",
+    "check_occupancy_mode": "supports_occupancy_mode",
+    "change_window_open_detection_mode": "supports_window_open_detection_mode",
+    "check_window_open_detection_mode": "supports_window_open_detection_mode",
+    "check_window_open_detection": "supports_window_open_detection",
+    "check_occupancy": "supports_occupancy",
+    "check_water_sensor_state": "supports_water_leak",
 }
+
+# Referentiel capabilities with no HA entity planned (timers, energy totals, …).
+NOT_PLANNED_CAPABILITIES = frozenset(
+    {
+        "cancel_electrical_power_switch_in",
+        "next_electrical_power_switch_in",
+        "switch_electrical_power_in",
+        "total_supply_charge_consumption",
+    }
+)
+
+# Hub / infrastructure — never actionable as HA entity support requests.
+_GATEWAY_DEVICE_TYPES = frozenset({"gateways", "gateway"})
+_GATEWAY_CAPABILITY_MARKERS = frozenset(
+    {
+        "gateway_inventory",
+        "gateway_reboot",
+        "gateway_logs",
+        "change_gateway_certificate",
+        "check_gateway_state",
+    }
+)
 
 
 def profile_from_record(record: EnkiDiscoveryRecord) -> EnkiCapabilityProfile:
@@ -76,13 +111,48 @@ def capability_is_covered(capability: str, profile: EnkiCapabilityProfile) -> bo
     return bool(getattr(profile, probe_name))
 
 
-def discovery_record_needs_telemetry(record: EnkiDiscoveryRecord) -> bool:
+def _normalize_type(value: str | None) -> str:
+    if not value:
+        return ""
+    return value.strip().lower().replace(" ", "_")
+
+
+def discovery_record_eligible_for_telemetry(record: EnkiDiscoveryRecord) -> bool:
+    """Return False for out-of-scope or hub profiles that should not spam GitHub."""
+    if not device_in_enki_scope(
+        manufacturer=record.manufacturer,
+        device_type=record.device_type,
+    ):
+        return False
+
+    device_type = _normalize_type(record.device_type)
+    bff_type = _normalize_type(record.bff_device_type)
+    if device_type in _GATEWAY_DEVICE_TYPES or bff_type in _GATEWAY_DEVICE_TYPES:
+        return False
+
+    caps = record.capabilities or []
+    return not (caps and any(cap in _GATEWAY_CAPABILITY_MARKERS for cap in caps))
+
+
+def discovery_record_needs_telemetry(
+    record: EnkiDiscoveryRecord,
+    *,
+    api_read_errors: dict[str, str] | None = None,
+) -> bool:
     """Return True when the user should be nudged to open a GitHub issue."""
+    if not discovery_record_eligible_for_telemetry(record):
+        return False
+
+    if api_read_errors:
+        return True
+
     if not record.supported_by_integration:
         return True
 
     profile = profile_from_record(record)
     for capability in record.capabilities or []:
+        if capability in NOT_PLANNED_CAPABILITIES:
+            continue
         if not capability_is_covered(capability, profile):
             return True
     return False

--- a/custom_components/enki/domain/telemetry_enrichment.py
+++ b/custom_components/enki/domain/telemetry_enrichment.py
@@ -1,0 +1,99 @@
+"""Enrich anonymized telemetry exports with integration context."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .capabilities import EnkiCapabilityProfile
+from .models import EnkiDiscoveryRecord
+from .telemetry_coverage import (
+    NOT_PLANNED_CAPABILITIES,
+    capability_is_covered,
+    discovery_record_eligible_for_telemetry,
+    profile_from_record,
+)
+
+
+def ha_platforms_for_profile(profile: EnkiCapabilityProfile) -> list[str]:
+    """Home Assistant platforms that would be created for this profile."""
+    platforms: list[str] = []
+    if profile.is_fan:
+        platforms.append("fan")
+    if profile.is_light_controllable:
+        platforms.append("light")
+    if profile.is_outlet:
+        platforms.append("switch")
+    if profile.is_inverter:
+        platforms.append("sensor")
+    if profile.is_cover:
+        platforms.append("cover")
+    if profile.is_climate:
+        platforms.append("climate")
+    if profile.is_pilot_wire:
+        platforms.append("select")
+    if profile.is_binary_sensor:
+        platforms.append("binary_sensor")
+    if profile.is_environment_sensor:
+        platforms.append("sensor")
+    if profile.is_config_switch:
+        platforms.append("switch")
+    if profile.supports_vibration_sensibility:
+        platforms.append("number")
+    return sorted(dict.fromkeys(platforms))
+
+
+def uncovered_capabilities(record: EnkiDiscoveryRecord) -> list[str]:
+    """Capabilities not implemented and not marked as admin-only or not planned."""
+    profile = profile_from_record(record)
+    missing: list[str] = []
+    for capability in record.capabilities or []:
+        if capability in NOT_PLANNED_CAPABILITIES:
+            continue
+        if capability_is_covered(capability, profile):
+            continue
+        missing.append(capability)
+    return sorted(missing)
+
+
+def telemetry_notification_reason(
+    record: EnkiDiscoveryRecord,
+    *,
+    api_read_errors: dict[str, str] | None = None,
+) -> str | None:
+    """Short English reason why a telemetry notification would fire."""
+    if not discovery_record_eligible_for_telemetry(record):
+        return None
+    if api_read_errors:
+        return "api_read_errors"
+    if not record.supported_by_integration:
+        return "unsupported_device"
+    if uncovered_capabilities(record):
+        return "uncovered_capabilities"
+    return None
+
+
+def enrich_telemetry_export(
+    export: dict[str, Any],
+    record: EnkiDiscoveryRecord,
+    *,
+    api_read_errors: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Add non-fingerprint fields for diagnostics and GitHub prefill."""
+    profile = profile_from_record(record)
+    enriched = dict(export)
+    platforms = ha_platforms_for_profile(profile)
+    if platforms:
+        enriched["ha_platforms"] = platforms
+
+    missing = uncovered_capabilities(record)
+    if missing:
+        enriched["uncovered_capabilities"] = missing
+
+    if api_read_errors:
+        enriched["api_read_errors"] = dict(sorted(api_read_errors.items()))
+
+    reason = telemetry_notification_reason(record, api_read_errors=api_read_errors)
+    if reason:
+        enriched["telemetry_reason"] = reason
+
+    return enriched

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.5"
+  "version": "1.6.6"
 }

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -17,6 +17,7 @@ from ..domain.profile import (
     profile_to_export_dict,
 )
 from ..domain.telemetry_coverage import discovery_record_needs_telemetry
+from ..domain.telemetry_enrichment import enrich_telemetry_export
 
 STORAGE_VERSION = 1
 
@@ -43,6 +44,7 @@ class EnkiTelemetryReporter:
         reported = await self._load_reported()
         integration_version = _integration_version()
         ha_version = _ha_version(self._hass)
+        coordinator = self._entry.runtime_data
 
         new_count = 0
         for record in records:
@@ -53,6 +55,12 @@ class EnkiTelemetryReporter:
                     ha_version=ha_version,
                 )
                 fingerprint = profile_fingerprint(export_dict)
+                api_errors = coordinator.api.read_errors_for_fingerprint(fingerprint)
+                export_dict = enrich_telemetry_export(
+                    export_dict,
+                    record,
+                    api_read_errors=api_errors or None,
+                )
             except (TypeError, ValueError) as err:
                 LOGGER.warning(
                     "Skipping telemetry for profile %s: %s",
@@ -67,7 +75,7 @@ class EnkiTelemetryReporter:
             reported.add(fingerprint)
             await self._save_reported(reported)
 
-            if not discovery_record_needs_telemetry(record):
+            if not discovery_record_needs_telemetry(record, api_read_errors=api_errors):
                 continue
 
             new_count += 1

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -69,13 +69,20 @@ class EnkiTelemetryReporter:
                 )
                 continue
 
-            if fingerprint in reported:
+            needs_telemetry = discovery_record_needs_telemetry(
+                record,
+                api_read_errors=api_errors,
+            )
+
+            # Re-notify when API read errors appear on a profile seen earlier.
+            if fingerprint in reported and not (needs_telemetry and api_errors):
                 continue
 
-            reported.add(fingerprint)
-            await self._save_reported(reported)
+            if fingerprint not in reported:
+                reported.add(fingerprint)
+                await self._save_reported(reported)
 
-            if not discovery_record_needs_telemetry(record, api_read_errors=api_errors):
+            if not needs_telemetry:
                 continue
 
             new_count += 1

--- a/docs/BETA_VOLETS_KEY.md
+++ b/docs/BETA_VOLETS_KEY.md
@@ -1,111 +1,111 @@
-# Clés gateway volets — guide contributeur
+# Cover gateway keys — contributor guide
 
-Ce document s’adresse aux **personnes à l’aise avec le réseau / le débogage mobile**. Les testeurs lambda n’ont pas besoin de le lire : voir [Beta volets — pour les testeurs](SUPPORTED_DEVICES.md#pour-les-testeurs) dans `SUPPORTED_DEVICES.md`.
+This document is for **people comfortable with networking / mobile debugging**. Casual testers do not need it: see [Beta covers — for testers](SUPPORTED_DEVICES.md#for-testers-covers) in `SUPPORTED_DEVICES.md`.
 
-## État actuel
+## Current state
 
-Pour les **volets** (`api-enki-rolling-prod`, APK ≥ 2.25.1), la clé **`ENKI_ACCESS_MOTORIZATION_API_KEY`** est déjà incluse dans `const.py` (extraite de l’APK Enki 2.25.1). L’ancien micro-service `api-enki-access-and-motorizations-prod` n’est plus utilisé.
+For **roller shutters** (`api-enki-rolling-prod`, APK ≥ 2.25.1), the **`ENKI_ACCESS_MOTORIZATION_API_KEY`** is already included in `const.py` (extracted from Enki APK 2.25.1). The legacy micro-service `api-enki-access-and-motorizations-prod` is no longer used.
 
-Les utilisateurs **n’ont rien à configurer** : l’entité **« Volet (beta) »** apparaît si le volet est actif dans l’app Enki et que l’intégration est en **v1.5.0+**.
+Users **configure nothing**: the **“Shutter (beta)”** entity appears if the cover is active in the Enki app and the integration is **v1.5.0+**.
 
-## Quand relire ce guide
+## When to read this guide
 
-- **Mise à jour de l’app Enki** — les clés gateway peuvent changer ; la méthode recommandée est `scripts/extract_gateway_keys.py` (voir [DEVELOPMENT.md](DEVELOPMENT.md)).
-- **HTTP 403** sur `api-enki-rolling-prod` — valider la clé embarquée vs le trafic réel de l’app (mitmproxy ci-dessous).
-- **Échec de l’extraction APK** — capturer manuellement `X-Gateway-APIKey` et ouvrir une issue ou PR.
+- **Enki app update** — gateway keys may change; the recommended method is `scripts/extract_gateway_keys.py` (see [DEVELOPMENT.md](DEVELOPMENT.md)).
+- **HTTP 403** on `api-enki-rolling-prod` — validate the embedded key vs real app traffic (mitmproxy below).
+- **APK extraction failure** — capture `X-Gateway-APIKey` manually and open an issue or PR.
 
-**Ce n’est pas :**
+**This is not:**
 
-- le mot de passe du compte Enki ;
-- un secret personnel lié à un foyer ;
-- une donnée à partager publiquement sur les réseaux sociaux (c’est une clé applicative Leroy Merlin / Adeo, réutilisable pour toute l’intégration une fois intégrée au repo).
+- the Enki account password;
+- a personal secret tied to a home;
+- data to share publicly on social media (it is a Leroy Merlin / Adeo app key, reusable for the whole integration once merged in the repo).
 
-## Ce qu’il faut récupérer (validation manuelle)
+## What to capture (manual validation)
 
-Lors d’un contrôle de volet dans l’app Enki, repérer une requête HTTP vers :
+When controlling a cover in the Enki app, look for an HTTP request to:
 
 ```text
 …/api-enki-rolling-prod/v1/shutter/{nodeId}/…
 ```
 
-Copier la valeur de l’en-tête :
+Copy the header value:
 
 ```text
-X-Gateway-APIKey: <valeur à comparer ou transmettre au mainteneur>
+X-Gateway-APIKey: <value to compare or send to maintainer>
 ```
 
-Actions typiques visibles dans l’URL : `check-shutter-position`, `change-shutter-position`, `check-shutter-opening`.
+Typical actions in the URL: `check-shutter-position`, `change-shutter-position`, `check-shutter-opening`.
 
-## Méthode recommandée — extraction APK
+## Recommended method — APK extraction
 
-Sur la machine de dev :
+On the dev machine:
 
 ```bash
-python3 scripts/extract_gateway_keys.py chemin/vers/enki.apk --apply --update-known
+python3 scripts/extract_gateway_keys.py path/to/enki.apk --apply --update-known
 ```
 
-Le script met à jour `custom_components/enki/const.py` (dont `ENKI_ACCESS_MOTORIZATION_API_KEY`). Détail : [DEVELOPMENT.md](DEVELOPMENT.md).
+The script updates `custom_components/enki/const.py` (including `ENKI_ACCESS_MOTORIZATION_API_KEY`). Details: [DEVELOPMENT.md](DEVELOPMENT.md).
 
-## Alternative — mitmproxy (validation réseau)
+## Alternative — mitmproxy (network validation)
 
-### Prérequis
+### Prerequisites
 
-- PC et téléphone sur le **même réseau Wi‑Fi**
-- [mitmproxy](https://mitmproxy.org/) installé sur le PC
-- App **Enki** sur le téléphone, avec au moins un volet fonctionnel
+- PC and phone on the **same Wi‑Fi network**
+- [mitmproxy](https://mitmproxy.org/) installed on the PC
+- **Enki** app on the phone, with at least one working cover
 
-### Étapes
+### Steps
 
-1. **Lancer mitmproxy** sur le PC :
+1. **Start mitmproxy** on the PC:
    ```bash
    mitmweb
    ```
-   Interface web : http://127.0.0.1:8081 — proxy écoute sur le port **8080**.
+   Web UI: http://127.0.0.1:8081 — proxy listens on port **8080**.
 
-2. **Configurer le proxy Wi‑Fi sur le téléphone**  
-   Réglages Wi‑Fi → réseau actuel → proxy manuel → IP du PC, port **8080**.
+2. **Configure Wi‑Fi proxy on the phone**  
+   Wi‑Fi settings → current network → manual proxy → PC IP, port **8080**.
 
-3. **Installer le certificat mitmproxy** sur le téléphone  
-   Sur le téléphone, ouvrir http://mitm.it et suivre les instructions (iOS ou Android). Sans certificat, le trafic HTTPS de l’app ne sera pas visible.
+3. **Install the mitmproxy certificate** on the phone  
+   On the phone, open http://mitm.it and follow instructions (iOS or Android). Without the certificate, the app HTTPS traffic will not be visible.
 
-4. **Contrôler un volet dans l’app Enki**  
-   Ouvrir, fermer ou régler la position d’un volet.
+4. **Control a cover in the Enki app**  
+   Open, close, or set position.
 
-5. **Filtrer le trafic** dans mitmweb  
-   Rechercher `rolling-prod` ou `change-shutter`.
+5. **Filter traffic** in mitmweb  
+   Search for `rolling-prod` or `change-shutter`.
 
-6. **Copier `X-Gateway-APIKey`** depuis les en-têtes de la requête et la comparer à `ENKI_ACCESS_MOTORIZATION_API_KEY` dans `const.py`.
+6. **Copy `X-Gateway-APIKey`** from the request headers and compare to `ENKI_ACCESS_MOTORIZATION_API_KEY` in `const.py`.
 
-7. **Désactiver le proxy** sur le téléphone une fois terminé.
+7. **Disable the proxy** on the phone when done.
 
-### Transmission au projet
+### Reporting to the project
 
-Si la clé diffère de celle du dépôt, ouvrir une [issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new) ou commenter sur une issue volets existante avec :
+If the key differs from the repo, open an [issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new) or comment on an existing cover issue with:
 
-- la valeur de `X-Gateway-APIKey` (texte seul) ;
-- modèle de volet testé (ex. Evology SIN2RS1) ;
-- version de l’app Enki (APK) ;
-- confirmation que la commande fonctionnait dans l’app au moment de la capture.
+- the `X-Gateway-APIKey` value (text only);
+- cover model tested (e.g. Evology SIN2RS1);
+- Enki app (APK) version;
+- confirmation the command worked in the app at capture time.
 
-**Ne jamais joindre :** e-mail, mot de passe, tokens Bearer, homeId, nodeId.
+**Never attach:** email, password, Bearer tokens, homeId, nodeId.
 
 ## Alternative — HTTP Toolkit
 
-[HTTP Toolkit](https://httptoolkit.com/) propose une interface graphique (connexion téléphone Android via ADB, ou proxy manuel similaire à mitmproxy). Même principe : intercepter une requête `api-enki-rolling-prod` / `shutter/…` et lire `X-Gateway-APIKey`.
+[HTTP Toolkit](https://httptoolkit.com/) provides a GUI (Android via ADB, or manual proxy like mitmproxy). Same principle: intercept an `api-enki-rolling-prod` / `shutter/…` request and read `X-Gateway-APIKey`.
 
-## Intégration côté repo
+## Repository integration
 
-1. **Préféré :** `extract_gateway_keys.py --apply --update-known` (voir ci-dessus).
-2. **Sinon :** le mainteneur met à jour manuellement :
+1. **Preferred:** `extract_gateway_keys.py --apply --update-known` (see above).
+2. **Otherwise:** maintainer updates manually:
 
 ```python
 # custom_components/enki/const.py
 ENKI_ACCESS_MOTORIZATION_API_KEY = "…"
 ```
 
-Puis publie une nouvelle version. Les utilisateurs n’ont rien à modifier manuellement s’ils passent par HACS.
+Then publish a new version. Users change nothing manually if they use HACS.
 
-## Références
+## References
 
-- Notes API volets : [API.md](API.md#roller-shutters-evology-sin2rs1--beta)
-- Testeurs (sans proxy) : [SUPPORTED_DEVICES.md](SUPPORTED_DEVICES.md#pour-les-testeurs)
+- Cover API notes: [API.md](API.md#roller-shutters-evology-sin2rs1--beta)
+- Testers (no proxy): [SUPPORTED_DEVICES.md](SUPPORTED_DEVICES.md#for-testers-covers)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,124 +1,124 @@
-# Développement
+# Development
 
-Documentation technique pour contribuer, tester et publier l’intégration.
+Technical documentation for contributing, testing, and releasing the integration.
 
-## Prérequis
+## Prerequisites
 
 - Python 3.12+
-- Home Assistant 2024.12+ (pour tester sur une instance réelle)
+- Home Assistant 2024.12+ (for testing on a real instance)
 
 ```bash
 git clone https://github.com/cyrilcolinet/enki-integration-hass.git
 cd enki-integration-hass
 python3 -m venv .venv
-source .venv/bin/activate   # Windows : .venv\Scripts\activate
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -r requirements-dev.txt
 ```
 
-## Tests unitaires
+## Unit tests
 
-Sans compte Enki ni matériel :
+Without an Enki account or hardware:
 
 ```bash
 pytest tests/unit -v
 ```
 
-## Lint et format
+## Lint and format
 
 ```bash
 ruff check .
-ruff format --check .   # ou ruff format . pour corriger
+ruff format --check .   # or ruff format . to fix
 ```
 
-## Scripts locaux (hors Home Assistant)
+## Local scripts (outside Home Assistant)
 
-Les scripts dans `scripts/` s’exécutent **sur votre machine de dev**, pas dans le conteneur HA. Ils parlent directement à l’API Enki cloud (ou analysent un APK). Home Assistant n’a pas besoin d’être installé — seulement Python 3 et `pip install -r requirements-dev.txt`.
+Scripts in `scripts/` run **on your dev machine**, not inside the HA container. They talk directly to the Enki cloud API (or parse an APK). Home Assistant is not required — only Python 3 and `pip install -r requirements-dev.txt`.
 
 | Script | Usage |
 |--------|--------|
-| `scripts/fetch_gateway_keys.py` | Vérifie le login et lit `mobile-config` `/settings` (pas les clés gateway) |
-| `scripts/extract_gateway_keys.py` | Extrait les clés gateway depuis un APK (jadx + DI module) ; `--apply` met à jour `const.py` |
-| `scripts/discover_devices.py` | Exporte les profils appareils anonymisés du compte |
+| `scripts/fetch_gateway_keys.py` | Verify login and read `mobile-config` `/settings` (not gateway keys) |
+| `scripts/extract_gateway_keys.py` | Extract gateway keys from an APK (jadx + DI module); `--apply` updates `const.py` |
+| `scripts/discover_devices.py` | Export anonymized device profiles from the account |
 
 ```bash
 source .venv/bin/activate
 python3 scripts/fetch_gateway_keys.py
-python3 scripts/extract_gateway_keys.py chemin/vers/enki.apk
-python3 scripts/extract_gateway_keys.py chemin/vers/enki.apk --apply --update-known
-python3 scripts/discover_devices.py votre@email.com 'mot-de-passe'
+python3 scripts/extract_gateway_keys.py path/to/enki.apk
+python3 scripts/extract_gateway_keys.py path/to/enki.apk --apply --update-known
+python3 scripts/discover_devices.py your@email.com 'password'
 ```
 
-Les clés gateway sont embarquées dans l’APK (une par micro-service). Utiliser `extract_gateway_keys.py --apply` après chaque mise à jour de l’app Enki.
+Gateway keys are embedded in the APK (one per micro-service). Run `extract_gateway_keys.py --apply` after each Enki app update.
 
-## Langue du dépôt
+## Repository language
 
-- **Code Python** (commentaires, docstrings) : anglais — voir [CONTRIBUTING.md](../CONTRIBUTING.md#langue)
-- **Markdown** (`docs/`, `README.md`, …) : français
-- **UI Home Assistant** (`strings.json`, traductions) : français
+- **Python code** (comments, docstrings): English — see [CONTRIBUTING.md](../CONTRIBUTING.md#language)
+- **Markdown** (`docs/`, `README.md`, …): English
+- **Home Assistant UI** (`strings.json`, translations): French and English via translation files
 
-## Tests sur l’API réelle (optionnel)
+## Real API tests (optional)
 
-1. Copier `.env.example` vers `.env`
-2. Renseigner `ENKI_USERNAME`, `ENKI_PASSWORD`, `ENKI_HOME_ID`, `ENKI_NODE_ID`
-3. Les IDs se récupèrent avec :
+1. Copy `.env.example` to `.env`
+2. Fill in `ENKI_USERNAME`, `ENKI_PASSWORD`, `ENKI_HOME_ID`, `ENKI_NODE_ID`
+3. Retrieve IDs with:
 
 ```bash
 python3 scripts/discover_devices.py <email> <password>
 ```
 
-4. Lancer les tests :
+4. Run tests:
 
 ```bash
 set -a && source .env && set +a
 pytest tests/integration -v -m integration
 ```
 
-Les tests live remettent le ventilateur et la lumière à l’arrêt en fin de session.
+Live tests restore the fan and light to off at the end of the session.
 
-## Tester dans Home Assistant
+## Testing in Home Assistant
 
-Copier `custom_components/enki/` dans le dossier `config/custom_components/` de votre instance de dev, redémarrer, ajouter l’intégration via l’UI.
+Copy `custom_components/enki/` into your dev instance `config/custom_components/`, restart, add the integration via the UI.
 
 ## CI
 
-Workflow unique : [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)
+Single workflow: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)
 
-Déclenché sur chaque push vers `main` et chaque pull request :
+Triggered on every push to `main` and every pull request:
 
-| Job | Rôle |
+| Job | Role |
 |-----|------|
 | Lint | Ruff check + format |
 | Unit tests | `pytest tests/unit` |
-| Hassfest | Validation intégration HA |
-| HACS | Validation dépôt (éligibilité store par défaut) |
+| Hassfest | HA integration validation |
+| HACS | Repository validation (default store eligibility) |
 
-Tests live : uniquement via `workflow_dispatch` avec secrets `ENKI_*` configurés sur le dépôt.
+Live tests: only via `workflow_dispatch` with `ENKI_*` secrets configured on the repo.
 
-## Publier une release
+## Publishing a release
 
-1. Mettre à jour `custom_components/enki/manifest.json` avec la version cible (ex. `1.5.0`)
-2. Taguer et pousser :
+1. Update `custom_components/enki/manifest.json` with the target version (e.g. `1.6.5`)
+2. Tag and push:
 
 ```bash
-git tag v1.5.0
-git push origin v1.5.0
+git tag v1.6.5
+git push origin v1.6.5
 ```
 
-3. Créer la **GitHub Release** depuis le tag — le workflow [`release.yml`](../.github/workflows/release.yml) attache `enki.zip` avec la version du tag injectée dans le manifest du ZIP (sans commit automatique sur le dépôt).
+3. Create the **GitHub Release** from the tag — the [`release.yml`](../.github/workflows/release.yml) workflow attaches `enki.zip` with the tag version injected into the ZIP manifest (no automatic commit on the repo).
 
-La validation APK en CI release est **désactivée pour le moment**. En local, après une mise à jour de l’app Enki : `python3 scripts/extract_gateway_keys.py chemin/vers/enki.apk --check` puis `--apply --update-known` si besoin.
+APK validation in CI release is **disabled for now**. Locally, after an Enki app update: `python3 scripts/extract_gateway_keys.py path/to/enki.apk --check` then `--apply --update-known` if needed.
 
-## Documentation technique
+## Technical documentation
 
-| Document | Contenu |
+| Document | Content |
 |----------|---------|
-| [API.md](API.md) | Endpoints cloud Enki (reverse engineering) |
-| [HACS.md](HACS.md) | Checklist publication HACS |
-| [SUPPORTED_DEVICES.md](SUPPORTED_DEVICES.md) | Matériel et statut réel par appareil |
+| [API.md](API.md) | Enki cloud endpoints (reverse engineering) |
+| [HACS.md](HACS.md) | HACS publication checklist |
+| [SUPPORTED_DEVICES.md](SUPPORTED_DEVICES.md) | Hardware and per-device status |
 
-## Structure du code
+## Code structure
 
-Home Assistant exige que les **loaders de plateforme** et `config_flow.py` restent à la racine de `custom_components/enki/`. Le reste est organisé par couche :
+Home Assistant requires **platform loaders** and `config_flow.py` at the root of `custom_components/enki/`. Everything else is organized by layer:
 
 ```
 custom_components/enki/
@@ -127,17 +127,17 @@ custom_components/enki/
 ├── number.py, select.py, sensor.py, switch.py, diagnostics.py
 ├── const.py, exceptions.py, strings.json, translations/, brand/
 │
-├── api/                    # couche cloud
+├── api/                    # cloud layer
 │   ├── client.py           # discovery + REST commands
 │   ├── auth.py             # OAuth Keycloak
 │   ├── transport.py        # HTTP per micro-service
 │   ├── gateway_registry.py # APK micro-service catalogue
 │   └── gateway_keys.py     # runtime key store + mobile-config settings path
 │
-├── domain/                 # modèle métier (sans import HA)
+├── domain/                 # business model (no HA import)
 │   ├── models.py, capabilities.py, state.py, profile.py
 │
-├── platforms/              # logique interne partagée
+├── platforms/              # shared internal logic
 │   ├── light/behavior.py
 │   └── fan/airflow.py
 │
@@ -145,21 +145,21 @@ custom_components/enki/
 │   ├── reporter.py
 │   └── nudge.py
 │
-└── lib/                    # fonctions pures (0 import HA)
+└── lib/                    # pure functions (0 HA import)
     ├── conversion.py, bff.py, battery.py, capability_path.py
     ├── heating.py, shutter.py, enki_scope.py
 ```
 
-Plateformes enregistrées dans `__init__.py` → `PLATFORMS` : `binary_sensor`, `climate`, `cover`, `fan`, `light`, `number`, `select`, `sensor`, `switch`.
+Platforms registered in `__init__.py` → `PLATFORMS`: `binary_sensor`, `climate`, `cover`, `fan`, `light`, `number`, `select`, `sensor`, `switch`.
 
-### Conventions d’import
+### Import conventions
 
-| Package | Rôle | Exemple |
+| Package | Role | Example |
 |---------|------|---------|
-| `enki.api` | Client cloud public | `from enki.api import EnkiAPI` |
-| `enki.domain` | Modèle et capacités | `from enki.domain.models import EnkiDevice` |
-| `enki.lib` | Helpers testables sans HA | `from enki.lib.conversion import speed_to_percentage` |
-| `enki.platforms.fan` | Logique ventilateur | `from enki.platforms.fan.airflow import preset_to_enki_airflow_mode` |
-| `enki.telemetry` | Opt-in télémétrie | `from enki.telemetry import EnkiTelemetryReporter` |
+| `enki.api` | Public cloud client | `from enki.api import EnkiAPI` |
+| `enki.domain` | Model and capabilities | `from enki.domain.models import EnkiDevice` |
+| `enki.lib` | Helpers testable without HA | `from enki.lib.conversion import speed_to_percentage` |
+| `enki.platforms.fan` | Fan logic | `from enki.platforms.fan.airflow import preset_to_enki_airflow_mode` |
+| `enki.telemetry` | Opt-in telemetry | `from enki.telemetry import EnkiTelemetryReporter` |
 
-Voir aussi [CONTRIBUTING.md](../CONTRIBUTING.md) pour les conventions de PR.
+See also [CONTRIBUTING.md](../CONTRIBUTING.md) for PR conventions.

--- a/docs/HACS.md
+++ b/docs/HACS.md
@@ -1,63 +1,63 @@
-# Publication HACS
+# HACS publication
 
-Checklist alignée sur la [documentation officielle HACS](https://www.hacs.xyz/docs/publish/).
+Checklist aligned with the [official HACS documentation](https://www.hacs.xyz/docs/publish/).
 
-## Dépôt custom (installation actuelle)
+## Custom repository (current install)
 
-En attendant l’inclusion dans le store par défaut, les utilisateurs ajoutent le dépôt manuellement ou via le badge **Open in HACS**.
+Until inclusion in the default store, users add the repo manually or via the **Open in HACS** badge.
 
-1. Dépôt **public** sur GitHub
-2. Fichier [`hacs.json`](../hacs.json) à la racine avec au minimum `name`
-3. Structure `custom_components/enki/` avec `manifest.json`
-4. README d’installation
-5. Workflow [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) (lint, tests, HACS, Hassfest) **sans erreur**
+1. **Public** GitHub repository
+2. [`hacs.json`](../hacs.json) at the root with at least `name`
+3. `custom_components/enki/` structure with `manifest.json`
+4. Installation README
+5. [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) workflow (lint, tests, HACS, Hassfest) **without errors**
 
-### Lien d’installation rapide (my.home-assistant.io)
+### Quick install link (my.home-assistant.io)
 
-Après publication du dépôt, générez un lien :
+After publishing the repo, generate a link:
 
-[Créer un lien HACS](https://my.home-assistant.io/create-link/?redirect=hacs_repository&owner=cyrilcolinet&repository=enki-integration-hass&category=integration)
+[Create a HACS link](https://my.home-assistant.io/create-link/?redirect=hacs_repository&owner=cyrilcolinet&repository=enki-integration-hass&category=integration)
 
-Exemple Markdown pour le README :
+Example Markdown for the README:
 
 ```markdown
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=cyrilcolinet&repository=enki-integration-hass&category=integration)
 ```
 
-## Métadonnées GitHub (obligatoire pour HACS)
+## GitHub metadata (required for HACS)
 
-Configurer sur la page **Settings** du dépôt GitHub :
+Configure on the repository **Settings** page:
 
-| Champ | Exemple |
+| Field | Example |
 |-------|---------|
 | **Description** | Home Assistant integration for the Enki / Leroy Merlin smart home cloud — lights, fans, switches, sensors, covers, climate, scenarios, and more. |
 | **Topics** | `home-assistant`, `hacs`, `hacs-integration`, `enki`, `leroy-merlin`, `smart-home`, `home-automation`, `iot`, `lexman`, `edisio`, `equation` |
-| **Issues** | Activées |
+| **Issues** | Enabled |
 
-## Releases (recommandé)
+## Releases (recommended)
 
-HACS affiche les 5 dernières releases si elles existent.
+HACS shows the last 5 releases when they exist.
 
-1. Créer un tag sémantique (`v1.5.0`) aligné sur `custom_components/enki/manifest.json`
-2. Publier une **GitHub Release** (pas seulement un tag)
-3. Le workflow [`release.yml`](../.github/workflows/release.yml) injecte la version du tag dans le ZIP HACS attaché (`enki.zip`) — le fichier `manifest.json` du dépôt git doit être mis à jour manuellement avant le tag
+1. Create a semantic tag (`v1.6.5`) aligned with `custom_components/enki/manifest.json`
+2. Publish a **GitHub Release** (not just a tag)
+3. The [`release.yml`](../.github/workflows/release.yml) workflow attaches `enki.zip` with the tag version injected into the ZIP manifest — update `manifest.json` in git manually before tagging
 
-## Store HACS par défaut
+## Default HACS store
 
-Procédure : [Include default repositories](https://www.hacs.xyz/docs/publish/include/)
+Procedure: [Include default repositories](https://www.hacs.xyz/docs/publish/include/)
 
-**État du dépôt :** les prérequis techniques sont couverts par la CI sur chaque push/PR :
+**Repository status:** technical prerequisites are covered by CI on every push/PR:
 
-| Prérequis | Statut |
+| Prerequisite | Status |
 |-----------|--------|
-| Action **HACS** (`hacs/action`, sans `ignore: brands`) | ✅ [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) |
-| Action **Hassfest** | ✅ idem |
+| **HACS** action (`hacs/action`, no `ignore: brands`) | ✅ [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) |
+| **Hassfest** action | ✅ same |
 | `hacs.json` + `country: FR` | ✅ [`hacs.json`](../hacs.json) |
-| Au moins **une release** GitHub | ✅ [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases) |
-| Brand `custom_components/enki/brand/` | ✅ `icon.png` (256) + `icon@2x.png` (512) — servies localement par HA **2026.3+** ([Brands Proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)) ; **plus besoin** de PR sur [home-assistant/brands](https://github.com/home-assistant/brands) (nouvelles intégrations custom refusées depuis fév. 2026) |
+| At least **one** GitHub release | ✅ [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases) |
+| Brand `custom_components/enki/brand/` | ✅ `icon.png` (256) + `icon@2x.png` (512) — served locally by HA **2026.3+** ([Brands Proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)); **no longer need** a PR on [home-assistant/brands](https://github.com/home-assistant/brands) (new custom integrations rejected since Feb 2026) |
 
-**Reste à faire côté publication :** PR sur [hacs/default](https://github.com/hacs/default) (fichier `integration`), entrée **alphabétique** : `cyrilcolinet/enki-integration-hass`.
+**Remaining publication step:** PR on [hacs/default](https://github.com/hacs/default) (`integration` file), **alphabetical** entry: `cyrilcolinet/enki-integration-hass`.
 
-## Validation locale
+## Local validation
 
-Les mêmes vérifications que le workflow **CI** (ruff, pytest, Hassfest, HACS action) tournent sur chaque push/PR. Sur GitHub : onglet **Actions** → workflow **CI**.
+Same checks as the **CI** workflow (ruff, pytest, Hassfest, HACS action) on every push/PR. On GitHub: **Actions** tab → **CI** workflow.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,34 +1,31 @@
-# Feuille de route (vue détaillée)
+# Roadmap (detailed view)
 
-Version courte pour HACS : [README § Feuille de route](../README.md#feuille-de-route).  
-Détail par appareil : [SUPPORTED_DEVICES.md](SUPPORTED_DEVICES.md).
+Short version: [README](../README.md) · detailed view below.
 
 | | |
 |---|---|
-| **Dernière release GitHub** | [v1.3.3](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) |
-| **Version `manifest.json` (dépôt)** | 1.5.0 |
+| **Latest GitHub release** | [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) |
+| **Repository `manifest.json`** | 1.6.5 |
 
-**Écart release / dépôt :** la [dernière release GitHub](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) (v1.3.3) n’inclut pas encore RGB (HS), chauffage, fuite ni volets. Le dépôt `main` est en **1.5.0** : RGB, clés gateway APK 2.25.1, chauffage / fuite / volets (beta), filtre fabricant Enki.
+## Status by device
 
-## Statut par appareil
-
-| Statut | Appareil | Fonctionnalités |
+| Status | Device | Features |
 |--------|----------|-------------------|
-| ✅ Supporté | Ventilateurs Inspire (Siroco+, Cadix, …) | ventilateur, lumière kit, vitesse, sens, modes (selon référentiel) |
-| ✅ Supporté | Luminaires Enki (Eglo, Lexman, …) | ON/OFF, luminosité, blanc variable, couleur RGB (HS) si `change_hue` + `change_saturation` |
-| ✅ Supporté | Prises / interrupteurs (Edisio, Equation, …) | ON/OFF via `switch-electrical-power` |
-| ✅ Supporté | Panneaux solaires Envertech-Lexman | production (W) via dashboard BFF |
-| ✅ Supporté | Capteurs mouvement / ouverture / vibration (Lexman, …) | `binary_sensor` |
-| ✅ Supporté | Thermomètres Enki (Sedea, …) | température, humidité, batterie |
-| ✅ Supporté | Sirènes Lexman | `switch` ON/OFF |
-| ✅ Supporté | Relais ON/OFF Equation | ON/OFF (comme prises Edisio) |
-| 🔬 Beta | Volets roulants (Evology, Nodon, …) | `cover` « Volet (beta) » si volet actif dans l’app ; clé `ENKI_ACCESS_MOTORIZATION_API_KEY` (APK 2.25.1) ; peu testé en conditions réelles |
-| 🔬 Beta | Détecteur fuite Lexman (v1.5.0+) | `binary_sensor` fuite + `sensor` batterie ; clés `ENKI_WATER_SENSOR_API_KEY` et `ENKI_BATTERY_HEALTH_API_KEY` (APK 2.25.1) |
-| 🔬 Beta | Fil pilote Equation (v1.5.0+) | entité `select` (modes confort / éco / hors gel) ; clé `ENKI_HEATING_API_KEY` (APK 2.25.1) |
-| 🔬 Beta | Radiateur Noirot (v1.5.0+) | `climate` + détection fenêtre / présence ; clé `ENKI_HEATING_API_KEY` (APK 2.25.1) |
-| 🔜 Bientôt | Radiateurs ACOVA ARLAN | allowlist fabricant OK, pas de matériel de test |
-| 🔬 Beta | Scénarios Enki (« Ouvrir Salon », …) | `button` (v1.6.0+) |
-| ⏳ Pas prévu | Alarme Enki | pas d’API identifiée |
-| ✅ Prérequis OK | Store HACS global | CI HACS + Hassfest vertes, releases publiées — [PR `hacs/default` à ouvrir](HACS.md#store-hacs-par-défaut) |
+| ✅ Supported | Inspire fans (Siroco+, Cadix, …) | fan, LED kit light, speed, direction, modes (per referentiel) |
+| ✅ Supported | Enki lights (Eglo, Lexman, …) | ON/OFF, brightness, tunable white, RGB (HS) if `change_hue` + `change_saturation` |
+| ✅ Supported | Outlets / switches (Edisio, Equation, …) | ON/OFF via `switch-electrical-power` |
+| ✅ Supported | Envertech-Lexman solar panels | production (W) via BFF dashboard |
+| ✅ Supported | Motion / contact / vibration sensors (Lexman, …) | `binary_sensor` |
+| ✅ Supported | Enki thermometers (Sedea, …) | temperature, humidity, battery |
+| ✅ Supported | Lexman sirens | `switch` ON/OFF |
+| ✅ Supported | Equation ON/OFF relay | ON/OFF (like Edisio outlets) |
+| 🔬 Beta | Roller shutters (Evology, Nodon, …) | `cover` “Shutter (beta)” if active in the app; `ENKI_ACCESS_MOTORIZATION_API_KEY` (APK 2.25.1); limited real-world testing |
+| 🔬 Beta | Lexman water leak detector (v1.5.0+) | leak `binary_sensor` + battery `sensor`; `ENKI_WATER_SENSOR_API_KEY` and `ENKI_BATTERY_HEALTH_API_KEY` (APK 2.25.1) |
+| 🔬 Beta | Equation pilot wire (v1.5.0+) | `select` entity (comfort / eco / frost protection modes); `ENKI_HEATING_API_KEY` (APK 2.25.1) |
+| 🔬 Beta | Noirot radiator (v1.5.0+) | `climate` + window / presence detection; `ENKI_HEATING_API_KEY` (APK 2.25.1) |
+| 🔜 Soon | ACOVA ARLAN radiators | manufacturer allowlist OK, no test hardware |
+| 🔬 Beta | Enki scenarios (“Open living room”, …) | `button` (v1.6.0+) |
+| ⏳ Not planned | Enki alarm | no API identified |
+| ✅ Prerequisite OK | Default HACS store | CI HACS + Hassfest green, releases published — [PR to `hacs/default`](HACS.md#default-hacs-store) |
 
-**Hors périmètre :** Zigbee tiers appairé sur la box (Sonoff, Tuya, Aqara, IKEA, …) → [Zigbee2MQTT](https://www.zigbee2mqtt.io/) ou ZHA. Seules les marques **Enki / Leroy Merlin** listées dans [`lib/enki_scope.py`](../custom_components/enki/lib/enki_scope.py) sont importées.
+**Out of scope:** third-party Zigbee on the hub (Sonoff, Tuya, Aqara, IKEA, …) → [Zigbee2MQTT](https://www.zigbee2mqtt.io/) or ZHA. Only **Enki / Leroy Merlin** brands in [`lib/enki_scope.py`](../custom_components/enki/lib/enki_scope.py) are imported.

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -1,166 +1,164 @@
-# Appareils et fonctionnalités supportés
+# Supported devices and features
 
-Détail par type d’appareil et entités Home Assistant créées. L’intégration détecte les appareils via leurs **capabilities** API (comme l’app mobile), pas seulement par modèle.
+Detail by device type and Home Assistant entities created. The integration detects devices via API **capabilities** (like the mobile app), not model names alone.
 
 | | |
 |---|---|
-| **Dernière release GitHub** | [v1.3.3](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) |
-| **Version `manifest.json` (dépôt)** | 1.5.0 |
+| **Latest GitHub release** | [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) |
+| **Repository `manifest.json`** | 1.6.5 |
 
-**Écart release / dépôt :** la [dernière release GitHub](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) (v1.3.3) n’inclut pas encore RGB (HS), chauffage, fuite ni volets. Le dépôt `main` est en **1.5.0** : RGB, clés gateway APK 2.25.1, chauffage / fuite / volets (beta), filtre fabricant Enki.
+Summary: [ROADMAP.md](ROADMAP.md)
 
-Vue synthèse : [ROADMAP.md](ROADMAP.md) · version courte (HACS) : [README § Feuille de route](../README.md#feuille-de-route)
+## Scope
 
-## Périmètre
+This integration covers **only the Enki / Leroy Merlin ecosystem**: Lexman, Equation, Inspire, Noirot, Edisio, Eglo, Sedea, Evology, Nodon, ACOVA, Envertech, etc. (exact list: [`lib/enki_scope.py`](../custom_components/enki/lib/enki_scope.py)).
 
-Cette intégration couvre **uniquement l’écosystème Enki / Leroy Merlin** : Lexman, Equation, Inspire, Noirot, Edisio, Eglo, Sedea, Evology, Nodon, ACOVA, Envertech, etc. (liste exacte : [`lib/enki_scope.py`](../custom_components/enki/lib/enki_scope.py)).
+**Important:** many of these devices use **Zigbee radio** via the Enki hub — that is expected and in scope. However, any **third-party Zigbee** on the hub (Sonoff, Tuya, Aqara, IKEA, …) or any node **without a known Enki manufacturer** is **skipped** at discovery: integrate them via **Zigbee2MQTT** or **ZHA**, not this repo.
 
-**Important :** beaucoup de ces appareils utilisent **Zigbee en radio** via la box Enki — c’est normal et ils restent dans le périmètre. En revanche, tout **Zigbee tiers** appairé sur la box (Sonoff, Tuya, Aqara, IKEA, …) ou tout nœud **sans fabricant Enki connu** est **ignoré** à la découverte : intégrez-les via **Zigbee2MQTT** ou **ZHA**, pas ce dépôt.
+## Inspire ceiling fans (Siroco+, Aruba+, Cadix, Radix, …)
 
-## Ventilateurs Inspire (Siroco+, Aruba+, Cadix, Radix, …)
+**HA entities:** `fan` + `light` (LED kit)
 
-**Entités HA :** `fan` + `light` (kit LED)
-
-| Fonction | Détail |
+| Function | Detail |
 |----------|--------|
-| Marche / arrêt | Vitesse 0 ou coupure moteur |
-| Vitesse | Jusqu’à 6 niveaux (mapping pourcentage HA ; max selon référentiel) |
-| Sens de rotation | Été / hiver si `change_fan_rotation_direction` (API `CLOCKWISE` / `COUNTERCLOCKWISE`) |
-| Modes | Presets HA dérivés du référentiel : `manual`, `breeze`, et selon modèle `ventilation`, `boost`, `auto`, `sleep` (libellé UI « Nuit ») |
+| On / off | Speed 0 or motor power cut |
+| Speed | Up to 6 levels (HA percentage mapping; max from referentiel) |
+| Rotation direction | Summer / winter if `change_fan_rotation_direction` (API `CLOCKWISE` / `COUNTERCLOCKWISE`) |
+| Modes | HA presets from referentiel: `manual`, `breeze`, and per model `ventilation`, `boost`, `auto`, `sleep` (UI label “Night”) |
 
-Le ventilateur et sa lumière sont **indépendants** : allumer l’un n’allume pas l’autre.
+Fan and light kit are **independent**: turning one on does not turn the other on.
 
-## Luminaires Enki (Eglo, Lexman, …)
+## Enki lights (Eglo, Lexman, …)
 
-**Entité HA :** `light`
+**HA entity:** `light`
 
-| Fonction | Détail |
+| Function | Detail |
 |----------|--------|
-| Marche / arrêt | ON / OFF |
-| Luminosité | Si `change_brightness` ou `change_light_state` |
-| Blanc variable | Température de couleur (`colorTemperature`, ex. `T3500K`) si annoncée |
-| Couleur RGB | Mode HS si `change_hue` + `change_saturation` (depuis manifest **1.4.0**, pas dans la release v1.3.3) |
+| On / off | ON / OFF |
+| Brightness | If `change_brightness` or `change_light_state` |
+| Tunable white | Color temperature (`colorTemperature`, e.g. `T3500K`) when advertised |
+| RGB color | HS mode if `change_hue` + `change_saturation` (since manifest **1.4.0**) |
 
-## Prises, relais et interrupteurs (Edisio, Equation, …)
+## Outlets, relays, and switches (Edisio, Equation, …)
 
-**Entité HA :** `light` ON/OFF (API `switch-electrical-power`, pas l’API lighting)
+**HA entity:** `light` ON/OFF (API `switch-electrical-power`, not lighting API)
 
-| Modèle / type | Statut |
+| Model / type | Status |
 |---------------|--------|
-| Prises Edisio | ✅ ON/OFF, ✅ conso instantanée (W) |
-| Relais ON/OFF Equation ([profil](./devices/63a053851a423d4a245a877c.json)) | ✅ ON/OFF, ✅ conso instantanée (W) |
+| Edisio outlets | ✅ ON/OFF, ✅ instant consumption (W) |
+| Equation ON/OFF relay ([profile](./devices/63a053851a423d4a245a877c.json)) | ✅ ON/OFF, ✅ instant consumption (W) |
 
-Les nœuds multi-circuits peuvent créer **une entité par circuit** (endpoint BFF). Timers (`switch_electrical_power_in`, …) : pas encore exposés.
+Multi-circuit nodes may create **one entity per circuit** (BFF endpoint). Timers (`switch_electrical_power_in`, …): not exposed yet.
 
-## Scénarios Enki (v1.6.0+)
+## Enki scenarios (v1.6.0+)
 
-**Entités HA :** `button` (un bouton par scénario cloud)
+**HA entities:** `button` (one button per cloud scenario)
 
-| Fonction | Détail |
+| Function | Detail |
 |----------|--------|
-| Lister | `GET /api-enki-scenario-prod/v1/scenarios?homeId=…` |
-| Lancer | `POST …/scenarios/{id}/activate` |
+| List | `GET /api-enki-scenario-prod/v1/scenarios?homeId=…` |
+| Run | `POST …/scenarios/{id}/activate` |
 
-Les scénarios sont rafraîchis à chaque poll du coordinateur. Ils apparaissent sous l’appareil virtuel **Enki scenarios**.
+Scenarios refresh on each coordinator poll. They appear under the virtual device **Enki scenarios**.
 
-## Panneaux solaires (Envertech-Lexman)
+## Solar panels (Envertech-Lexman)
 
-**Entité HA :** `sensor` (production W)
+**HA entity:** `sensor` (production W)
 
-| Fonction | Détail |
+| Function | Detail |
 |----------|--------|
-| Production instantanée | Valeur lue sur le dashboard BFF (`description.value`) |
+| Instant production | Value from BFF dashboard (`description.value`) |
 
-## Capteurs Enki (Lexman, Sedea, …)
+## Enki sensors (Lexman, Sedea, …)
 
-Micro-services alignés sur [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki) (clés gateway déjà dans `const.py`).
+Micro-services aligned with [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki) (gateway keys already in `const.py`).
 
-### Mouvement / ouverture / vibration
+### Motion / contact / vibration
 
-**Entités HA :** `binary_sensor`
+**HA entities:** `binary_sensor`
 
-| Capabilité API | Entité |
+| API capability | Entity |
 |----------------|--------|
-| `check_motion_detection` / `check_motion_detector_state` | Mouvement |
-| `check_contact_sensor_state` | Contact (ouvert / fermé) |
+| `check_motion_detection` / `check_motion_detector_state` | Motion |
+| `check_contact_sensor_state` | Contact (open / closed) |
 | `check_vibration_detection` | Vibration |
 
-### Température / humidité / batterie
+### Temperature / humidity / battery
 
-**Entités HA :** `sensor`
+**HA entities:** `sensor`
 
-| Capabilité API | Entité |
+| API capability | Entity |
 |----------------|--------|
-| `check_current_temperature` | Température (°C) — sauf thermostats (température sur `climate`) |
-| `check_current_humidity` | Humidité (%) |
-| `check_battery_health` | Batterie (%, mapping Enki) |
+| `check_current_temperature` | Temperature (°C) — except thermostats (temperature on `climate`) |
+| `check_current_humidity` | Humidity (%) |
+| `check_battery_health` | Battery (%, Enki mapping) |
 
-Thermomètres **Sedea** (écran) : température, humidité, batterie.
+**Sedea** thermometers (display): temperature, humidity, battery.
 
-### Sirène Lexman
+### Lexman siren
 
-**Entité HA :** `switch` (ON/OFF via `switch_siren_status`)
+**HA entity:** `switch` (ON/OFF via `switch_siren_status`)
 
-### Réglages capteur contact
+### Contact sensor settings
 
-**Entités HA :** `switch` (activation détection), `number` (sensibilité vibration 1–5)
+**HA entities:** `switch` (detection enable), `number` (vibration sensitivity 1–5)
 
-### Fuite d’eau (Lexman) — beta (v1.5.0+)
+### Water leak (Lexman) — beta (v1.5.0+)
 
-**Entités HA :** `binary_sensor` (fuite), `sensor` (batterie)
+**HA entities:** `binary_sensor` (leak), `sensor` (battery)
 
-**Profil :** [651eada55b3a798ef6b6bc5c.json](./devices/651eada55b3a798ef6b6bc5c.json)
+**Profile:** [651eada55b3a798ef6b6bc5c.json](./devices/651eada55b3a798ef6b6bc5c.json)
 
-| Capabilité | Service | Statut actuel |
+| Capability | Service | Current status |
 |------------|---------|---------------|
-| `check_battery_health` | `battery-health` | ✅ clé APK 2.25.1 |
-| `check_water_sensor_state` | `water-leak-detector` | ✅ clé APK 2.25.1 |
+| `check_battery_health` | `battery-health` | ✅ APK 2.25.1 key |
+| `check_water_sensor_state` | `water-leak-detector` | ✅ APK 2.25.1 key |
 
-## Chauffage — beta (v1.5.0+)
+## Heating — beta (v1.5.0+)
 
-| Modèle | Entités HA | Profil |
+| Model | HA entities | Profile |
 |--------|------------|--------|
-| Fil pilote Equation | `select` (COMFORT, ECO, FROST_PROTECTION, OFF, …) | [63a054c81a423d4a245a877e.json](./devices/63a054c81a423d4a245a877e.json) |
-| Radiateur Noirot | `climate`, `binary_sensor` (fenêtre, présence), `switch` (modes détection) | [67a4b12bae1eca4709a45680.json](./devices/67a4b12bae1eca4709a45680.json) |
+| Equation pilot wire | `select` (COMFORT, ECO, FROST_PROTECTION, OFF, …) | [63a054c81a423d4a245a877e.json](./devices/63a054c81a423d4a245a877e.json) |
+| Noirot radiator | `climate`, `binary_sensor` (window, presence), `switch` (detection modes) | [67a4b12bae1eca4709a45680.json](./devices/67a4b12bae1eca4709a45680.json) |
 
-**Clés API :** remplies depuis l’APK Enki 2.25.1 (`ENKI_HEATING_API_KEY`, `ENKI_WATER_SENSOR_API_KEY`). Mise à jour : [DEVELOPMENT.md](DEVELOPMENT.md) · détail API : [API.md](API.md#heating-and-water-sensors-manifest--150).
+**API keys:** from Enki APK 2.25.1 (`ENKI_HEATING_API_KEY`, `ENKI_WATER_SENSOR_API_KEY`). Update: [DEVELOPMENT.md](DEVELOPMENT.md) · API detail: [API.md](API.md#heating-and-water-sensors-manifest--150).
 
-Catalogue JSON : [docs/devices/README.md](./devices/README.md)
+JSON catalogue: [docs/devices/README.md](./devices/README.md)
 
-## Volets roulants — beta (Evology, Nodon, …)
+## Roller shutters — beta (Evology, Nodon, …)
 
-**Entité HA :** `cover` « Volet (beta) »
+**HA entity:** `cover` “Shutter (beta)”
 
-| Fonction | Détail |
+| Function | Detail |
 |----------|--------|
-| Ouverture / fermeture | Commandes cover HA |
+| Open / close | HA cover commands |
 | Position | 0–100 % via `change-shutter-position` |
 
-**État actuel :** clé `ENKI_ACCESS_MOTORIZATION_API_KEY` incluse (APK 2.25.1). Micro-service : `api-enki-rolling-prod` (plus `access-and-motorizations`). Entité **« Volet (beta) »** si le volet est actif dans l’app Enki.
+**Current state:** `ENKI_ACCESS_MOTORIZATION_API_KEY` included (APK 2.25.1). Micro-service: `api-enki-rolling-prod` (not `access-and-motorizations`). **“Shutter (beta)”** entity if the shutter is active in the Enki app.
 
-Retours contributeurs réseau : [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md).
+Contributor network feedback: [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md).
 
-### Pour les testeurs (volets)
+### For testers (covers)
 
-1. Mettre à jour l’intégration Enki (**v1.5.0+**) via HACS, puis redémarrer Home Assistant.
-2. Vérifier l’entité **« Volet (beta) »** sous Enki.
-3. Tester ouvrir / fermer / positionner vs l’app mobile Enki.
-4. Remonter le résultat (modèle, version HA, version intégration, extrait journaux `enki` si échec).
+1. Update the Enki integration (**v1.5.0+**) via HACS, then restart Home Assistant.
+2. Check the **“Shutter (beta)”** entity under Enki.
+3. Test open / close / position vs the Enki mobile app.
+4. Report results (model, HA version, integration version, `enki` log excerpt if it fails).
 
-## Fonctionnalités transverses
+## Cross-cutting features
 
-- **Auth OAuth** — refresh token Keycloak ; notification HA si identifiants invalides
-- **Télémétrie opt-in** — notification pour profils inconnus, lien GitHub pré-rempli (rien n’est envoyé sans clic)
-- **Notifications opérationnelles** — échec login, clé gateway 403, cloud inaccessible ([API.md](API.md#operational-notifications))
-- **Diagnostics** — export JSON anonymisé depuis l’UI Enki
+- **OAuth auth** — Keycloak refresh token; HA notification on invalid credentials
+- **Opt-in telemetry** — notification for unknown profiles, pre-filled GitHub link (nothing sent without a click)
+- **Operational notifications** — login failure, gateway key 403, cloud unreachable ([API.md](API.md#operational-notifications))
+- **Diagnostics** — anonymized JSON export from Enki UI
 
-## En cours / non supporté
+## In progress / not supported
 
-| Statut | Sujet |
+| Status | Topic |
 |--------|--------|
-| Beta | Volets, chauffage, fuite d’eau, scénarios — clés APK 2.25.1, retours bienvenus |
-| Bientôt | Radiateurs ACOVA ARLAN (même API heating si capabilities compatibles) |
-| Non planifié | Alarme Enki (pas d’API identifiée) |
-| Hors périmètre | Box Enki, appairage, compte Leroy Merlin → [support Enki](https://support.enki-home.com/) |
+| Beta | Covers, heating, water leak, scenarios — APK 2.25.1 keys, feedback welcome |
+| Soon | ACOVA ARLAN radiators (same heating API if capabilities match) |
+| Not planned | Enki alarm (no API identified) |
+| Out of scope | Enki hub, pairing, Leroy Merlin account → [Enki support](https://support.enki-home.com/) |
 
-Documentation API : [API.md](API.md)
+API documentation: [API.md](API.md)

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,43 +1,58 @@
-# Partage de profils appareils (opt-in)
+# Device profile sharing (opt-in)
 
-Aide à supporter de nouveaux matériels Enki **sans envoi automatique** et **sans secret** dans l’intégration.
+Helps support new Enki hardware **without automatic uploads** and **without secrets** in the integration.
 
-## Pour l’utilisateur
+## For users
 
-### Diagnostics (sans opt-in)
+### Diagnostics (no opt-in)
 
-**Paramètres** → **Appareils et services** → **Enki** → menu ⋮ → **Télécharger les diagnostics**
+**Settings** → **Devices & services** → **Enki** → ⋮ menu → **Download diagnostics**
 
-Export JSON local : profils anonymisés (type, fabricant, capabilities). À joindre à une [issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new) si besoin.
+Local JSON export: anonymized profiles (type, manufacturer, capabilities). Attach to an [issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new) if needed.
 
-### Opt-in (notification + issue pré-remplie)
+### Opt-in (notification + pre-filled issue)
 
-**Enki** → **Configurer** → activer :
+**Enki** → **Configure** → enable:
 
-> M’avertir des nouveaux appareils (lien issue GitHub)
+> Notify me about new devices (GitHub issue link)
 
-Quand un **nouveau** profil est détecté (empreinte unique) **et qu'il manque du support** (appareil non géré ou capabilities non implémentées) :
+When a **new** profile is detected (unique fingerprint) **and support is missing** (unsupported device or unimplemented capabilities):
 
-1. Une **notification persistante** apparaît dans Home Assistant
-2. Le lien ouvre GitHub avec titre et description **pré-remplis**
-3. Vous **validez** la création de l’issue — rien n’est envoyé sans ce clic
+1. A **persistent notification** appears in Home Assistant
+2. The link opens GitHub with a **pre-filled** title and body
+3. You **confirm** issue creation — nothing is sent without that click
 
-**Jamais inclus :** e-mail, mot de passe, homeId, nodeId, noms de pièces.
+**Never included:** email, password, homeId, nodeId, room names.
 
-**Pas de notification** si l'appareil est déjà entièrement supporté (ex. variante de ventilateur Inspire déjà couverte).
+**No notification** if the device is already fully supported (e.g. another Inspire fan variant already covered).
 
-## Pour les contributeurs
+**Also skipped (no notification, no GitHub link):** Enki hub / gateway profiles, and third-party Zigbee (Sonoff, Tuya, Aqara, …) that the integration deliberately ignores at discovery.
 
-Script local (compte requis) :
+### Enriched export
+
+Diagnostics and GitHub prefill now include extra **English** context when available:
+
+| Field | Meaning |
+|-------|---------|
+| `ha_platforms` | HA platforms that would be created (`climate`, `select`, …) |
+| `uncovered_capabilities` | Referentiel capabilities not implemented yet |
+| `api_read_errors` | Cloud read failures from the **last poll** (`heating/check_pilot_wire_state → HTTP 500`) — no node/home ids |
+| `telemetry_reason` | Why a notification was suggested |
+
+This helps reproduce cases like “entities exist but stay unavailable” without uploading full logs.
+
+## For contributors
+
+Local script (account required):
 
 ```bash
 python3 scripts/discover_devices.py <email> <password> --export
 ```
 
-Voir [DEVELOPMENT.md](DEVELOPMENT.md) pour les tests.
+See [DEVELOPMENT.md](DEVELOPMENT.md) for tests.
 
-## Technique
+## Technical
 
-- Déduplication par empreinte SHA256 (stockage local HA)
-- URL : `github.com/.../issues/new?title=...&body=...&labels=device-telemetry`
-- Aucun token, aucun `repository_dispatch`
+- Deduplication by SHA256 fingerprint (local HA storage)
+- URL: `github.com/.../issues/new?title=...&body=...&labels=device-telemetry`
+- No token, no `repository_dispatch`

--- a/docs/devices/README.md
+++ b/docs/devices/README.md
@@ -1,14 +1,14 @@
-# Profils appareils (référentiel)
+# Device profiles (referentiel)
 
-Fiches JSON anonymisées (capabilities + `possibleValues`) pour documenter des modèles Enki **sans compte ni nodeId**. Source : API referentiel ou contributions communautaires.
+Anonymized JSON sheets (capabilities + `possibleValues`) to document Enki models **without account or nodeId**. Source: referentiel API or community contributions.
 
-| Appareil | Fabricant | deviceId | Statut HA (fork) | Fiche |
+| Device | Manufacturer | deviceId | HA status (fork) | Sheet |
 |----------|-----------|----------|------------------|-------|
-| Relais ON/OFF | Equation | `63a053851a423d4a245a877c` | ✅ ON/OFF (conso / timers : non) | [JSON](./63a053851a423d4a245a877c.json) |
-| Détecteur de fuite | Lexman | `651eada55b3a798ef6b6bc5c` | 🔬 beta v1.5.0+ — fuite + batterie (clés APK 2.25.1) | [JSON](./651eada55b3a798ef6b6bc5c.json) |
-| Contrôleur fil pilote | Equation | `63a054c81a423d4a245a877e` | 🔬 beta v1.5.0+ — `select` fil pilote (clé `ENKI_HEATING_API_KEY`, APK 2.25.1) | [JSON](./63a054c81a423d4a245a877e.json) |
-| Radiateur connecté | Noirot | `67a4b12bae1eca4709a45680` | 🔬 beta v1.5.0+ — `climate` + détections (clé `ENKI_HEATING_API_KEY`, APK 2.25.1) | [JSON](./67a4b12bae1eca4709a45680.json) |
+| ON/OFF relay | Equation | `63a053851a423d4a245a877c` | ✅ ON/OFF (consumption / timers: no) | [JSON](./63a053851a423d4a245a877c.json) |
+| Water leak detector | Lexman | `651eada55b3a798ef6b6bc5c` | 🔬 beta v1.5.0+ — leak + battery (APK 2.25.1 keys) | [JSON](./651eada55b3a798ef6b6bc5c.json) |
+| Pilot wire controller | Equation | `63a054c81a423d4a245a877e` | 🔬 beta v1.5.0+ — `select` pilot wire (`ENKI_HEATING_API_KEY`, APK 2.25.1) | [JSON](./63a054c81a423d4a245a877e.json) |
+| Connected radiator | Noirot | `67a4b12bae1eca4709a45680` | 🔬 beta v1.5.0+ — `climate` + detections (`ENKI_HEATING_API_KEY`, APK 2.25.1) | [JSON](./67a4b12bae1eca4709a45680.json) |
 
-Profils importés depuis [StephaneBranly/ha-enki#15](https://github.com/StephaneBranly/ha-enki/pull/15) (contribution [@zetiti10](https://github.com/zetiti10)). Périmètre **Enki / Leroy Merlin uniquement** — pas de Zigbee tiers (→ Zigbee2MQTT / ZHA).
+Profiles imported from [StephaneBranly/ha-enki#15](https://github.com/StephaneBranly/ha-enki/pull/15) (contribution [@zetiti10](https://github.com/zetiti10)). **Enki / Leroy Merlin scope only** — no third-party Zigbee (→ Zigbee2MQTT / ZHA).
 
-Pour proposer un nouveau profil : télémétrie opt-in dans HA, [issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=feature_request.yml), ou PR avec un JSON dans ce dossier.
+To propose a new profile: opt-in telemetry in HA, [issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=feature_request.yml), or PR with a JSON file in this folder.

--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -21,9 +21,11 @@ from enki_bootstrap import bootstrap_api_client, load_module  # noqa: E402
 
 client_mod = bootstrap_api_client()
 profile_mod = load_module("enki.domain.profile")
+enrichment_mod = load_module("enki.domain.telemetry_enrichment")
 EnkiAPI = client_mod.EnkiAPI
 profile_fingerprint = profile_mod.profile_fingerprint
 profile_to_export_dict = profile_mod.profile_to_export_dict
+enrich_telemetry_export = enrichment_mod.enrich_telemetry_export
 
 
 async def main(username: str, password: str, export: bool) -> None:
@@ -31,14 +33,21 @@ async def main(username: str, password: str, export: bool) -> None:
     await api.async_connect()
     await api.async_get_devices()
 
-    profiles = [
-        profile_to_export_dict(
+    profiles = []
+    for record in api.discovery_records:
+        export = profile_to_export_dict(
             record,
             integration_version="dev",
             ha_version="n/a",
         )
-        for record in api.discovery_records
-    ]
+        fingerprint = profile_fingerprint(export)
+        profiles.append(
+            enrich_telemetry_export(
+                export,
+                record,
+                api_read_errors=api.read_errors_for_fingerprint(fingerprint) or None,
+            )
+        )
 
     if export:
         print(json.dumps(profiles, indent=2, sort_keys=True))

--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -28,28 +28,28 @@ profile_to_export_dict = profile_mod.profile_to_export_dict
 enrich_telemetry_export = enrichment_mod.enrich_telemetry_export
 
 
-async def main(username: str, password: str, export: bool) -> None:
+async def main(username: str, password: str, export_json: bool) -> None:
     api = EnkiAPI(username, password)
     await api.async_connect()
     await api.async_get_devices()
 
     profiles = []
     for record in api.discovery_records:
-        export = profile_to_export_dict(
+        profile_export = profile_to_export_dict(
             record,
             integration_version="dev",
             ha_version="n/a",
         )
-        fingerprint = profile_fingerprint(export)
+        fingerprint = profile_fingerprint(profile_export)
         profiles.append(
             enrich_telemetry_export(
-                export,
+                profile_export,
                 record,
                 api_read_errors=api.read_errors_for_fingerprint(fingerprint) or None,
             )
         )
 
-    if export:
+    if export_json:
         print(json.dumps(profiles, indent=2, sort_keys=True))
     else:
         for profile in profiles:

--- a/tests/unit/test_device_profile.py
+++ b/tests/unit/test_device_profile.py
@@ -48,7 +48,7 @@ def test_profile_fingerprint_stable_across_versions() -> None:
 
 def test_format_github_issue_title_unsupported() -> None:
     export = profile_to_export_dict(_sample_record(), integration_version="1.0.7", ha_version="x")
-    assert "non supporté" in format_github_issue_title(export)
+    assert "Unsupported device" in format_github_issue_title(export)
 
 
 def test_build_github_new_issue_url_contains_repo_and_body() -> None:

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -155,6 +155,50 @@ async def test_telemetry_skips_out_of_scope_sonoff() -> None:
 
 
 @pytest.mark.asyncio
+async def test_telemetry_notifies_when_api_errors_appear_after_fingerprint_stored() -> None:
+    hass = MagicMock()
+    hass.config.version = "2024.12.0"
+    entry = _entry_with_coordinator(telemetry=True)
+
+    record = build_discovery_record(
+        device_type="heaters_and_pilot_wires",
+        bff_device_type="heaters_and_pilot_wires",
+        capabilities=[
+            "change_thermostat_target_temperature",
+            "check_thermostat_target_temperature",
+        ],
+        possible_values={},
+        manufacturer="Noirot",
+        model="radiator",
+        firmware_version="2.15.0",
+        supported_by_integration=True,
+    )
+
+    reporter = EnkiTelemetryReporter(hass, entry)
+    reporter._store.async_load = AsyncMock(
+        return_value={"fingerprints": ["already-known-fp"]}
+    )  # type: ignore[method-assign]
+    reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    from enki.domain.profile import profile_fingerprint, profile_to_export_dict
+
+    export = profile_to_export_dict(record, integration_version="1.6.6", ha_version="2025.1")
+    fingerprint = profile_fingerprint(export)
+    reporter._store.async_load = AsyncMock(return_value={"fingerprints": [fingerprint]})  # type: ignore[method-assign]
+
+    entry.runtime_data.api.read_errors_for_fingerprint.return_value = {
+        "heating/check_thermostat_target_temperature": "HTTP 500",
+    }
+
+    with patch(
+        "enki.telemetry.reporter.persistent_notification.async_create",
+        new_callable=MagicMock,
+    ) as notify:
+        await reporter.async_report([record])
+        notify.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_telemetry_tolerates_corrupt_storage() -> None:
     hass = MagicMock()
     hass.config.version = "2024.12.0"

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -23,13 +23,20 @@ def _record():
     )
 
 
+def _entry_with_coordinator(*, telemetry: bool) -> MagicMock:
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    entry.options = {CONF_TELEMETRY: telemetry}
+    entry.runtime_data = MagicMock()
+    entry.runtime_data.api.read_errors_for_fingerprint.return_value = {}
+    return entry
+
+
 @pytest.mark.asyncio
 async def test_telemetry_skipped_when_disabled() -> None:
     hass = MagicMock()
     hass.config.version = "2024.12.0"
-    entry = MagicMock()
-    entry.entry_id = "entry1"
-    entry.options = {CONF_TELEMETRY: False}
+    entry = _entry_with_coordinator(telemetry=False)
 
     reporter = EnkiTelemetryReporter(hass, entry)
     with patch(
@@ -44,9 +51,7 @@ async def test_telemetry_skipped_when_disabled() -> None:
 async def test_telemetry_notifies_new_profile() -> None:
     hass = MagicMock()
     hass.config.version = "2024.12.0"
-    entry = MagicMock()
-    entry.entry_id = "entry1"
-    entry.options = {CONF_TELEMETRY: True}
+    entry = _entry_with_coordinator(telemetry=True)
 
     reporter = EnkiTelemetryReporter(hass, entry)
     reporter._store.async_load = AsyncMock(return_value={"fingerprints": []})  # type: ignore[method-assign]
@@ -68,9 +73,7 @@ async def test_telemetry_notifies_new_profile() -> None:
 async def test_telemetry_dedupes_fingerprint() -> None:
     hass = MagicMock()
     hass.config.version = "2024.12.0"
-    entry = MagicMock()
-    entry.entry_id = "entry1"
-    entry.options = {CONF_TELEMETRY: True}
+    entry = _entry_with_coordinator(telemetry=True)
 
     reporter = EnkiTelemetryReporter(hass, entry)
     reporter._store.async_load = AsyncMock(return_value={"fingerprints": []})  # type: ignore[method-assign]
@@ -89,9 +92,7 @@ async def test_telemetry_dedupes_fingerprint() -> None:
 async def test_telemetry_skips_fully_supported_profile() -> None:
     hass = MagicMock()
     hass.config.version = "2024.12.0"
-    entry = MagicMock()
-    entry.entry_id = "entry1"
-    entry.options = {CONF_TELEMETRY: True}
+    entry = _entry_with_coordinator(telemetry=True)
 
     record = build_discovery_record(
         device_type="ceiling_fans",
@@ -125,13 +126,40 @@ async def test_telemetry_skips_fully_supported_profile() -> None:
 
 
 @pytest.mark.asyncio
+async def test_telemetry_skips_out_of_scope_sonoff() -> None:
+    hass = MagicMock()
+    hass.config.version = "2024.12.0"
+    entry = _entry_with_coordinator(telemetry=True)
+
+    record = build_discovery_record(
+        device_type="sensors",
+        bff_device_type="sensors",
+        capabilities=["check_current_temperature"],
+        possible_values={},
+        manufacturer="Sonoff",
+        model="SNZB-02D",
+        firmware_version=None,
+        supported_by_integration=False,
+    )
+
+    reporter = EnkiTelemetryReporter(hass, entry)
+    reporter._store.async_load = AsyncMock(return_value={"fingerprints": []})  # type: ignore[method-assign]
+    reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    with patch(
+        "enki.telemetry.reporter.persistent_notification.async_create",
+        new_callable=MagicMock,
+    ) as notify:
+        await reporter.async_report([record])
+        notify.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_telemetry_tolerates_corrupt_storage() -> None:
     hass = MagicMock()
     hass.config.version = "2024.12.0"
     hass.config.language = "en"
-    entry = MagicMock()
-    entry.entry_id = "entry1"
-    entry.options = {CONF_TELEMETRY: True}
+    entry = _entry_with_coordinator(telemetry=True)
 
     reporter = EnkiTelemetryReporter(hass, entry)
     reporter._store.async_load = AsyncMock(return_value={"fingerprints": None})  # type: ignore[method-assign]

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -175,9 +175,7 @@ async def test_telemetry_notifies_when_api_errors_appear_after_fingerprint_store
     )
 
     reporter = EnkiTelemetryReporter(hass, entry)
-    reporter._store.async_load = AsyncMock(
-        return_value={"fingerprints": ["already-known-fp"]}
-    )  # type: ignore[method-assign]
+    reporter._store.async_load = AsyncMock(return_value={"fingerprints": ["already-known-fp"]})  # type: ignore[method-assign]
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     from enki.domain.profile import profile_fingerprint, profile_to_export_dict

--- a/tests/unit/test_telemetry_coverage.py
+++ b/tests/unit/test_telemetry_coverage.py
@@ -86,3 +86,31 @@ def test_admin_capabilities_are_ignored() -> None:
     profile = profile_from_record(_ceiling_fan_record())
     assert capability_is_covered("ota_inventory", profile) is True
     assert capability_is_covered("change_esdk_certificate", profile) is True
+
+
+def test_sonoff_profile_not_eligible_for_telemetry() -> None:
+    record = build_discovery_record(
+        device_type="sensors",
+        bff_device_type="sensors",
+        capabilities=["check_current_temperature"],
+        possible_values={},
+        manufacturer="Sonoff",
+        model="SNZB-02D",
+        firmware_version="1.0.0",
+        supported_by_integration=False,
+    )
+    assert discovery_record_needs_telemetry(record) is False
+
+
+def test_gateway_profile_not_eligible_for_telemetry() -> None:
+    record = build_discovery_record(
+        device_type="gateways",
+        bff_device_type="gateways",
+        capabilities=["gateway_reboot", "gateway_inventory", "check_gateway_state"],
+        possible_values={},
+        manufacturer="Enki",
+        model="EnkiConnectGW001",
+        firmware_version="2.0.0",
+        supported_by_integration=False,
+    )
+    assert discovery_record_needs_telemetry(record) is False

--- a/tests/unit/test_telemetry_enrichment.py
+++ b/tests/unit/test_telemetry_enrichment.py
@@ -1,0 +1,68 @@
+"""Unit tests for telemetry enrichment."""
+
+from __future__ import annotations
+
+from enki.domain.profile import (
+    build_discovery_record,
+    format_github_issue_body,
+    profile_to_export_dict,
+)
+from enki.domain.telemetry_coverage import discovery_record_needs_telemetry
+from enki.domain.telemetry_enrichment import enrich_telemetry_export
+
+
+def _noirot_record():
+    return build_discovery_record(
+        device_type="heaters_and_pilot_wires",
+        bff_device_type="heaters_and_pilot_wires",
+        capabilities=[
+            "change_thermostat_target_temperature",
+            "check_thermostat_target_temperature",
+            "check_thermostat_running_state",
+            "check_window_open_detection",
+            "total_supply_charge_consumption",
+        ],
+        possible_values={},
+        manufacturer="Noirot",
+        model="radiator",
+        firmware_version="2.15.0",
+        supported_by_integration=True,
+    )
+
+
+def test_noirot_profile_does_not_need_telemetry_without_api_errors() -> None:
+    record = _noirot_record()
+    assert discovery_record_needs_telemetry(record) is False
+
+
+def test_supported_profile_needs_telemetry_when_api_errors_present() -> None:
+    record = _noirot_record()
+    errors = {"heating/check_thermostat_target_temperature": "HTTP 500"}
+    assert discovery_record_needs_telemetry(record, api_read_errors=errors) is True
+
+
+def test_enrich_export_includes_platforms_and_api_errors() -> None:
+    record = _noirot_record()
+    export = profile_to_export_dict(record, integration_version="1.6.5", ha_version="2025.1")
+    enriched = enrich_telemetry_export(
+        export,
+        record,
+        api_read_errors={"heating/check_thermostat_target_temperature": "HTTP 500"},
+    )
+    assert "climate" in enriched["ha_platforms"]
+    assert enriched["telemetry_reason"] == "api_read_errors"
+    assert "HTTP 500" in enriched["api_read_errors"]["heating/check_thermostat_target_temperature"]
+
+
+def test_github_issue_body_is_english_and_includes_api_errors() -> None:
+    record = _noirot_record()
+    export = enrich_telemetry_export(
+        profile_to_export_dict(record, integration_version="1.6.5", ha_version="2025.1"),
+        record,
+        api_read_errors={"heating/check_thermostat_target_temperature": "HTTP 500"},
+    )
+    body = format_github_issue_body(export, "abc123")
+    assert "Referentiel type:" in body
+    assert "API read errors (last poll)" in body
+    assert "HTTP 500" in body
+    assert "Profil appareil" not in body


### PR DESCRIPTION
## Summary

- Enriched opt-in telemetry: diagnostics and pre-filled GitHub issues now include `ha_platforms`, `uncovered_capabilities`, `api_read_errors` (last poll, no node/home ids), and `telemetry_reason`.
- Supported devices that hit cloud read errors on poll (e.g. heating HTTP 500) can trigger a telemetry notification, including when the profile fingerprint was already stored.
- Filtered out telemetry noise for Enki hub profiles and out-of-scope Zigbee (Sonoff, Tuya, …).
- Translated GitHub-facing docs and telemetry issue prefill to English (HA UI translations unchanged).
- Fixed `discover_devices.py` CLI flag shadowing and telemetry dedup skipping API-error re-notifications.

## Type

- [x] Feature
- [x] Docs / tooling

## Version

`manifest.json` → **1.6.6**

## Test plan

- [x] `ruff check .` and `ruff format --check .`
- [x] `pytest tests/unit` (134 passed)