### PR TITLE
fix: gateway keys + last_poll_state telemetry (v1.6.7)

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -15,6 +15,7 @@ from ..domain.profile import (
     integration_supports_device,
     profile_fingerprint,
     profile_to_export_dict,
+    sanitize_poll_state,
 )
 from ..exceptions import EnkiApiNotFoundError, EnkiConnectionError
 from ..lib.bff import parse_bff_power
@@ -52,6 +53,7 @@ class EnkiAPI:
         self._scenarios: tuple[EnkiScenario, ...] = ()
         self._node_fingerprints: dict[str, str] = {}
         self._profile_read_errors: dict[str, dict[str, str]] = {}
+        self._profile_poll_state: dict[str, dict[str, Any]] = {}
 
     async def async_close(self) -> None:
         """Close the underlying HTTP session."""
@@ -101,6 +103,7 @@ class EnkiAPI:
         self._discovery_records = []
         self._node_fingerprints.clear()
         self._profile_read_errors.clear()
+        self._profile_poll_state.clear()
         for home_id in homes:
             home_devices, records = await self._discover_home(http, home_id)
             devices.extend(home_devices)
@@ -115,9 +118,21 @@ class EnkiAPI:
         """Anonymized API read failures from the last poll (no node or home ids)."""
         return dict(self._profile_read_errors.get(fingerprint, {}))
 
+    def poll_state_for_fingerprint(self, fingerprint: str) -> dict[str, Any]:
+        """Anonymized state values merged from the last poll (no node or home ids)."""
+        return dict(self._profile_poll_state.get(fingerprint, {}))
+
     def _register_node_profile(self, node_id: str, record: EnkiDiscoveryRecord) -> None:
         export = profile_to_export_dict(record, integration_version="", ha_version="")
         self._node_fingerprints[node_id] = profile_fingerprint(export)
+
+    def _register_poll_state(self, node_id: str, state: dict[str, Any]) -> None:
+        fingerprint = self._node_fingerprints.get(node_id)
+        if not fingerprint:
+            return
+        sanitized = sanitize_poll_state(state)
+        if sanitized:
+            self._profile_poll_state[fingerprint] = sanitized
 
     def _note_read_error(
         self,
@@ -293,6 +308,8 @@ class EnkiAPI:
         last_reported: dict[str, Any] = {}
         if item.get("isEnabled", True):
             last_reported = await self._refresh_device_state(http, skeleton, node_info)
+
+        self._register_poll_state(node_id, {**node_info, **last_reported})
 
         if not supported:
             LOGGER.debug(

--- a/custom_components/enki/diagnostics.py
+++ b/custom_components/enki/diagnostics.py
@@ -37,6 +37,7 @@ async def async_get_config_entry_diagnostics(
                 export,
                 record,
                 api_read_errors=coordinator.api.read_errors_for_fingerprint(fingerprint) or None,
+                last_poll_state=coordinator.api.poll_state_for_fingerprint(fingerprint) or None,
             )
         )
 

--- a/custom_components/enki/domain/profile.py
+++ b/custom_components/enki/domain/profile.py
@@ -33,6 +33,89 @@ _SENSITIVE_STATE_KEYS = frozenset(
     }
 )
 
+# Integration state keys safe to export in telemetry (no account/home/node ids).
+_POLL_STATE_EXPORT_KEYS = frozenset(
+    {
+        "fan_speed",
+        "airflow_mode",
+        "airflow_rotation",
+        "airflow_rotation_supported",
+        "light_power",
+        "power",
+        "electrical_power",
+        "electrical_consumption",
+        "electrical_consumption_unit",
+        "brightness",
+        "colorTemperature",
+        "hue",
+        "saturation",
+        "colorMode",
+        "power_production",
+        "shutter_position",
+        "shutter_opening",
+        "current_temperature",
+        "current_humidity",
+        "illuminance_level",
+        "battery_health",
+        "motion_detection",
+        "motion_detector_state",
+        "vibration_detection",
+        "contact_sensor_state",
+        "vibration_detection_activation",
+        "contact_detection_activation",
+        "vibration_sensibility_level",
+        "siren_global_state",
+        "water_sensor_state",
+        "pilot_wire_state",
+        "thermostat_target_temperature",
+        "thermostat_running_state",
+        "window_open_detection",
+        "window_open_detection_mode",
+        "occupancy",
+        "occupancy_mode",
+        "electrical_endpoints",
+    }
+)
+
+
+def _sanitize_endpoint(endpoint: dict[str, Any]) -> dict[str, Any] | None:
+    endpoint_id = endpoint.get("id")
+    if endpoint_id is None:
+        return None
+    last_reported = endpoint.get("lastReportedValue")
+    if isinstance(last_reported, str):
+        return {"id": endpoint_id, "power": last_reported}
+    if isinstance(last_reported, dict):
+        allowed = {"power", "brightness", "colorTemperature", "hue", "saturation"}
+        filtered = {
+            key: value
+            for key, value in last_reported.items()
+            if key in allowed and isinstance(value, (str, int, float))
+        }
+        if filtered:
+            return {"id": endpoint_id, **filtered}
+    return {"id": endpoint_id}
+
+
+def sanitize_poll_state(raw: dict[str, Any] | None) -> dict[str, Any]:
+    """Return anonymized last-poll values for diagnostics and GitHub prefill."""
+    if not isinstance(raw, dict):
+        return {}
+    sanitized: dict[str, Any] = {}
+    for key in _POLL_STATE_EXPORT_KEYS:
+        if key not in raw:
+            continue
+        value = raw[key]
+        if key == "electrical_endpoints" and isinstance(value, list):
+            endpoints = [_sanitize_endpoint(item) for item in value if isinstance(item, dict)]
+            endpoints = [item for item in endpoints if item]
+            if endpoints:
+                sanitized[key] = endpoints
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            sanitized[key] = value
+    return sanitized
+
 
 def _sanitize_possible_values(values: dict[str, Any]) -> dict[str, Any]:
     sanitized: dict[str, Any] = {}
@@ -147,6 +230,12 @@ def format_github_issue_body(export_dict: dict[str, Any], fingerprint: str) -> s
     if uncovered := export_dict.get("uncovered_capabilities"):
         uncovered_lines = "\n".join(f"- `{capability}`" for capability in uncovered)
         body += f"\n### Uncovered capabilities\n{uncovered_lines}\n"
+
+    if poll_state := export_dict.get("last_poll_state"):
+        body += (
+            "\n### Last poll state (anonymized)\n"
+            f"```json\n{json.dumps(poll_state, indent=2, sort_keys=True)}\n```\n"
+        )
 
     if api_errors := export_dict.get("api_read_errors"):
         error_lines = "\n".join(

--- a/custom_components/enki/domain/telemetry_enrichment.py
+++ b/custom_components/enki/domain/telemetry_enrichment.py
@@ -77,6 +77,7 @@ def enrich_telemetry_export(
     record: EnkiDiscoveryRecord,
     *,
     api_read_errors: dict[str, str] | None = None,
+    last_poll_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Add non-fingerprint fields for diagnostics and GitHub prefill."""
     profile = profile_from_record(record)
@@ -88,6 +89,9 @@ def enrich_telemetry_export(
     missing = uncovered_capabilities(record)
     if missing:
         enriched["uncovered_capabilities"] = missing
+
+    if last_poll_state:
+        enriched["last_poll_state"] = dict(sorted(last_poll_state.items()))
 
     if api_read_errors:
         enriched["api_read_errors"] = dict(sorted(api_read_errors.items()))

--- a/custom_components/enki/gateway_keys_data.py
+++ b/custom_components/enki/gateway_keys_data.py
@@ -3,7 +3,9 @@
 Do not edit manually — refresh with:
     python scripts/extract_gateway_keys.py path/to/enki.apk --apply --update-known
 
-Source APK: Enki 2.25.1
+Source APK: Enki 2.25.1 (most keys). POWER and AIRFLOW verified against live
+api-enki-power-prod / api-enki-airflow-prod traffic (APK 2.25.1 extractor
+misassigned those two slugs — see #45).
 """
 
 # Wired micro-services (used by the integration today).
@@ -12,8 +14,8 @@ ENKI_BFF_API_KEY = "Bco7qBHRHOQiSVcEHdgS0rijpebMBwkB"
 ENKI_NODE_API_KEY = "UBb0Kv6xXpG6bOvD8VZ9A63uxqQ4G1A3"
 ENKI_REFERENTIEL_API_KEY = "3uk9rlaIUgBsz1tEPV7GQMhhGfRwPFJY"
 ENKI_LIGHTS_API_KEY = "3OVsNulRsUXfr7Hze54OHx8l6qDu2UcE"
-ENKI_POWER_API_KEY = "PCnbndkIqlfXwXGhFkqSWWMn4HcWza9J"
-ENKI_AIRFLOW_API_KEY = "L7nSeH7MOgxOCz0HpysKmOI3PQMM8SDV"
+ENKI_POWER_API_KEY = "DZ9MSuTT7sQxJWxxkBokAGvIt57qVl9N"
+ENKI_AIRFLOW_API_KEY = "hder4GeBrdbzQlV2R22dm2a9pbfTTHPj"
 ENKI_TEMPERATURE_HUMIDITY_API_KEY = "5Oqfse9MTtAWdfxwhlSPrOVO4gwqfgku"
 ENKI_BATTERY_HEALTH_API_KEY = "4o6CgR2B5fsq8eJw3VUk1GDs02Y6zKO3"
 ENKI_PRESENCE_DETECTOR_API_KEY = "b5A3sQcYHpRta3SqGXwH9T9GNaNHpj96"

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.6"
+  "version": "1.6.7"
 }

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -56,10 +56,12 @@ class EnkiTelemetryReporter:
                 )
                 fingerprint = profile_fingerprint(export_dict)
                 api_errors = coordinator.api.read_errors_for_fingerprint(fingerprint)
+                poll_state = coordinator.api.poll_state_for_fingerprint(fingerprint)
                 export_dict = enrich_telemetry_export(
                     export_dict,
                     record,
                     api_read_errors=api_errors or None,
+                    last_poll_state=poll_state or None,
                 )
             except (TypeError, ValueError) as err:
                 LOGGER.warning(

--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -46,6 +46,7 @@ async def main(username: str, password: str, export_json: bool) -> None:
                 profile_export,
                 record,
                 api_read_errors=api.read_errors_for_fingerprint(fingerprint) or None,
+                last_poll_state=api.poll_state_for_fingerprint(fingerprint) or None,
             )
         )
 

--- a/tests/unit/test_gateway_keys.py
+++ b/tests/unit/test_gateway_keys.py
@@ -66,3 +66,13 @@ def test_gateway_key_store_does_not_override_filled_const(monkeypatch) -> None:
     payload = {"api-enki-home-prod": "f" * 32}
     store.apply_mobile_config(payload)
     assert keys_module.ENKI_HOME_API_KEY == "existing-home-key-0123456789012"
+
+
+def test_wired_fan_and_power_keys_match_live_traffic() -> None:
+    """Regression: APK 2.25.1 extractor misassigned power/airflow (#45)."""
+    import enki.gateway_keys_data as keys_module
+
+    store = GatewayKeyStore()
+    assert store.get_transport_key("airflow") == "hder4GeBrdbzQlV2R22dm2a9pbfTTHPj"
+    assert store.get_transport_key("power") == "DZ9MSuTT7sQxJWxxkBokAGvIt57qVl9N"
+    assert keys_module.ENKI_LIGHTS_API_KEY == "3OVsNulRsUXfr7Hze54OHx8l6qDu2UcE"

--- a/tests/unit/test_poll_state.py
+++ b/tests/unit/test_poll_state.py
@@ -1,0 +1,37 @@
+"""Unit tests for anonymized last-poll state export."""
+
+from __future__ import annotations
+
+from enki.domain.profile import sanitize_poll_state
+
+
+def test_sanitize_poll_state_strips_identifiers() -> None:
+    raw = {
+        "node_id": "secret-node",
+        "homeId": "secret-home",
+        "fan_speed": 3,
+        "airflow_mode": "MANUAL",
+        "light_power": "ON",
+        "brightness": 0.5,
+    }
+    assert sanitize_poll_state(raw) == {
+        "airflow_mode": "MANUAL",
+        "brightness": 0.5,
+        "fan_speed": 3,
+        "light_power": "ON",
+    }
+
+
+def test_sanitize_poll_state_redacts_endpoint_payload() -> None:
+    raw = {
+        "electrical_endpoints": [
+            {"id": 1, "lastReportedValue": "ON", "nodeId": "secret"},
+            {"id": 2, "lastReportedValue": {"power": "OFF", "brightness": 0.2}},
+        ]
+    }
+    assert sanitize_poll_state(raw) == {
+        "electrical_endpoints": [
+            {"id": 1, "power": "ON"},
+            {"id": 2, "power": "OFF", "brightness": 0.2},
+        ]
+    }

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -29,6 +29,7 @@ def _entry_with_coordinator(*, telemetry: bool) -> MagicMock:
     entry.options = {CONF_TELEMETRY: telemetry}
     entry.runtime_data = MagicMock()
     entry.runtime_data.api.read_errors_for_fingerprint.return_value = {}
+    entry.runtime_data.api.poll_state_for_fingerprint.return_value = {}
     return entry
 
 

--- a/tests/unit/test_telemetry_enrichment.py
+++ b/tests/unit/test_telemetry_enrichment.py
@@ -48,10 +48,12 @@ def test_enrich_export_includes_platforms_and_api_errors() -> None:
         export,
         record,
         api_read_errors={"heating/check_thermostat_target_temperature": "HTTP 500"},
+        last_poll_state={"thermostat_target_temperature": 21.0},
     )
     assert "climate" in enriched["ha_platforms"]
     assert enriched["telemetry_reason"] == "api_read_errors"
     assert "HTTP 500" in enriched["api_read_errors"]["heating/check_thermostat_target_temperature"]
+    assert enriched["last_poll_state"]["thermostat_target_temperature"] == 21.0
 
 
 def test_github_issue_body_is_english_and_includes_api_errors() -> None:
@@ -60,9 +62,12 @@ def test_github_issue_body_is_english_and_includes_api_errors() -> None:
         profile_to_export_dict(record, integration_version="1.6.5", ha_version="2025.1"),
         record,
         api_read_errors={"heating/check_thermostat_target_temperature": "HTTP 500"},
+        last_poll_state={"thermostat_target_temperature": 21.0},
     )
     body = format_github_issue_body(export, "abc123")
     assert "Referentiel type:" in body
+    assert "Last poll state (anonymized)" in body
+    assert "thermostat_target_temperature" in body
     assert "API read errors (last poll)" in body
     assert "HTTP 500" in body
     assert "Profil appareil" not in body


### PR DESCRIPTION
## Summary

- Restore **power** and **airflow** gateway keys that were misassigned by the APK 2.25.1 extractor — fixes HTTP 403 on fans, relays, and other power-prod devices (#45, #35).
- Export **`last_poll_state`** in diagnostics and GitHub telemetry prefill: anonymized values from the last poll (`fan_speed`, `light_power`, heating state, endpoints, …) alongside existing `api_read_errors`.

## Type

- [x] Bug fix
- [x] Feature (telemetry)

## Version

`manifest.json` → **1.6.7**

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest tests/unit` passes (137 tests)

## Related issues

Fixes #45

## Test plan

- [ ] Update to 1.6.7 via HACS, restart HA
- [ ] Inspire AD_TCFL_1: fan speed/mode reads OK, no 403 in logs
- [ ] Equation ON/OFF relay: switch state and commands work
- [ ] Opt-in telemetry / diagnostics: `last_poll_state` + `api_read_errors` both present when reads fail partially