### PR TITLE
fix: stop redundant telemetry notifications on working devices

### DIFF
--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -198,9 +198,7 @@ def api_read_errors_need_telemetry(
         if not _poll_state_has_key(poll_state, state_key):
             return True
 
-    if saw_unknown_error and not poll_state:
-        return True
-    return False
+    return bool(saw_unknown_error and not poll_state)
 
 
 def discovery_record_needs_telemetry(
@@ -223,11 +221,11 @@ def discovery_record_needs_telemetry(
         if not capability_is_covered(capability, profile):
             return True
 
-    if api_read_errors and api_read_errors_need_telemetry(
-        record,
-        api_read_errors,
-        poll_state,
-    ):
-        return True
-
-    return False
+    return bool(
+        api_read_errors
+        and api_read_errors_need_telemetry(
+            record,
+            api_read_errors,
+            poll_state,
+        )
+    )

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+from ..api.capability_routing import CAPABILITY_READS
 from ..lib.enki_scope import device_in_enki_scope
 from .capabilities import EnkiCapabilityProfile
 from .models import EnkiDiscoveryRecord
@@ -91,6 +94,29 @@ _GATEWAY_CAPABILITY_MARKERS = frozenset(
     }
 )
 
+# Poll keys for optional sensors — API read failures alone should not nag the user.
+_OPTIONAL_POLL_STATE_KEYS = frozenset(
+    {
+        "electrical_consumption",
+        "electrical_consumption_unit",
+    }
+)
+
+_CAPABILITY_TO_POLL_STATE_KEY: dict[str, str] = {
+    read.capability: read.state_key for read in CAPABILITY_READS
+}
+_CAPABILITY_TO_POLL_STATE_KEY.update(
+    {
+        "check_electrical_power": "electrical_power",
+        "check_electrical_consumption": "electrical_consumption",
+    }
+)
+
+_ALTERNATE_POLL_STATE_KEYS: dict[str, tuple[str, ...]] = {
+    "electrical_power": ("power",),
+    "power": ("electrical_power",),
+}
+
 
 def profile_from_record(record: EnkiDiscoveryRecord) -> EnkiCapabilityProfile:
     return EnkiCapabilityProfile(
@@ -134,17 +160,58 @@ def discovery_record_eligible_for_telemetry(record: EnkiDiscoveryRecord) -> bool
     return not (caps and any(cap in _GATEWAY_CAPABILITY_MARKERS for cap in caps))
 
 
+def _poll_state_has_key(poll_state: dict[str, Any], state_key: str) -> bool:
+    if state_key in poll_state:
+        return True
+    for alternate in _ALTERNATE_POLL_STATE_KEYS.get(state_key, ()):
+        if alternate in poll_state:
+            return True
+    return False
+
+
+def api_read_errors_need_telemetry(
+    record: EnkiDiscoveryRecord,
+    api_read_errors: dict[str, str],
+    poll_state: dict[str, Any] | None,
+) -> bool:
+    """Return True when API read failures likely mean broken primary entities."""
+    if not api_read_errors:
+        return False
+
+    poll_state = poll_state or {}
+    profile = profile_from_record(record)
+    saw_unknown_error = False
+
+    for error_key in api_read_errors:
+        capability = error_key.split("/", 1)[-1]
+        if capability in NOT_PLANNED_CAPABILITIES:
+            continue
+        if not capability_is_covered(capability, profile):
+            continue
+
+        state_key = _CAPABILITY_TO_POLL_STATE_KEY.get(capability)
+        if state_key is None:
+            saw_unknown_error = True
+            continue
+        if state_key in _OPTIONAL_POLL_STATE_KEYS:
+            continue
+        if not _poll_state_has_key(poll_state, state_key):
+            return True
+
+    if saw_unknown_error and not poll_state:
+        return True
+    return False
+
+
 def discovery_record_needs_telemetry(
     record: EnkiDiscoveryRecord,
     *,
     api_read_errors: dict[str, str] | None = None,
+    poll_state: dict[str, Any] | None = None,
 ) -> bool:
     """Return True when the user should be nudged to open a GitHub issue."""
     if not discovery_record_eligible_for_telemetry(record):
         return False
-
-    if api_read_errors:
-        return True
 
     if not record.supported_by_integration:
         return True
@@ -155,4 +222,12 @@ def discovery_record_needs_telemetry(
             continue
         if not capability_is_covered(capability, profile):
             return True
+
+    if api_read_errors and api_read_errors_need_telemetry(
+        record,
+        api_read_errors,
+        poll_state,
+    ):
+        return True
+
     return False

--- a/custom_components/enki/domain/telemetry_enrichment.py
+++ b/custom_components/enki/domain/telemetry_enrichment.py
@@ -8,6 +8,7 @@ from .capabilities import EnkiCapabilityProfile
 from .models import EnkiDiscoveryRecord
 from .telemetry_coverage import (
     NOT_PLANNED_CAPABILITIES,
+    api_read_errors_need_telemetry,
     capability_is_covered,
     discovery_record_eligible_for_telemetry,
     profile_from_record,
@@ -59,16 +60,21 @@ def telemetry_notification_reason(
     record: EnkiDiscoveryRecord,
     *,
     api_read_errors: dict[str, str] | None = None,
+    poll_state: dict[str, Any] | None = None,
 ) -> str | None:
     """Short English reason why a telemetry notification would fire."""
     if not discovery_record_eligible_for_telemetry(record):
         return None
-    if api_read_errors:
-        return "api_read_errors"
     if not record.supported_by_integration:
         return "unsupported_device"
     if uncovered_capabilities(record):
         return "uncovered_capabilities"
+    if api_read_errors and api_read_errors_need_telemetry(
+        record,
+        api_read_errors,
+        poll_state,
+    ):
+        return "api_read_errors"
     return None
 
 
@@ -96,7 +102,11 @@ def enrich_telemetry_export(
     if api_read_errors:
         enriched["api_read_errors"] = dict(sorted(api_read_errors.items()))
 
-    reason = telemetry_notification_reason(record, api_read_errors=api_read_errors)
+    reason = telemetry_notification_reason(
+        record,
+        api_read_errors=api_read_errors,
+        poll_state=last_poll_state,
+    )
     if reason:
         enriched["telemetry_reason"] = reason
 

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.8"
+  "version": "1.6.9"
 }

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -74,10 +74,12 @@ class EnkiTelemetryReporter:
             needs_telemetry = discovery_record_needs_telemetry(
                 record,
                 api_read_errors=api_errors,
+                poll_state=poll_state,
             )
 
-            # Re-notify when API read errors appear on a profile seen earlier.
-            if fingerprint in reported and not (needs_telemetry and api_errors):
+            if fingerprint in reported:
+                if not needs_telemetry:
+                    self._dismiss_profile_notification(fingerprint)
                 continue
 
             if fingerprint not in reported:
@@ -96,6 +98,12 @@ class EnkiTelemetryReporter:
         LOGGER.info(
             "Notified about %s new Enki device profile(s) (opt-in telemetry)",
             new_count,
+        )
+
+    def _dismiss_profile_notification(self, fingerprint: str) -> None:
+        persistent_notification.async_dismiss(
+            self._hass,
+            notification_id=f"{DOMAIN}_profile_{fingerprint[:16]}",
         )
 
     def _notify_new_profile(self, export_dict: dict[str, Any], fingerprint: str) -> None:

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -156,7 +156,7 @@ async def test_telemetry_skips_out_of_scope_sonoff() -> None:
 
 
 @pytest.mark.asyncio
-async def test_telemetry_notifies_when_api_errors_appear_after_fingerprint_stored() -> None:
+async def test_telemetry_notifies_when_api_errors_block_primary_poll() -> None:
     hass = MagicMock()
     hass.config.version = "2024.12.0"
     entry = _entry_with_coordinator(telemetry=True)
@@ -176,7 +176,48 @@ async def test_telemetry_notifies_when_api_errors_appear_after_fingerprint_store
     )
 
     reporter = EnkiTelemetryReporter(hass, entry)
-    reporter._store.async_load = AsyncMock(return_value={"fingerprints": ["already-known-fp"]})  # type: ignore[method-assign]
+    reporter._store.async_load = AsyncMock(return_value={"fingerprints": []})  # type: ignore[method-assign]
+    reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    from enki.domain.profile import profile_fingerprint, profile_to_export_dict
+
+    export = profile_to_export_dict(record, integration_version="1.6.6", ha_version="2025.1")
+    fingerprint = profile_fingerprint(export)
+
+    entry.runtime_data.api.read_errors_for_fingerprint.return_value = {
+        "thermostat/check_thermostat_target_temperature": "HTTP 500",
+    }
+    entry.runtime_data.api.poll_state_for_fingerprint.return_value = {}
+
+    with patch(
+        "enki.telemetry.reporter.persistent_notification.async_create",
+        new_callable=MagicMock,
+    ) as notify:
+        await reporter.async_report([record])
+        notify.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_does_not_renotify_reported_fingerprint() -> None:
+    hass = MagicMock()
+    hass.config.version = "2024.12.0"
+    entry = _entry_with_coordinator(telemetry=True)
+
+    record = build_discovery_record(
+        device_type="heaters_and_pilot_wires",
+        bff_device_type="heaters_and_pilot_wires",
+        capabilities=[
+            "change_thermostat_target_temperature",
+            "check_thermostat_target_temperature",
+        ],
+        possible_values={},
+        manufacturer="Noirot",
+        model="radiator",
+        firmware_version="2.15.0",
+        supported_by_integration=True,
+    )
+
+    reporter = EnkiTelemetryReporter(hass, entry)
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     from enki.domain.profile import profile_fingerprint, profile_to_export_dict
@@ -188,13 +229,60 @@ async def test_telemetry_notifies_when_api_errors_appear_after_fingerprint_store
     entry.runtime_data.api.read_errors_for_fingerprint.return_value = {
         "thermostat/check_thermostat_target_temperature": "HTTP 500",
     }
+    entry.runtime_data.api.poll_state_for_fingerprint.return_value = {}
 
     with patch(
         "enki.telemetry.reporter.persistent_notification.async_create",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([record])
-        notify.assert_called_once()
+        notify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_dismisses_notification_when_profile_is_healthy() -> None:
+    hass = MagicMock()
+    hass.config.version = "2024.12.0"
+    entry = _entry_with_coordinator(telemetry=True)
+
+    record = build_discovery_record(
+        device_type="heaters_and_pilot_wires",
+        bff_device_type="heaters_and_pilot_wires",
+        capabilities=[
+            "change_thermostat_target_temperature",
+            "check_thermostat_target_temperature",
+            "check_electrical_consumption",
+        ],
+        possible_values={},
+        manufacturer="Noirot",
+        model="radiator",
+        firmware_version="2.15.0",
+        supported_by_integration=True,
+    )
+
+    reporter = EnkiTelemetryReporter(hass, entry)
+    reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
+
+    from enki.domain.profile import profile_fingerprint, profile_to_export_dict
+
+    export = profile_to_export_dict(record, integration_version="1.6.8", ha_version="2025.1")
+    fingerprint = profile_fingerprint(export)
+    reporter._store.async_load = AsyncMock(return_value={"fingerprints": [fingerprint]})  # type: ignore[method-assign]
+
+    entry.runtime_data.api.read_errors_for_fingerprint.return_value = {
+        "consumption/check_electrical_consumption": "HTTP 403",
+    }
+    entry.runtime_data.api.poll_state_for_fingerprint.return_value = {
+        "thermostat_target_temperature": 21.0,
+    }
+
+    with patch(
+        "enki.telemetry.reporter.persistent_notification.async_dismiss",
+        new_callable=MagicMock,
+    ) as dismiss:
+        await reporter.async_report([record])
+        dismiss.assert_called_once()
+        assert dismiss.call_args.kwargs["notification_id"] == f"enki_profile_{fingerprint[:16]}"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -179,11 +179,6 @@ async def test_telemetry_notifies_when_api_errors_block_primary_poll() -> None:
     reporter._store.async_load = AsyncMock(return_value={"fingerprints": []})  # type: ignore[method-assign]
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
-    from enki.domain.profile import profile_fingerprint, profile_to_export_dict
-
-    export = profile_to_export_dict(record, integration_version="1.6.6", ha_version="2025.1")
-    fingerprint = profile_fingerprint(export)
-
     entry.runtime_data.api.read_errors_for_fingerprint.return_value = {
         "thermostat/check_thermostat_target_temperature": "HTTP 500",
     }

--- a/tests/unit/test_telemetry_coverage.py
+++ b/tests/unit/test_telemetry_coverage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enki.domain.profile import build_discovery_record
 from enki.domain.telemetry_coverage import (
+    api_read_errors_need_telemetry,
     capability_is_covered,
     discovery_record_needs_telemetry,
     profile_from_record,
@@ -114,3 +115,46 @@ def test_gateway_profile_not_eligible_for_telemetry() -> None:
         supported_by_integration=False,
     )
     assert discovery_record_needs_telemetry(record) is False
+
+
+def test_noirot_consumption_error_does_not_need_telemetry_when_primary_poll_ok() -> None:
+    record = build_discovery_record(
+        device_type="heaters_and_pilot_wires",
+        bff_device_type="heaters_and_pilot_wires",
+        capabilities=[
+            "change_thermostat_target_temperature",
+            "check_thermostat_target_temperature",
+            "check_electrical_consumption",
+        ],
+        possible_values={},
+        manufacturer="Noirot",
+        model="radiator",
+        firmware_version="2.15.0",
+        supported_by_integration=True,
+    )
+    errors = {"consumption/check_electrical_consumption": "HTTP 403"}
+    poll_state = {"thermostat_target_temperature": 21.0}
+    assert api_read_errors_need_telemetry(record, errors, poll_state) is False
+    assert (
+        discovery_record_needs_telemetry(
+            record,
+            api_read_errors=errors,
+            poll_state=poll_state,
+        )
+        is False
+    )
+
+
+def test_module_power_error_needs_telemetry_without_poll_state() -> None:
+    record = build_discovery_record(
+        device_type="modules",
+        bff_device_type="modules",
+        capabilities=["switch_electrical_power", "check_electrical_power"],
+        possible_values={},
+        manufacturer="Equation",
+        model="relay",
+        firmware_version="1.0.0",
+        supported_by_integration=True,
+    )
+    errors = {"power/check_electrical_power": "HTTP 403"}
+    assert api_read_errors_need_telemetry(record, errors, {}) is True

--- a/tests/unit/test_telemetry_enrichment.py
+++ b/tests/unit/test_telemetry_enrichment.py
@@ -41,6 +41,35 @@ def test_supported_profile_needs_telemetry_when_api_errors_present() -> None:
     assert discovery_record_needs_telemetry(record, api_read_errors=errors) is True
 
 
+def test_supported_profile_skips_telemetry_when_poll_state_has_primary_values() -> None:
+    record = _noirot_record()
+    errors = {
+        "consumption/check_electrical_consumption": "HTTP 403",
+        "thermostat/check_thermostat_target_temperature": "HTTP 500",
+    }
+    poll_state = {"thermostat_target_temperature": 21.0, "occupancy": "UNOCCUPIED"}
+    assert (
+        discovery_record_needs_telemetry(
+            record,
+            api_read_errors=errors,
+            poll_state=poll_state,
+        )
+        is False
+    )
+
+
+def test_enrich_export_omits_telemetry_reason_when_poll_state_is_healthy() -> None:
+    record = _noirot_record()
+    export = profile_to_export_dict(record, integration_version="1.6.8", ha_version="2025.1")
+    enriched = enrich_telemetry_export(
+        export,
+        record,
+        api_read_errors={"consumption/check_electrical_consumption": "HTTP 403"},
+        last_poll_state={"thermostat_target_temperature": 21.0},
+    )
+    assert "telemetry_reason" not in enriched
+
+
 def test_enrich_export_includes_platforms_and_api_errors() -> None:
     record = _noirot_record()
     export = profile_to_export_dict(record, integration_version="1.6.5", ha_version="2025.1")
@@ -51,10 +80,21 @@ def test_enrich_export_includes_platforms_and_api_errors() -> None:
         last_poll_state={"thermostat_target_temperature": 21.0},
     )
     assert "climate" in enriched["ha_platforms"]
-    assert enriched["telemetry_reason"] == "api_read_errors"
+    assert "telemetry_reason" not in enriched
     errors = enriched["api_read_errors"]
     assert "HTTP 500" in errors["thermostat/check_thermostat_target_temperature"]
     assert enriched["last_poll_state"]["thermostat_target_temperature"] == 21.0
+
+
+def test_enrich_export_marks_api_read_errors_when_poll_state_missing() -> None:
+    record = _noirot_record()
+    export = profile_to_export_dict(record, integration_version="1.6.5", ha_version="2025.1")
+    enriched = enrich_telemetry_export(
+        export,
+        record,
+        api_read_errors={"thermostat/check_thermostat_target_temperature": "HTTP 500"},
+    )
+    assert enriched["telemetry_reason"] == "api_read_errors"
 
 
 def test_github_issue_body_is_english_and_includes_api_errors() -> None:


### PR DESCRIPTION
## Summary

- Stop re-notifying the same device profile on every coordinator poll when API read errors linger (e.g. optional consumption 403 while climate/relay works).
- Only trigger opt-in telemetry when read errors block **primary** entity poll state; ignore optional `electrical_consumption` failures when core state is present.
- Auto-dismiss stale persistent notifications once a profile polls cleanly.

Fixes false-positive GitHub issue prompts reported by @zetiti10 on #31 / #42–#44 after v1.6.8.

## Test plan

- [x] Unit tests (`test_telemetry*.py`) — 151 passed
- [ ] @zetiti10: upgrade to this build, restart HA, confirm the 3 telemetry cards disappear and do not return after poll