### PR TITLE
fix: OFF below min step for lights and discrete fan speeds

### DIFF
--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -13,12 +13,15 @@ from homeassistant.components.fan import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
 
 from .const import DOMAIN, FAN_SPEED_MAX
 from .coordinator import EnkiCoordinator
 from .domain.models import EnkiDevice
 from .entity import EnkiEntity
-from .lib.conversion import fan_speed_to_percentage, percentage_to_fan_speed
 from .platforms.fan.airflow import (
     airflow_modes_from_metadata,
     device_supports_fan_rotation,
@@ -51,11 +54,12 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-fan"
         self._preset_modes = airflow_modes_from_metadata(device)
-        self._fan_max_speed = device.profile.fan_max_speed or FAN_SPEED_MAX
+        max_speed = device.profile.fan_max_speed or FAN_SPEED_MAX
+        self._ordered_speeds = list(range(1, max_speed + 1))
 
     @property
     def _max_fan_speed(self) -> int:
-        return self._fan_max_speed
+        return self._ordered_speeds[-1] if self._ordered_speeds else FAN_SPEED_MAX
 
     @property
     def supported_features(self) -> FanEntityFeature:
@@ -118,11 +122,12 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
             return None
         if speed <= 0:
             return 0
-        return fan_speed_to_percentage(speed, self._max_fan_speed)
+        return ordered_list_item_to_percentage(self._ordered_speeds, speed)
 
     @property
     def speed_count(self) -> int:
-        return self._max_fan_speed
+        """HA discrete speed steps (1…max); UI shows ~17 % steps for 6 speeds, not 0–100 smooth."""
+        return len(self._ordered_speeds)
 
     @property
     def current_direction(self) -> str | None:
@@ -162,10 +167,7 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
                 if percentage <= 0:
                     await self.async_turn_off(**kwargs)
                     return
-                speed = percentage_to_fan_speed(percentage, self._max_fan_speed)
-                if speed <= 0:
-                    await self.async_turn_off(**kwargs)
-                    return
+                speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
                 await self._set_speed(speed)
                 return
             speed = max(1, self._device.reported.fan_speed or 1)
@@ -184,10 +186,10 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
     async def async_set_percentage(self, percentage: int) -> None:
         if not self._device.profile.supports_fan_speed_control:
             return
-        speed = percentage_to_fan_speed(percentage, self._max_fan_speed)
-        if speed <= 0:
+        if percentage <= 0:
             await self.async_turn_off()
             return
+        speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
         await self._set_speed(speed)
 
     async def _set_speed(self, speed: int) -> None:

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -13,15 +13,12 @@ from homeassistant.components.fan import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util.percentage import (
-    ordered_list_item_to_percentage,
-    percentage_to_ordered_list_item,
-)
 
 from .const import DOMAIN, FAN_SPEED_MAX
 from .coordinator import EnkiCoordinator
 from .domain.models import EnkiDevice
 from .entity import EnkiEntity
+from .lib.conversion import fan_speed_to_percentage, percentage_to_fan_speed
 from .platforms.fan.airflow import (
     airflow_modes_from_metadata,
     device_supports_fan_rotation,
@@ -54,11 +51,11 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-fan"
         self._preset_modes = airflow_modes_from_metadata(device)
-        self._ordered_speeds = self._build_ordered_speeds(device)
+        self._fan_max_speed = device.profile.fan_max_speed or FAN_SPEED_MAX
 
-    def _build_ordered_speeds(self, device: EnkiDevice) -> list[int]:
-        max_speed = device.profile.fan_max_speed or FAN_SPEED_MAX
-        return list(range(1, max_speed + 1))
+    @property
+    def _max_fan_speed(self) -> int:
+        return self._fan_max_speed
 
     @property
     def supported_features(self) -> FanEntityFeature:
@@ -121,11 +118,11 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
             return None
         if speed <= 0:
             return 0
-        return ordered_list_item_to_percentage(self._ordered_speeds, speed)
+        return fan_speed_to_percentage(speed, self._max_fan_speed)
 
     @property
     def speed_count(self) -> int:
-        return len(self._ordered_speeds)
+        return self._max_fan_speed
 
     @property
     def current_direction(self) -> str | None:
@@ -161,10 +158,17 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
             await self.async_set_preset_mode(preset_mode)
 
         if self._device.profile.supports_fan_speed_control:
-            if percentage is not None and percentage > 0:
-                speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
-            else:
-                speed = max(1, self._device.reported.fan_speed or 1)
+            if percentage is not None:
+                if percentage <= 0:
+                    await self.async_turn_off(**kwargs)
+                    return
+                speed = percentage_to_fan_speed(percentage, self._max_fan_speed)
+                if speed <= 0:
+                    await self.async_turn_off(**kwargs)
+                    return
+                await self._set_speed(speed)
+                return
+            speed = max(1, self._device.reported.fan_speed or 1)
             await self._set_speed(speed)
             return
 
@@ -180,10 +184,11 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
     async def async_set_percentage(self, percentage: int) -> None:
         if not self._device.profile.supports_fan_speed_control:
             return
-        if percentage == 0:
+        speed = percentage_to_fan_speed(percentage, self._max_fan_speed)
+        if speed <= 0:
             await self.async_turn_off()
             return
-        await self._set_speed(percentage_to_ordered_list_item(self._ordered_speeds, percentage))
+        await self._set_speed(speed)
 
     async def _set_speed(self, speed: int) -> None:
         home_id = self._device.home_id

--- a/custom_components/enki/lib/conversion.py
+++ b/custom_components/enki/lib/conversion.py
@@ -48,6 +48,20 @@ def percentage_to_speed(percentage: int) -> int:
     return max(1, min(FAN_SPEED_MAX, speed))
 
 
+def percentage_to_fan_speed(percentage: int, max_speed: int) -> int:
+    """Map HA percentage to a fan speed level using the device max (0 = off)."""
+    if percentage <= 0 or max_speed <= 0:
+        return 0
+    return max(0, min(max_speed, round(percentage * max_speed / 100)))
+
+
+def fan_speed_to_percentage(speed: int, max_speed: int) -> int:
+    """Map Enki fan speed to HA percentage (linear, matches CyrilP/hass-enki-component)."""
+    if speed <= 0 or max_speed <= 0:
+        return 0
+    return int(round(speed * 100 / max_speed))
+
+
 def normalize_power_state(last_reported: Any, endpoint: int) -> str:
     """Parse check-electrical-power lastReportedValue (string or per-endpoint map)."""
     if isinstance(last_reported, str):
@@ -138,6 +152,12 @@ def merge_light_state_payload(
     payload = dict(current)
     if changes.get("power") == "OFF":
         payload.update(changes)
+        return payload
+    brightness = changes.get("brightness")
+    if brightness is not None and float(brightness) <= 0:
+        payload = dict(current)
+        payload.update(changes)
+        payload["power"] = "OFF"
         return payload
     payload["power"] = "ON"
     payload.update(changes)

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -122,6 +122,9 @@ class EnkiFanLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
 
         await self._mixed_endpoint_workaround()
         changes = self._build_turn_on_changes(kwargs, restore_last_brightness=True)
+        if changes.get("power") == "OFF":
+            await self.async_turn_off(**kwargs)
+            return
         await self.coordinator.api.async_change_light_state(
             self._device.home_id,
             self._device.node_id,
@@ -299,6 +302,9 @@ class EnkiLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
 
         await self._mixed_endpoint_workaround()
         changes = self._build_turn_on_changes(kwargs)
+        if changes.get("power") == "OFF":
+            await self.async_turn_off(**kwargs)
+            return
         await self.coordinator.api.async_change_light_state(home_id, node_id, changes)
         self.coordinator.update_cached_value(node_id, "power", "ON")
         if "brightness" in changes:

--- a/custom_components/enki/platforms/light/behavior.py
+++ b/custom_components/enki/platforms/light/behavior.py
@@ -74,10 +74,14 @@ class EnkiLightBehaviorMixin:
         """Build a single change-light-state payload from HA service kwargs."""
         changes: dict[str, Any] = {"power": "ON"}
         if ATTR_BRIGHTNESS in kwargs:
-            changes["brightness"] = round(
-                kwargs[ATTR_BRIGHTNESS] * self._brightness_max / 255,
-                2,
-            )
+            ha_brightness = int(kwargs[ATTR_BRIGHTNESS])
+            if ha_brightness <= 0:
+                return {"power": "OFF"}
+            enki_brightness = round(ha_brightness * self._brightness_max / 255, 2)
+            min_brightness = self._parse_brightness_min(self._device.profile.possible_values)
+            if enki_brightness < min_brightness:
+                return {"power": "OFF"}
+            changes["brightness"] = enki_brightness
         if ATTR_COLOR_TEMP_KELVIN in kwargs:
             if self._color_temp_values:
                 changes["colorTemperature"] = self._closest_color_temp(
@@ -122,3 +126,11 @@ class EnkiLightBehaviorMixin:
     def _parse_brightness_max(possible_values: dict[str, Any], default: int = 100) -> int:
         brightness_range = possible_values.get("change_brightness", {}).get("range", {})
         return int(brightness_range.get("max", default))
+
+    @staticmethod
+    def _parse_brightness_min(possible_values: dict[str, Any], *, default: float = 1.0) -> float:
+        brightness_range = possible_values.get("change_brightness", {}).get("range", {})
+        raw_min = brightness_range.get("min")
+        if isinstance(raw_min, (int, float)):
+            return float(raw_min)
+        return default

--- a/tests/unit/test_fan_light_state.py
+++ b/tests/unit/test_fan_light_state.py
@@ -26,6 +26,13 @@ def test_merge_light_state_payload_brightness_update_keeps_on() -> None:
     assert payload["brightness"] == 0.8
 
 
+def test_merge_light_state_payload_zero_brightness_forces_off() -> None:
+    current = {"power": "ON", "brightness": 50.0}
+    payload = merge_light_state_payload(current, {"brightness": 0})
+    assert payload["power"] == "OFF"
+    assert payload["brightness"] == 0
+
+
 def test_merge_light_state_payload_color_temp_sets_ct_mode() -> None:
     current = {"power": "ON", "colorMode": "hs", "hue": 0.5, "saturation": 0.8}
     payload = merge_light_state_payload(current, {"colorTemperature": "T3500K"})

--- a/tests/unit/test_fan_speed_mapping.py
+++ b/tests/unit/test_fan_speed_mapping.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from enki.const import FAN_SPEED_MAX, ORDERED_FAN_SPEEDS
-from enki.lib.conversion import percentage_to_speed, speed_to_percentage
+from enki.lib.conversion import (
+    fan_speed_to_percentage,
+    percentage_to_fan_speed,
+    percentage_to_speed,
+    speed_to_percentage,
+)
 
 
 def test_speed_to_percentage_levels() -> None:
@@ -28,3 +33,15 @@ def test_ordered_fan_speeds_matches_enki_levels() -> None:
     assert list(range(1, FAN_SPEED_MAX + 1)) == ORDERED_FAN_SPEEDS
     for speed in ORDERED_FAN_SPEEDS:
         assert speed_to_percentage(speed) == round(speed * 100 / FAN_SPEED_MAX)
+
+
+def test_percentage_to_fan_speed_low_values_turn_off() -> None:
+    assert percentage_to_fan_speed(0, 6) == 0
+    assert percentage_to_fan_speed(8, 6) == 0
+    assert percentage_to_fan_speed(17, 6) == 1
+
+
+def test_fan_speed_to_percentage_linear() -> None:
+    assert fan_speed_to_percentage(0, 6) == 0
+    assert fan_speed_to_percentage(3, 6) == 50
+    assert fan_speed_to_percentage(6, 6) == 100


### PR DESCRIPTION
## Summary
- **Lights:** when HA sends brightness at or below the Enki minimum (or 0), send `power: OFF` instead of forcing the lowest ON level — fixes Siroco+ kit staying on while HA shows off.
- **Fans:** restore Home Assistant discrete speed mapping (`speed_count` + `ordered_list_item`) so the UI shows steps 1–N (~17 % / 33 % / …) instead of a linear 0–100 slider; `0 %` and `turn_off` still map to Enki speed 0.
- **`merge_light_state_payload`:** zero brightness in a state update forces `power: OFF` in the API payload.

## Test plan
- [x] Inspire Siroco+: turn fan/light off from HA — Enki app shows OFF (not stuck at speed 1 / min brightness).
- [x] Fan speed slider shows discrete steps (6 levels + off for Inspire), not arbitrary percentages.
- [x] Dim light below referentiel `min` → entity off in HA and device off in Enki.
- [x] `pytest tests/unit/test_fan_light_state.py tests/unit/test_fan_speed_mapping.py tests/unit/test_api_routing.py -k fan`