### PR TITLE
feat: expose Enki device metadata (firmware, OTA, connectivity)

### DIFF
--- a/custom_components/enki/__init__.py
+++ b/custom_components/enki/__init__.py
@@ -53,10 +53,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnkiConfigEntry) -> bool
         notify_for_connection_error(notifier, err)
         raise ConfigEntryNotReady(f"Cannot reach Enki cloud: {err}") from err
 
-    mobile_settings = await coordinator.api.async_fetch_mobile_settings()
-    if mobile_settings.get("maintenance") is True:
-        notifier.notify_maintenance_mode()
-
     entry.runtime_data = coordinator
     await coordinator.async_config_entry_first_refresh()
 

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -86,15 +86,15 @@ class EnkiAPI:
         http = await self._get_http()
         await self._auth.connect(http.session)
 
-    async def async_fetch_mobile_settings(self) -> dict[str, Any]:
+    async def async_fetch_mobile_settings(self) -> dict[str, Any] | None:
         """Fetch Enki app settings (maintenance flags, min app version, …)."""
         http = await self._get_http()
         try:
             payload = await fetch_mobile_config(http)
         except EnkiConnectionError as err:
             LOGGER.debug("Mobile-config settings skipped: %s", err)
-            return {}
-        return payload if isinstance(payload, dict) else {}
+            return None
+        return payload if isinstance(payload, dict) else None
 
     async def async_get_devices(self) -> list[EnkiDevice]:
         """Discover all nodes across every home on the account."""

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 import aiohttp

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -29,6 +29,7 @@ from ..lib.enki_scope import device_in_enki_scope
 from ..lib.shutter import normalize_shutter_position
 from .auth import EnkiAuthSession
 from .capability_routing import CAPABILITY_READS, CapabilityRead
+from .device_metadata import refresh_device_metadata
 from .gateway_keys import GatewayKeyStore, fetch_mobile_config
 from .transport import EnkiHttpClient
 
@@ -290,9 +291,9 @@ class EnkiAPI:
             supported = False
         else:
             supported = integration_supports_device(skeleton)
-        model = node_info.get("modelNumber") or device_info.get("modelNumber")
-        firmware = node_info.get("version") or device_info.get("version")
 
+        model = node_info.get("modelNumber") or device_info.get("modelNumber")
+        preliminary_firmware = node_info.get("version") or device_info.get("version")
         record = build_discovery_record(
             device_type=device_type,
             bff_device_type=bff_type,
@@ -300,7 +301,7 @@ class EnkiAPI:
             possible_values=possible_values,
             manufacturer=manufacturer_str,
             model=str(model) if model else None,
-            firmware_version=str(firmware) if firmware else None,
+            firmware_version=str(preliminary_firmware) if preliminary_firmware else None,
             supported_by_integration=supported,
         )
         self._register_node_profile(node_id, record)
@@ -308,6 +309,24 @@ class EnkiAPI:
         last_reported: dict[str, Any] = {}
         if item.get("isEnabled", True):
             last_reported = await self._refresh_device_state(http, skeleton, node_info)
+            await refresh_device_metadata(
+                http,
+                skeleton,
+                last_reported,
+                note_error=self._note_read_error,
+            )
+
+        if last_reported.get("firmware_version"):
+            record = build_discovery_record(
+                device_type=device_type,
+                bff_device_type=bff_type,
+                capabilities=capabilities,
+                possible_values=possible_values,
+                manufacturer=manufacturer_str,
+                model=str(model) if model else None,
+                firmware_version=str(last_reported["firmware_version"]),
+                supported_by_integration=supported,
+            )
 
         self._register_poll_state(node_id, {**node_info, **last_reported})
 

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -309,12 +309,20 @@ class EnkiAPI:
         last_reported: dict[str, Any] = {}
         if item.get("isEnabled", True):
             last_reported = await self._refresh_device_state(http, skeleton, node_info)
-            await refresh_device_metadata(
-                http,
-                skeleton,
-                last_reported,
-                note_error=self._note_read_error,
-            )
+            try:
+                await refresh_device_metadata(
+                    http,
+                    skeleton,
+                    last_reported,
+                    note_error=self._note_read_error,
+                )
+            except Exception as err:  # noqa: BLE001 — metadata must never break discovery
+                LOGGER.debug(
+                    "Device metadata skipped for node %s: %s",
+                    node_id,
+                    err,
+                    exc_info=LOGGER.isEnabledFor(logging.DEBUG),
+                )
 
         if last_reported.get("firmware_version"):
             record = build_discovery_record(

--- a/custom_components/enki/api/device_metadata.py
+++ b/custom_components/enki/api/device_metadata.py
@@ -1,0 +1,120 @@
+"""Referentiel-driven device metadata reads (firmware, OTA, connectivity)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from ..const import LOGGER
+from ..exceptions import EnkiConnectionError
+from .transport import EnkiHttpClient
+
+if TYPE_CHECKING:
+    from ..domain.models import EnkiDevice
+
+FIRMWARE_VERSION_CAPABILITY = "check_current_firmware_version"
+OTA_INVENTORY_CAPABILITY = "ota_inventory"
+
+_OTA_UPDATE_NEEDED = "OTA_NEEDED"
+
+
+def merge_ota_version(state: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Apply OTA version response (currentVersion / latestVersion)."""
+    current = payload.get("currentVersion")
+    latest = payload.get("latestVersion")
+    if isinstance(current, str) and current:
+        state["firmware_version"] = current
+        state["version"] = current
+    if isinstance(latest, str) and latest:
+        state["firmware_latest_version"] = latest
+    if isinstance(current, str) and isinstance(latest, str) and current and latest:
+        state["firmware_update_available"] = current != latest
+
+
+def merge_ota_check(state: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Apply OTA check response (status enum)."""
+    status = payload.get("status")
+    if not isinstance(status, str) or not status:
+        return
+    state["firmware_update_status"] = status
+    if status == _OTA_UPDATE_NEEDED:
+        state["firmware_update_available"] = True
+    elif status == "FIRMWARE_ALREADY_UP_TO_DATE":
+        state["firmware_update_available"] = False
+
+
+def merge_connectivity(state: dict[str, Any], payload: dict[str, Any]) -> None:
+    """Apply ESDK / gateway connectivity DTO (connected flag)."""
+    connected = payload.get("connected")
+    if isinstance(connected, bool):
+        state["node_connected"] = connected
+
+
+def _should_read_firmware_version(capabilities: set[str]) -> bool:
+    return FIRMWARE_VERSION_CAPABILITY in capabilities
+
+
+def _should_read_ota_check(capabilities: set[str]) -> bool:
+    return OTA_INVENTORY_CAPABILITY in capabilities
+
+
+def _should_read_esdk_connectivity(device: EnkiDevice) -> bool:
+    return device.profile.is_fan
+
+
+async def refresh_device_metadata(
+    http: EnkiHttpClient,
+    device: EnkiDevice,
+    state: dict[str, Any],
+    *,
+    note_error: Any | None = None,
+) -> None:
+    """Best-effort metadata reads driven by referentiel capabilities and device type."""
+    home_id = device.home_id
+    node_id = device.node_id
+    caps = set(device.capabilities)
+
+    async def read_firmware_version() -> None:
+        if not _should_read_firmware_version(caps):
+            return
+        try:
+            payload = await http.get_ota_version(home_id, node_id)
+        except EnkiConnectionError as err:
+            LOGGER.debug("Firmware version skipped for node %s: %s", node_id, err)
+            if note_error is not None:
+                note_error(node_id, service="ota", capability=FIRMWARE_VERSION_CAPABILITY, err=err)
+            return
+        if payload:
+            merge_ota_version(state, payload)
+
+    async def read_ota_check() -> None:
+        if not _should_read_ota_check(caps):
+            return
+        try:
+            payload = await http.get_ota_check(home_id, node_id)
+        except EnkiConnectionError as err:
+            LOGGER.debug("OTA check skipped for node %s: %s", node_id, err)
+            if note_error is not None:
+                note_error(node_id, service="ota", capability=OTA_INVENTORY_CAPABILITY, err=err)
+            return
+        if payload:
+            merge_ota_check(state, payload)
+
+    async def read_esdk_connectivity() -> None:
+        if not _should_read_esdk_connectivity(device):
+            return
+        try:
+            payload = await http.get_esdk_connectivity(home_id, node_id)
+        except EnkiConnectionError as err:
+            LOGGER.debug("ESDK connectivity skipped for node %s: %s", node_id, err)
+            if note_error is not None:
+                note_error(node_id, service="esdk", capability="node_connected", err=err)
+            return
+        if payload:
+            merge_connectivity(state, payload)
+
+    await asyncio.gather(
+        read_firmware_version(),
+        read_ota_check(),
+        read_esdk_connectivity(),
+    )

--- a/custom_components/enki/api/device_metadata.py
+++ b/custom_components/enki/api/device_metadata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import TYPE_CHECKING, Any
 
 from ..const import LOGGER
@@ -69,7 +70,29 @@ async def refresh_device_metadata(
     *,
     note_error: Any | None = None,
 ) -> None:
-    """Best-effort metadata reads driven by referentiel capabilities and device type."""
+    """Best-effort metadata reads driven by referentiel capabilities and device type.
+
+    Failures are swallowed: missing fields are simply omitted from *state* so
+    discovery and entity polling never break.
+    """
+    try:
+        await _refresh_device_metadata_impl(http, device, state, note_error=note_error)
+    except Exception as err:  # noqa: BLE001 — metadata must never break discovery
+        LOGGER.debug(
+            "Device metadata skipped for node %s: %s",
+            device.node_id,
+            err,
+            exc_info=LOGGER.isEnabledFor(logging.DEBUG),
+        )
+
+
+async def _refresh_device_metadata_impl(
+    http: EnkiHttpClient,
+    device: EnkiDevice,
+    state: dict[str, Any],
+    *,
+    note_error: Any | None = None,
+) -> None:
     home_id = device.home_id
     node_id = device.node_id
     caps = set(device.capabilities)
@@ -79,9 +102,9 @@ async def refresh_device_metadata(
             return
         try:
             payload = await http.get_ota_version(home_id, node_id)
-        except EnkiConnectionError as err:
+        except Exception as err:  # noqa: BLE001
             LOGGER.debug("Firmware version skipped for node %s: %s", node_id, err)
-            if note_error is not None:
+            if note_error is not None and isinstance(err, EnkiConnectionError):
                 note_error(node_id, service="ota", capability=FIRMWARE_VERSION_CAPABILITY, err=err)
             return
         if payload:
@@ -92,9 +115,9 @@ async def refresh_device_metadata(
             return
         try:
             payload = await http.get_ota_check(home_id, node_id)
-        except EnkiConnectionError as err:
+        except Exception as err:  # noqa: BLE001
             LOGGER.debug("OTA check skipped for node %s: %s", node_id, err)
-            if note_error is not None:
+            if note_error is not None and isinstance(err, EnkiConnectionError):
                 note_error(node_id, service="ota", capability=OTA_INVENTORY_CAPABILITY, err=err)
             return
         if payload:
@@ -105,16 +128,24 @@ async def refresh_device_metadata(
             return
         try:
             payload = await http.get_esdk_connectivity(home_id, node_id)
-        except EnkiConnectionError as err:
+        except Exception as err:  # noqa: BLE001
             LOGGER.debug("ESDK connectivity skipped for node %s: %s", node_id, err)
-            if note_error is not None:
+            if note_error is not None and isinstance(err, EnkiConnectionError):
                 note_error(node_id, service="esdk", capability="node_connected", err=err)
             return
         if payload:
             merge_connectivity(state, payload)
 
-    await asyncio.gather(
+    results = await asyncio.gather(
         read_firmware_version(),
         read_ota_check(),
         read_esdk_connectivity(),
+        return_exceptions=True,
     )
+    for result in results:
+        if isinstance(result, Exception):
+            LOGGER.debug(
+                "Device metadata task failed for node %s: %s",
+                node_id,
+                result,
+            )

--- a/custom_components/enki/api/gateway_registry.py
+++ b/custom_components/enki/api/gateway_registry.py
@@ -185,10 +185,10 @@ ENKI_MICRO_SERVICES: tuple[EnkiMicroService, ...] = (
     EnkiMicroService(
         "api-enki-esdk-prod",
         "ENKI_ESDK_API_KEY",
-        "",
+        "esdk",
         "/api-enki-esdk-prod/v1/esdk",
-        wired=False,
-        notes="",
+        wired=True,
+        notes="ESDK fan connectivity (states/{nodeId})",
     ),
     EnkiMicroService(
         "api-enki-group-prod",
@@ -377,10 +377,10 @@ ENKI_MICRO_SERVICES: tuple[EnkiMicroService, ...] = (
     EnkiMicroService(
         "api-enki-ota-prod",
         "ENKI_OTA_API_KEY",
-        "",
+        "ota",
         "/api-enki-ota-prod/v1/ota",
-        wired=False,
-        notes="",
+        wired=True,
+        notes="Firmware version and OTA inventory",
     ),
     EnkiMicroService(
         "api-enki-payment-prod",
@@ -647,7 +647,7 @@ LEGACY_SLUG_ALIASES: dict[str, str] = {
     "api-enki-access-and-motorizations-prod": "api-enki-rolling-prod",
 }
 
-OPTIONAL_KEY_TRANSPORT_IDS = frozenset({"heating", "water_sensor", "motorization"})
+OPTIONAL_KEY_TRANSPORT_IDS = frozenset({"heating", "water_sensor", "motorization", "ota", "esdk"})
 
 WIRED_PATH_PREFIXES: dict[str, str] = {
     svc.transport_id: svc.path_prefix

--- a/custom_components/enki/api/transport.py
+++ b/custom_components/enki/api/transport.py
@@ -170,6 +170,43 @@ class EnkiHttpClient:
             home_id=home_id,
         )
 
+    async def get_ota_version(self, home_id: str, node_id: str) -> dict[str, Any]:
+        """Firmware version (APK t0i.c → ota/version/{nodeId})."""
+        if not self._service_api_key("ota"):
+            return {}
+        prefix = WIRED_PATH_PREFIXES["ota"]
+        return await self.get_json(
+            "ota",
+            f"{prefix}/ota/version/{node_id}",
+            home_id=home_id,
+            not_found_ok=True,
+        )
+
+    async def get_ota_check(self, home_id: str, node_id: str) -> dict[str, Any]:
+        """OTA update availability (APK t0i.d → ota/check/{nodeId})."""
+        if not self._service_api_key("ota"):
+            return {}
+        prefix = WIRED_PATH_PREFIXES["ota"]
+        return await self.get_json(
+            "ota",
+            f"{prefix}/ota/check/{node_id}",
+            home_id=home_id,
+            params={"isBlockingOrNoRetryNeeded": "false"},
+            not_found_ok=True,
+        )
+
+    async def get_esdk_connectivity(self, home_id: str, node_id: str) -> dict[str, Any]:
+        """ESDK fan hub link state (APK sq9.b → states/{nodeId})."""
+        if not self._service_api_key("esdk"):
+            return {}
+        prefix = WIRED_PATH_PREFIXES["esdk"]
+        return await self.get_json(
+            "esdk",
+            f"{prefix}/states/{node_id}",
+            home_id=home_id,
+            not_found_ok=True,
+        )
+
     async def get_referentiel_device(self, device_id: str) -> dict[str, Any]:
         """Referentiel metadata; ESDK fan nodes may return 404."""
         return await self.get_json(

--- a/custom_components/enki/binary_sensor.py
+++ b/custom_components/enki/binary_sensor.py
@@ -105,7 +105,7 @@ def _build_binary_sensor_entities(
     device: EnkiDevice,
 ) -> list[EnkiBinarySensor]:
     profile = device.profile
-    if not profile.is_binary_sensor:
+    if not profile.is_binary_sensor and not _device_has_metadata_sensors(device):
         return []
 
     capabilities = profile.capabilities
@@ -124,6 +124,50 @@ def _build_binary_sensor_entities(
                 device_class=spec["device_class"],
             )
         )
+    entities.extend(_build_metadata_binary_sensors(coordinator, device))
+    return entities
+
+
+def _device_has_metadata_sensors(device: EnkiDevice) -> bool:
+    caps = set(device.capabilities)
+    return (
+        device.profile.is_fan
+        or "ota_inventory" in caps
+        or device.last_reported_value.get("firmware_update_available") is not None
+    )
+
+
+def _build_metadata_binary_sensors(
+    coordinator: EnkiCoordinator,
+    device: EnkiDevice,
+) -> list[EnkiBinarySensor]:
+    entities: list[EnkiBinarySensor] = []
+    caps = set(device.capabilities)
+
+    if device.profile.is_fan:
+        entities.append(
+            EnkiBinarySensor(
+                coordinator,
+                device,
+                state_key="node_connected",
+                suffix="connectivity",
+                translation_key="connectivity",
+                device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            )
+        )
+
+    if "ota_inventory" in caps:
+        entities.append(
+            EnkiBinarySensor(
+                coordinator,
+                device,
+                state_key="firmware_update_available",
+                suffix="firmware_update",
+                translation_key="firmware_update",
+                device_class=BinarySensorDeviceClass.UPDATE,
+            )
+        )
+
     return entities
 
 
@@ -165,6 +209,10 @@ class EnkiBinarySensor(EnkiEntity, BinarySensorEntity):
             raw = self._device.reported.window_open_detection
         elif raw is None and self._state_key == "occupancy":
             raw = self._device.reported.occupancy
+        elif raw is None and self._state_key == "node_connected":
+            raw = self._device.reported.node_connected
+        elif raw is None and self._state_key == "firmware_update_available":
+            raw = self._device.reported.firmware_update_available
 
         if isinstance(raw, str):
             mapped = _ENUM_TO_BOOL.get(raw.upper())

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -44,6 +44,7 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         )
 
     async def _async_update_data(self) -> list[EnkiDevice]:
+        await self._async_sync_maintenance_notification()
         try:
             devices = await self.api.async_get_devices()
         except EnkiAuthError as err:
@@ -71,6 +72,19 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
                     exc_info=LOGGER.isEnabledFor(logging.DEBUG),
                 )
             return devices
+
+    async def _async_sync_maintenance_notification(self) -> None:
+        """Re-check Enki maintenance flag each poll; dismiss when it clears."""
+        try:
+            settings = await self.api.async_fetch_mobile_settings()
+        except Exception as err:  # noqa: BLE001 — must not break polling
+            LOGGER.debug(
+                "Maintenance status check skipped: %s",
+                err,
+                exc_info=LOGGER.isEnabledFor(logging.DEBUG),
+            )
+            return
+        self._notifier.sync_maintenance_mode(settings)
 
     def get_device_by_node(self, node_id: str) -> EnkiDevice | None:
         if not self.data:

--- a/custom_components/enki/domain/profile.py
+++ b/custom_components/enki/domain/profile.py
@@ -73,6 +73,12 @@ _POLL_STATE_EXPORT_KEYS = frozenset(
         "window_open_detection_mode",
         "occupancy",
         "occupancy_mode",
+        "firmware_version",
+        "firmware_latest_version",
+        "firmware_update_available",
+        "firmware_update_status",
+        "node_connected",
+        "version",
         "electrical_endpoints",
     }
 )

--- a/custom_components/enki/domain/state.py
+++ b/custom_components/enki/domain/state.py
@@ -213,6 +213,31 @@ class EnkiDeviceState:
         return str(value) if isinstance(value, str) else None
 
     @property
+    def firmware_version(self) -> str | None:
+        value = self._data.get("firmware_version") or self._data.get("version")
+        return str(value) if isinstance(value, str) and value else None
+
+    @property
+    def firmware_latest_version(self) -> str | None:
+        value = self._data.get("firmware_latest_version")
+        return str(value) if isinstance(value, str) and value else None
+
+    @property
+    def firmware_update_available(self) -> bool | None:
+        value = self._data.get("firmware_update_available")
+        return value if isinstance(value, bool) else None
+
+    @property
+    def firmware_update_status(self) -> str | None:
+        value = self._data.get("firmware_update_status")
+        return str(value) if isinstance(value, str) else None
+
+    @property
+    def node_connected(self) -> bool | None:
+        value = self._data.get("node_connected")
+        return value if isinstance(value, bool) else None
+
+    @property
     def electrical_endpoints(self) -> list[dict[str, Any]]:
         endpoints = self._data.get("electrical_endpoints")
         if isinstance(endpoints, list):

--- a/custom_components/enki/entity.py
+++ b/custom_components/enki/entity.py
@@ -47,6 +47,7 @@ class EnkiEntity(CoordinatorEntity[EnkiCoordinator]):
     def device_info(self) -> DeviceInfo:
         """Group entities by physical node (node_id + serial for HA registry)."""
         metadata = self._device.last_reported_value
+        firmware = metadata.get("firmware_version") or metadata.get("version")
         return DeviceInfo(
             identifiers={(DOMAIN, self._device.node_id)},
             name=self._device.device_name,
@@ -54,6 +55,7 @@ class EnkiEntity(CoordinatorEntity[EnkiCoordinator]):
             model=str(metadata.get("modelNumber", self._device.device_id))
             .replace("_", " ")
             .title(),
-            sw_version=metadata.get("version"),
+            model_id=self._device.device_id,
+            sw_version=str(firmware) if firmware else None,
             serial_number=metadata.get("eui64") or self._device.node_id,
         )

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.10"
+  "version": "1.6.11"
 }

--- a/custom_components/enki/notifications.py
+++ b/custom_components/enki/notifications.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -61,6 +63,19 @@ class EnkiNotifier:
         """Enki cloud reports active maintenance."""
         title, message = _maintenance_copy(self._hass)
         self._create(self._id("maintenance"), title, message)
+
+    def dismiss_maintenance_mode(self) -> None:
+        """Clear maintenance notification when Enki reports normal operations."""
+        self._dismiss(self._id("maintenance"))
+
+    def sync_maintenance_mode(self, settings: dict[str, Any] | None) -> None:
+        """Show or hide maintenance notification from mobile-config payload."""
+        if settings is None:
+            return
+        if settings.get("maintenance") is True:
+            self.notify_maintenance_mode()
+        else:
+            self.dismiss_maintenance_mode()
 
     def dismiss_operational_errors(self) -> None:
         """Clear auth / gateway / connection notifications after a successful poll."""

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -119,6 +119,12 @@
       },
       "occupancy": {
         "name": "Occupancy"
+      },
+      "connectivity": {
+        "name": "Connectivity"
+      },
+      "firmware_update": {
+        "name": "Firmware update"
       }
     },
     "switch": {

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -119,6 +119,12 @@
       },
       "occupancy": {
         "name": "Présence"
+      },
+      "connectivity": {
+        "name": "Connectivité"
+      },
+      "firmware_update": {
+        "name": "Mise à jour firmware"
       }
     },
     "switch": {

--- a/docs/API.md
+++ b/docs/API.md
@@ -140,8 +140,9 @@ Home Assistant shows **persistent notifications** (French or English) when:
 | Invalid Enki credentials | Link to reconfigure the integration |
 | HTTP 403 (gateway key) | Hint to refresh keys from the APK |
 | Network / cloud unreachable | Check Internet and `enki` logs |
+| Enki cloud maintenance (`mobile-config`) | Shown while `maintenance: true`; cleared on the next poll when it ends |
 
-Notifications clear automatically after the next successful poll.
+Notifications clear automatically after the next successful poll (maintenance is re-checked every poll; auth/gateway/connection clear after a successful device poll).
 
 ## Scenarios (api-enki-scenario-prod)
 

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -5,7 +5,7 @@ Detail by device type and Home Assistant entities created. The integration detec
 | | |
 |---|---|
 | **Latest GitHub release** | [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) |
-| **Repository `manifest.json`** | 1.6.10 |
+| **Repository `manifest.json`** | 1.6.11 |
 
 Summary: [ROADMAP.md](ROADMAP.md)
 
@@ -155,6 +155,18 @@ Contributor network feedback: [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md).
 - **Opt-in telemetry** — notification for unknown profiles, pre-filled GitHub link (nothing sent without a click)
 - **Operational notifications** — login failure, gateway key 403, cloud unreachable ([API.md](API.md#operational-notifications))
 - **Diagnostics** — anonymized JSON export from Enki UI
+
+## Device info (firmware, connectivity)
+
+Since **1.6.11**, metadata from the Enki app device screen is exposed when the referentiel advertises the capability:
+
+| Info | Source API | HA surface |
+|------|------------|------------|
+| Firmware version | `ota/version/{nodeId}` when `check_current_firmware_version` | Device `sw_version`, diagnostics poll state |
+| Update available | `ota/check/{nodeId}` when `ota_inventory` | `binary_sensor` (update) |
+| ESDK fan online | `esdk/states/{nodeId}` for ceiling fans | `binary_sensor` (connectivity) |
+
+Reads are best-effort (404 skipped) and driven by referentiel capabilities, not hard-coded per model.
 
 ## In progress / not supported
 

--- a/tests/unit/test_device_metadata.py
+++ b/tests/unit/test_device_metadata.py
@@ -1,0 +1,117 @@
+"""Unit tests for device metadata reads (firmware, OTA, connectivity)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.api.device_metadata import (
+    merge_connectivity,
+    merge_ota_check,
+    merge_ota_version,
+    refresh_device_metadata,
+)
+from enki.domain.models import EnkiDevice
+
+
+def _device(**overrides) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "AD_TCFL_1",
+        "node_id": "node-1",
+        "device_name": "Ventilateur",
+        "device_type": "ceiling_fans",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [
+            "check_current_firmware_version",
+            "ota_inventory",
+            "change_fan_speed",
+        ],
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def test_merge_ota_version_sets_firmware_and_update_flag() -> None:
+    state: dict = {}
+    merge_ota_version(
+        state,
+        {
+            "nodeId": "node-1",
+            "currentVersion": "2.21.0",
+            "latestVersion": "2.22.0",
+        },
+    )
+    assert state["firmware_version"] == "2.21.0"
+    assert state["version"] == "2.21.0"
+    assert state["firmware_latest_version"] == "2.22.0"
+    assert state["firmware_update_available"] is True
+
+
+def test_merge_ota_version_up_to_date() -> None:
+    state: dict = {}
+    merge_ota_version(
+        state,
+        {
+            "currentVersion": "2.21.0",
+            "latestVersion": "2.21.0",
+        },
+    )
+    assert state["firmware_update_available"] is False
+
+
+def test_merge_ota_check_needed() -> None:
+    state: dict = {}
+    merge_ota_check(state, {"status": "OTA_NEEDED"})
+    assert state["firmware_update_status"] == "OTA_NEEDED"
+    assert state["firmware_update_available"] is True
+
+
+def test_merge_ota_check_up_to_date() -> None:
+    state: dict = {}
+    merge_ota_check(state, {"status": "FIRMWARE_ALREADY_UP_TO_DATE"})
+    assert state["firmware_update_available"] is False
+
+
+def test_merge_connectivity() -> None:
+    state: dict = {}
+    merge_connectivity(state, {"connected": True})
+    assert state["node_connected"] is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_device_metadata_fan_calls_ota_and_esdk() -> None:
+    http = MagicMock()
+    http.get_ota_version = AsyncMock(
+        return_value={"currentVersion": "1.0.0", "latestVersion": "1.0.0"},
+    )
+    http.get_ota_check = AsyncMock(return_value={"status": "FIRMWARE_ALREADY_UP_TO_DATE"})
+    http.get_esdk_connectivity = AsyncMock(return_value={"connected": True})
+
+    state: dict = {}
+    await refresh_device_metadata(http, _device(), state)
+
+    http.get_ota_version.assert_awaited_once_with("home-1", "node-1")
+    http.get_ota_check.assert_awaited_once_with("home-1", "node-1")
+    http.get_esdk_connectivity.assert_awaited_once_with("home-1", "node-1")
+    assert state["firmware_version"] == "1.0.0"
+    assert state["node_connected"] is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_device_metadata_skips_without_capabilities() -> None:
+    http = MagicMock()
+    http.get_ota_version = AsyncMock()
+    http.get_ota_check = AsyncMock()
+    http.get_esdk_connectivity = AsyncMock()
+
+    device = _device(
+        device_type="lights",
+        capabilities=["change_light_state"],
+    )
+    await refresh_device_metadata(http, device, {})
+
+    http.get_ota_version.assert_not_called()
+    http.get_ota_check.assert_not_called()
+    http.get_esdk_connectivity.assert_not_called()

--- a/tests/unit/test_device_metadata.py
+++ b/tests/unit/test_device_metadata.py
@@ -100,6 +100,21 @@ async def test_refresh_device_metadata_fan_calls_ota_and_esdk() -> None:
 
 
 @pytest.mark.asyncio
+async def test_refresh_device_metadata_swallows_unexpected_errors() -> None:
+    http = MagicMock()
+    http.get_ota_version = AsyncMock(side_effect=RuntimeError("boom"))
+    http.get_ota_check = AsyncMock(return_value={"status": "FIRMWARE_ALREADY_UP_TO_DATE"})
+    http.get_esdk_connectivity = AsyncMock(return_value={"connected": True})
+
+    state: dict = {}
+    await refresh_device_metadata(http, _device(), state)
+
+    assert "firmware_version" not in state
+    assert state.get("firmware_update_available") is False
+    assert state.get("node_connected") is True
+
+
+@pytest.mark.asyncio
 async def test_refresh_device_metadata_skips_without_capabilities() -> None:
     http = MagicMock()
     http.get_ota_version = AsyncMock()

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -91,3 +91,43 @@ def test_french_auth_copy(mock_create: MagicMock) -> None:
     entry.entry_id = "abc"
     EnkiNotifier(hass, entry).notify_auth_failed()
     assert "connexion refusée" in mock_create.call_args.kwargs["title"].lower()
+
+
+@patch("enki.notifications.persistent_notification.async_dismiss")
+@patch("enki.notifications.persistent_notification.async_create")
+def test_sync_maintenance_mode_shows_notification(
+    mock_create: MagicMock,
+    mock_dismiss: MagicMock,
+    notifier: tuple[MagicMock, EnkiNotifier],
+) -> None:
+    _, n = notifier
+    n.sync_maintenance_mode({"maintenance": True})
+    mock_create.assert_called_once()
+    assert mock_create.call_args.kwargs["notification_id"] == "enki_maintenance_test-entry"
+    mock_dismiss.assert_not_called()
+
+
+@patch("enki.notifications.persistent_notification.async_dismiss")
+@patch("enki.notifications.persistent_notification.async_create")
+def test_sync_maintenance_mode_dismisses_when_clear(
+    mock_create: MagicMock,
+    mock_dismiss: MagicMock,
+    notifier: tuple[MagicMock, EnkiNotifier],
+) -> None:
+    hass, n = notifier
+    n.sync_maintenance_mode({"maintenance": False})
+    mock_create.assert_not_called()
+    mock_dismiss.assert_called_once_with(hass, "enki_maintenance_test-entry")
+
+
+@patch("enki.notifications.persistent_notification.async_dismiss")
+@patch("enki.notifications.persistent_notification.async_create")
+def test_sync_maintenance_mode_skips_when_settings_unavailable(
+    mock_create: MagicMock,
+    mock_dismiss: MagicMock,
+    notifier: tuple[MagicMock, EnkiNotifier],
+) -> None:
+    _, n = notifier
+    n.sync_maintenance_mode(None)
+    mock_create.assert_not_called()
+    mock_dismiss.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #52

- Poll Enki **OTA** APIs when referentiel lists `check_current_firmware_version` / `ota_inventory`
- Poll **ESDK connectivity** for ceiling fans (`states/{nodeId}`)
- Populate HA **device registry** (`sw_version`, `model_id`, serial) and optional binary sensors:
  - Connectivity (ESDK fans)
  - Firmware update available (`ota_inventory`)

## Implementation

Capability-driven reads in `api/device_metadata.py` (same pattern as sensor routing). Best-effort: 404 / missing API keys are skipped without breaking discovery.

## Test plan

- [x] Unit tests for merge helpers and refresh orchestration (`tests/unit/test_device_metadata.py`)
- [ ] Reload integration on a home with Inspire fan → device page shows firmware version
- [ ] Fan with OTA capability → `binary_sensor` update entity when `OTA_NEEDED`
- [ ] Fan → connectivity sensor reflects hub link state