### PR TITLE
refactor(labels): use spaced GitHub label names

### DIFF
--- a/.github/ISSUE_TEMPLATE/device_telemetry.yml
+++ b/.github/ISSUE_TEMPLATE/device_telemetry.yml
@@ -3,12 +3,12 @@ name: Device profile (telemetry)
 description: Anonymized Enki hardware profile for support prioritization
 title: "[telemetry] Manufacturer device kind · detail — reason"
 labels:
-  - device-telemetry
+  - device telemetry
 body:
   - type: markdown
     attributes:
       value: |
-        Issues with the `device-telemetry` label are often created from a **pre-filled GitHub link**
+        Issues with the `device telemetry` label are often created from a **pre-filled GitHub link**
         in Home Assistant (opt-in telemetry). Nothing is sent automatically.
 
         Do **not** include home/node IDs, email, passwords, or room names.
@@ -16,8 +16,8 @@ body:
         Prefer the HA notification link — titles, labels, and fields are filled from the
         anonymized profile (manufacturer, referentiel device ID, device kind, reason).
 
-        **Labels:** `device-telemetry` + reason (`unsupported`, `capability-gap`, or
-        `api-error`) + device family (`motorization`, `climate`, `lighting`, …).
+        **Labels:** `device telemetry` + reason (`unsupported`, `capability gap`, or
+        `api error`) + device family (`motorization`, `climate`, `lighting`, …).
         Brand and model stay in the title/body.
   - type: input
     attributes:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,8 +22,8 @@ jobs:
           days-before-pr-stale: 45
           days-before-issue-close: -1
           days-before-pr-close: -1
-          exempt-issue-labels: blocked,next-release,release-blocker,device-telemetry
-          exempt-pr-labels: blocked,next-release,release-blocker
+          exempt-issue-labels: blocked,next release,release blocker,device telemetry
+          exempt-pr-labels: blocked,next release,release blocker
           stale-issue-message: >
             This issue has had no activity for 60 days. It has been marked stale.
             Comment or remove the `stale` label to keep it open.

--- a/custom_components/enki/lib/telemetry_labels.py
+++ b/custom_components/enki/lib/telemetry_labels.py
@@ -7,8 +7,8 @@ from typing import Any
 _MISSING = "—"
 
 _REASON_GITHUB_LABELS: dict[str, str] = {
-    "api_read_errors": "api-error",
-    "uncovered_capabilities": "capability-gap",
+    "api_read_errors": "api error",
+    "uncovered_capabilities": "capability gap",
     "unsupported_device": "unsupported",
 }
 
@@ -23,14 +23,14 @@ _DEVICE_FAMILY_GITHUB_LABELS: dict[str, str] = {
     "sensors": "sensor",
 }
 
-_TELEMETRY_BASE_LABEL = "device-telemetry"
+_TELEMETRY_BASE_LABEL = "device telemetry"
 
 # Labels synced by scripts/sync_github_labels.sh (base + reason + coarse device family).
 TELEMETRY_GITHUB_LABEL_DEFINITIONS: tuple[tuple[str, str, str], ...] = (
-    ("device-telemetry", "6f42c1", "Opt-in anonymized device profile from Home Assistant"),
+    ("device telemetry", "6f42c1", "Opt-in anonymized device profile from Home Assistant"),
     ("unsupported", "d73a4a", "Device type not supported yet (telemetry)"),
-    ("capability-gap", "fbca04", "Supported device with missing capabilities (telemetry)"),
-    ("api-error", "b60205", "Cloud API read failures on supported device (telemetry)"),
+    ("capability gap", "fbca04", "Supported device with missing capabilities (telemetry)"),
+    ("api error", "b60205", "Cloud API read failures on supported device (telemetry)"),
     ("motorization", "1d76db", "Shutters, covers, and motorizations (telemetry)"),
     ("climate", "b60205", "Heating, pilot wire, ceiling fans (telemetry)"),
     ("lighting", "fef2c0", "Lights and dimmers (telemetry)"),
@@ -41,6 +41,9 @@ TELEMETRY_GITHUB_LABEL_DEFINITIONS: tuple[tuple[str, str, str], ...] = (
 
 # Removed from prefill; delete from repo via scripts/sync_github_labels.sh.
 TELEMETRY_GITHUB_ORPHAN_LABELS: tuple[str, ...] = (
+    "device-telemetry",
+    "capability-gap",
+    "api-error",
     "telemetry-unsupported",
     "telemetry-capability-gap",
     "telemetry-api-error",

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -96,7 +96,7 @@ Live tests: only via `workflow_dispatch` with `ENKI_*` secrets configured on the
 
 ## GitHub labels
 
-Workflow triage labels (`next-release`, `beta`, `stale`, …) and telemetry labels are defined in [`scripts/github_labels.py`](../scripts/github_labels.py). Sync them to the repository:
+Workflow triage labels (`next release`, `beta`, `stale`, …) and telemetry labels are defined in [`scripts/github_labels.py`](../scripts/github_labels.py). Sync them to the repository:
 
 ```bash
 ./scripts/sync_github_labels.sh
@@ -104,17 +104,17 @@ Workflow triage labels (`next-release`, `beta`, `stale`, …) and telemetry labe
 
 | Label | Use |
 |-------|-----|
-| `next-release` | Planned for the upcoming tag |
-| `release-blocker` | Must ship before the next release |
+| `next release` | Planned for the upcoming tag |
+| `release blocker` | Must ship before the next release |
 | `beta` | Experimental feature or device; needs testers |
 | `stale` | No recent activity (also applied weekly by CI) |
 | `blocked` | Waiting on hardware, upstream API, or third party |
-| `needs-info` | Waiting on reporter feedback |
+| `needs info` | Waiting on reporter feedback |
 | `confirmed` | Reproduced or accepted by a maintainer |
 | `regression` | Worked before, broken recently |
-| `breaking-change` | Intentional breaking change for users |
+| `breaking change` | Intentional breaking change for users |
 
-Telemetry-specific labels (`device-telemetry`, `unsupported`, `motorization`, …) are pre-filled on opt-in device profile issues — see [TELEMETRY.md](TELEMETRY.md).
+Telemetry-specific labels (`device telemetry`, `unsupported`, `motorization`, …) are pre-filled on opt-in device profile issues — see [TELEMETRY.md](TELEMETRY.md).
 
 ## Publishing a release
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -54,6 +54,6 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for tests.
 ## Technical
 
 - Deduplication by SHA256 fingerprint (local HA storage)
-- URL: `github.com/.../issues/new?title=...&body=...&labels=device-telemetry,unsupported`
-- Three labels per issue: `device-telemetry` + reason + device family (`motorization`, `climate`, …). Brand and model stay in the title/body. Sync repo labels with `scripts/sync_github_labels.sh` (also removes retired labels).
+- URL: `github.com/.../issues/new?title=...&body=...&labels=device%20telemetry,unsupported`
+- Three labels per issue: `device telemetry` + reason + device family (`motorization`, `climate`, …). Brand and model stay in the title/body. Sync repo labels with `scripts/sync_github_labels.sh` (also removes retired labels).
 - No token, no `repository_dispatch`

--- a/scripts/github_labels.py
+++ b/scripts/github_labels.py
@@ -8,18 +8,27 @@ from enki.lib.telemetry_labels import (
 )
 
 WORKFLOW_GITHUB_LABEL_DEFINITIONS: tuple[tuple[str, str, str], ...] = (
-    ("next-release", "0075ca", "Target for the upcoming tagged release"),
-    ("release-blocker", "b60205", "Must be resolved before the next release"),
+    ("next release", "0075ca", "Target for the upcoming tagged release"),
+    ("release blocker", "b60205", "Must be resolved before the next release"),
     ("beta", "fbca04", "Beta or experimental; needs real-world testing"),
     ("stale", "cfd3d7", "No recent activity"),
     ("blocked", "e99695", "Blocked by external dependency or missing hardware"),
-    ("needs-info", "d876e3", "Waiting on reporter feedback"),
+    ("needs info", "d876e3", "Waiting on reporter feedback"),
     ("confirmed", "0e8a16", "Reproduced or accepted by a maintainer"),
     ("regression", "d73a4a", "Worked before, broken in a recent version"),
-    ("breaking-change", "5319e7", "Breaking change for existing users"),
+    ("breaking change", "5319e7", "Breaking change for existing users"),
 )
 
-GITHUB_LABEL_ORPHAN_LABELS: tuple[str, ...] = TELEMETRY_GITHUB_ORPHAN_LABELS
+WORKFLOW_GITHUB_ORPHAN_LABELS: tuple[str, ...] = (
+    "next-release",
+    "release-blocker",
+    "breaking-change",
+    "needs-info",
+)
+
+GITHUB_LABEL_ORPHAN_LABELS: tuple[str, ...] = (
+    WORKFLOW_GITHUB_ORPHAN_LABELS + TELEMETRY_GITHUB_ORPHAN_LABELS
+)
 
 
 def github_label_definitions() -> tuple[tuple[str, str, str], ...]:

--- a/tests/unit/test_device_profile.py
+++ b/tests/unit/test_device_profile.py
@@ -67,5 +67,5 @@ def test_build_github_new_issue_url_contains_repo_and_body() -> None:
     assert "title=" in url
     assert "body=" in url
     assert "labels=" in url
-    assert "device-telemetry" in url
+    assert "device%20telemetry" in url or "device telemetry" in url
     assert "equation_radiator" in url

--- a/tests/unit/test_telemetry_labels.py
+++ b/tests/unit/test_telemetry_labels.py
@@ -63,7 +63,7 @@ def test_github_labels_for_unsupported_remote() -> None:
 
     labels = telemetry_github_labels(_lexman_remote_export())
     assert labels == (
-        "device-telemetry",
+        "device telemetry",
         "unsupported",
         "control",
     )
@@ -77,8 +77,8 @@ def test_github_labels_for_capability_gap_cover() -> None:
     export["telemetry_reason"] = "uncovered_capabilities"
     labels = telemetry_github_labels(export)
     assert labels == (
-        "device-telemetry",
-        "capability-gap",
+        "device telemetry",
+        "capability gap",
         "motorization",
     )
 


### PR DESCRIPTION
## Summary
- Align telemetry and workflow label names with repo convention (spaces instead of hyphens): `device telemetry`, `capability gap`, `next release`, etc.
- Update issue prefill, stale workflow exemptions, docs, and tests
- Extend sync script orphan list to retire hyphenated label names

## Test plan
- [x] `pytest tests/unit/test_telemetry_labels.py tests/unit/test_github_labels.py tests/unit/test_device_profile.py`
- [x] Run `./scripts/sync_github_labels.sh` after merge to clean up old hyphenated labels on GitHub