### PR TITLE
feat(fan,solar): Radix endpoints + Envertech energy sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,12 @@ Download a [release](https://github.com/cyrilcolinet/enki-integration-hass/relea
 - 🛠️ [Development & APK keys](docs/DEVELOPMENT.md)
 - 📡 [Opt-in telemetry](docs/TELEMETRY.md)
 - 🏠 [Enki support](https://support.enki-home.com/)
-- 🔗 [Original project — CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
+- 🔗 [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
 
 ## Credits & license
 
 **Community** integration, not affiliated with Leroy Merlin, Adeo, or Enki. Unofficial cloud API, subject to change.
 
-- Fork of [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
-- Sensors / siren: inspired by [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki)
-- Icon: [MarioCadenas/hass-enki-component](https://github.com/MarioCadenas/hass-enki-component)
+- Based on [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
 
 [MIT](LICENSE) license

--- a/custom_components/enki/api/capability_routing.py
+++ b/custom_components/enki/api/capability_routing.py
@@ -65,4 +65,16 @@ CAPABILITY_READS: tuple[CapabilityRead, ...] = (
     ),
     CapabilityRead("presence_detector", "check_occupancy", "occupancy"),
     CapabilityRead("presence_detector", "check_occupancy_mode", "occupancy_mode"),
+    CapabilityRead(
+        "lexman_envertech",
+        "check_power_production",
+        "power_production",
+        skip=lambda profile: not profile.is_inverter,
+    ),
+    CapabilityRead(
+        "lexman_envertech",
+        "check_energy_production",
+        "energy_production",
+        skip=lambda profile: not profile.is_inverter,
+    ),
 )

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -27,6 +27,7 @@ from ..lib.conversion import (
     normalize_power_state,
 )
 from ..lib.enki_scope import device_in_enki_scope
+from ..lib.production import parse_production_value
 from ..lib.shutter import normalize_shutter_position
 from .auth import EnkiAuthSession
 from .capability_routing import CAPABILITY_READS, CapabilityRead
@@ -253,9 +254,9 @@ class EnkiAPI:
         bff_type = metadata.get("deviceType", "")
         main_change_capability = metadata.get("mainChangeCapability") or {}
         main_change_endpoints = [
-            endpoint.get("id")
-            for endpoint in main_change_capability.get("endpoints", [])
-            if endpoint.get("id") is not None
+            endpoint
+            for endpoint in (main_change_capability.get("endpoints") or [])
+            if isinstance(endpoint, dict) and endpoint.get("id") is not None
         ]
 
         node_info = await http.get_node(home_id, node_id)
@@ -267,6 +268,7 @@ class EnkiAPI:
 
         title = item.get("title") or {}
         device_name = title.get("label") or node_id
+        model = _referentiel_model(node_info, device_info)
 
         skeleton = EnkiDevice(
             home_id=home_id,
@@ -282,6 +284,8 @@ class EnkiAPI:
             main_change_capability_id=metadata.get("mainChangeCapabilityId"),
             main_change_capability_endpoints=main_change_endpoints,
             power_production=power_production,
+            referentiel_i18n=str(device_info.get("i18n") or ""),
+            referentiel_model=str(model or ""),
         )
         manufacturer = (
             node_info.get("manufacturerId")
@@ -302,7 +306,6 @@ class EnkiAPI:
         else:
             supported = integration_supports_device(skeleton)
 
-        model = _referentiel_model(node_info, device_info)
         preliminary_firmware = node_info.get("version") or device_info.get("version")
         record = build_discovery_record(
             device_type=device_type,
@@ -374,6 +377,8 @@ class EnkiAPI:
                 main_change_capability_id=metadata.get("mainChangeCapabilityId"),
                 main_change_capability_endpoints=main_change_endpoints,
                 power_production=power_production,
+                referentiel_i18n=str(device_info.get("i18n") or ""),
+                referentiel_model=str(model or ""),
             ),
             record,
         )
@@ -471,8 +476,8 @@ class EnkiAPI:
                     err=err,
                 )
 
-        if profile.is_inverter:
-            state["power_production"] = device.power_production
+        if profile.is_inverter and device.power_production is not None:
+            state.setdefault("power_production", device.power_production)
 
         await self._append_capability_states(http, home_id, node_id, profile, state)
         return state
@@ -515,7 +520,12 @@ class EnkiAPI:
                 )
                 return None
             if data and "lastReportedValue" in data:
-                return read.state_key, data["lastReportedValue"]
+                value = data["lastReportedValue"]
+                if read.state_key in {"power_production", "energy_production"}:
+                    parsed = parse_production_value(value)
+                    if parsed is not None:
+                        return read.state_key, parsed
+                return read.state_key, value
             return None
 
         results = await asyncio.gather(*(read_one(read) for read in CAPABILITY_READS))

--- a/custom_components/enki/api/gateway_registry.py
+++ b/custom_components/enki/api/gateway_registry.py
@@ -289,10 +289,10 @@ ENKI_MICRO_SERVICES: tuple[EnkiMicroService, ...] = (
     EnkiMicroService(
         "api-enki-lexman-envertech-prod",
         "ENKI_LEXMAN_ENVERTECH_API_KEY",
-        "",
+        "lexman_envertech",
         "/api-enki-lexman-envertech-prod/v1/energy-production",
-        wired=False,
-        notes="",
+        wired=True,
+        notes="Lexman solar inverters (check-power/energy-production)",
     ),
     EnkiMicroService(
         "api-enki-lighting-prod",
@@ -647,7 +647,9 @@ LEGACY_SLUG_ALIASES: dict[str, str] = {
     "api-enki-access-and-motorizations-prod": "api-enki-rolling-prod",
 }
 
-OPTIONAL_KEY_TRANSPORT_IDS = frozenset({"heating", "water_sensor", "motorization", "ota", "esdk"})
+OPTIONAL_KEY_TRANSPORT_IDS = frozenset(
+    {"heating", "water_sensor", "motorization", "ota", "esdk", "lexman_envertech"}
+)
 
 WIRED_PATH_PREFIXES: dict[str, str] = {
     svc.transport_id: svc.path_prefix

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -10,7 +10,11 @@ from ..const import (
     DEVICE_TYPE_FANS,
     DEVICE_TYPE_INVERTERS,
     DEVICE_TYPE_LIGHTS,
-    FAN_ENDPOINT,
+)
+from ..lib.fan_endpoints import (
+    endpoint_id_from_entry,
+    fan_light_endpoints_from_motor,
+    infer_fan_motor_endpoints,
 )
 from .models import EnkiDevice
 
@@ -49,19 +53,21 @@ class EnkiCapabilityProfile:
     bff_device_type: str = ""
     main_change_capability_id: str | None = None
     main_change_capability_endpoints: tuple[int, ...] = ()
+    endpoint_entries: tuple[int | dict[str, Any], ...] = ()
+    device_name: str = ""
+    referentiel_i18n: str = ""
+    referentiel_model: str = ""
     power_production: float | None = None
 
     @classmethod
     def from_device(cls, device: EnkiDevice) -> EnkiCapabilityProfile:
         """Build a profile snapshot from a discovered device."""
+        endpoint_entries = tuple(device.main_change_capability_endpoints)
         endpoints: list[int] = []
-        for endpoint in device.main_change_capability_endpoints:
-            if isinstance(endpoint, int):
-                endpoints.append(endpoint)
-            elif isinstance(endpoint, dict):
-                endpoint_id = endpoint.get("id")
-                if isinstance(endpoint_id, int):
-                    endpoints.append(endpoint_id)
+        for entry in endpoint_entries:
+            endpoint_id = endpoint_id_from_entry(entry)
+            if endpoint_id is not None:
+                endpoints.append(endpoint_id)
         return cls(
             device_type=device.device_type,
             capabilities=frozenset(capabilities_set(device.capabilities)),
@@ -69,6 +75,10 @@ class EnkiCapabilityProfile:
             bff_device_type=device.bff_device_type,
             main_change_capability_id=device.main_change_capability_id,
             main_change_capability_endpoints=tuple(sorted(set(endpoints))),
+            endpoint_entries=endpoint_entries,
+            device_name=device.device_name,
+            referentiel_i18n=device.referentiel_i18n,
+            referentiel_model=device.referentiel_model,
             power_production=device.power_production,
         )
 
@@ -112,7 +122,7 @@ class EnkiCapabilityProfile:
 
     @property
     def supports_fan_speed_control(self) -> bool:
-        """True when referentiel defines a fan speed range (CyrilP/hass-enki-component)."""
+        """True when referentiel defines a writable fan speed range."""
         return self.supports_fan_speed and self.fan_max_speed is not None
 
     @property
@@ -136,6 +146,10 @@ class EnkiCapabilityProfile:
     @property
     def supports_power_production(self) -> bool:
         return "check_power_production" in self.capabilities
+
+    @property
+    def supports_energy_production(self) -> bool:
+        return "check_energy_production" in self.capabilities
 
     @property
     def supports_shutter_position(self) -> bool:
@@ -376,10 +390,10 @@ class EnkiCapabilityProfile:
 
     @property
     def is_inverter(self) -> bool:
-        """Solar inverters with live production on the BFF dashboard."""
+        """Solar inverters (Lexman Envertech, …)."""
         if self.device_type in {DEVICE_TYPE_INVERTERS, "inverters"}:
-            return self.power_production is not None
-        return self.supports_power_production and self.power_production is not None
+            return self.supports_power_production or self.supports_energy_production
+        return self.supports_power_production or self.supports_energy_production
 
     @property
     def is_cover(self) -> bool:
@@ -485,20 +499,41 @@ class EnkiCapabilityProfile:
         return list(self.main_change_capability_endpoints)
 
     @property
+    def _fan_motor_endpoint_ids(self) -> frozenset[int]:
+        if self.device_type != DEVICE_TYPE_FANS and not self.is_fan:
+            return frozenset()
+        if self.main_change_capability_id != "switch_electrical_power":
+            return frozenset()
+        return infer_fan_motor_endpoints(
+            power_endpoints=list(self.main_change_capability_endpoints),
+            endpoint_entries=self.endpoint_entries,
+            supports_light_state=self.supports_light_state,
+            supports_fan_speed=self.supports_fan_speed,
+            device_name=self.device_name,
+            referentiel_i18n=self.referentiel_i18n,
+            referentiel_model=self.referentiel_model,
+        )
+
+    @property
     def fan_light_endpoints(self) -> list[int]:
         """Light kit endpoints on ceiling fans (excludes the motor endpoint)."""
         if self.device_type != DEVICE_TYPE_FANS and not self.is_fan:
             return []
-        return [endpoint for endpoint in self.power_switch_endpoints if endpoint != FAN_ENDPOINT]
+        return fan_light_endpoints_from_motor(
+            list(self.power_switch_endpoints),
+            self._fan_motor_endpoint_ids,
+        )
 
     @property
     def fan_motor_endpoints(self) -> list[int]:
         """Power-prod endpoints that are not light kit circuits."""
         if self.main_change_capability_id != "switch_electrical_power":
             return []
-        light_endpoints = set(self.fan_light_endpoints)
+        motor_ids = self._fan_motor_endpoint_ids
         return [
-            endpoint for endpoint in self.power_switch_endpoints if endpoint not in light_endpoints
+            endpoint
+            for endpoint in self.power_switch_endpoints
+            if endpoint in motor_ids
         ]
 
     @property

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -530,11 +530,7 @@ class EnkiCapabilityProfile:
         if self.main_change_capability_id != "switch_electrical_power":
             return []
         motor_ids = self._fan_motor_endpoint_ids
-        return [
-            endpoint
-            for endpoint in self.power_switch_endpoints
-            if endpoint in motor_ids
-        ]
+        return [endpoint for endpoint in self.power_switch_endpoints if endpoint in motor_ids]
 
     @property
     def fan_motor_endpoint(self) -> int | None:

--- a/custom_components/enki/domain/models.py
+++ b/custom_components/enki/domain/models.py
@@ -28,6 +28,8 @@ class EnkiDevice:
     main_change_capability_id: str | None = None
     main_change_capability_endpoints: list[int | dict[str, Any]] = field(default_factory=list)
     power_production: float | None = None
+    referentiel_i18n: str = ""
+    referentiel_model: str = ""
 
     @property
     def is_active(self) -> bool:

--- a/custom_components/enki/domain/state.py
+++ b/custom_components/enki/domain/state.py
@@ -112,6 +112,10 @@ class EnkiDeviceState:
         return None
 
     @property
+    def energy_production(self) -> float | None:
+        return _as_float(self._data.get("energy_production"))
+
+    @property
     def shutter_position(self) -> int | None:
         from ..lib.shutter import normalize_shutter_position
 

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -55,6 +55,7 @@ _CAPABILITY_PROBES: dict[str, str] = {
     "check_motion_detection": "supports_motion_detection",
     "check_motion_detector_state": "supports_motion_detection",
     "check_power_production": "supports_power_production",
+    "check_energy_production": "supports_energy_production",
     "check_shutter_opening": "supports_shutter_opening",
     "check_shutter_position": "supports_shutter_position",
     "check_siren_global_state": "supports_siren",

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -199,12 +199,14 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         self.coordinator.update_cached_value(node_id, "fan_speed", speed)
 
     async def _set_motor_power(self, power: str) -> None:
-        """ON/OFF fans without speed range — global power API (CyrilP/hass-enki-component)."""
+        """ON/OFF fans without speed range — per-endpoint or global power API."""
         node_id = self._device.node_id
+        motor_endpoint = self._device.profile.fan_motor_endpoint
         await self.coordinator.api.async_switch_electrical_power(
             self._device.home_id,
             node_id,
             power,
+            endpoint=motor_endpoint,
         )
         self.coordinator.update_cached_value(node_id, "electrical_power", power)
         self.coordinator.update_cached_value(node_id, "power", power)

--- a/custom_components/enki/lib/conversion.py
+++ b/custom_components/enki/lib/conversion.py
@@ -56,7 +56,7 @@ def percentage_to_fan_speed(percentage: int, max_speed: int) -> int:
 
 
 def fan_speed_to_percentage(speed: int, max_speed: int) -> int:
-    """Map Enki fan speed to HA percentage (linear, matches CyrilP/hass-enki-component)."""
+    """Map Enki fan speed to HA percentage (linear 1…max)."""
     if speed <= 0 or max_speed <= 0:
         return 0
     return int(round(speed * 100 / max_speed))

--- a/custom_components/enki/lib/fan_endpoints.py
+++ b/custom_components/enki/lib/fan_endpoints.py
@@ -1,0 +1,108 @@
+"""Resolve fan motor vs light-kit endpoints on multi-endpoint ceiling fans."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..const import FAN_ENDPOINT
+
+_FAN_METADATA_KEYS = ("type", "endpointType", "category", "role", "label")
+_FAN_TYPE_MARKERS = frozenset({"fan", "motor", "ventilation", "vmc"})
+_LIGHT_TYPE_MARKERS = frozenset({"light", "lighting", "dimmer", "lamp"})
+
+
+def endpoint_id_from_entry(entry: int | dict[str, Any]) -> int | None:
+    if isinstance(entry, int):
+        return entry
+    if isinstance(entry, dict):
+        raw = entry.get("id")
+        if isinstance(raw, int):
+            return raw
+    return None
+
+
+def _normalize_marker(value: object) -> str:
+    return str(value).strip().lower() if value is not None else ""
+
+
+def motor_endpoints_from_metadata(
+    endpoint_entries: tuple[int | dict[str, Any], ...],
+) -> frozenset[int] | None:
+    """Return motor endpoint IDs when BFF endpoint dicts carry type metadata."""
+    motors: set[int] = set()
+    lights: set[int] = set()
+    for entry in endpoint_entries:
+        ep_id = endpoint_id_from_entry(entry)
+        if ep_id is None or not isinstance(entry, dict):
+            continue
+        marker = ""
+        for key in _FAN_METADATA_KEYS:
+            marker = marker or _normalize_marker(entry.get(key))
+        if any(token in marker for token in _FAN_TYPE_MARKERS):
+            motors.add(ep_id)
+        elif any(token in marker for token in _LIGHT_TYPE_MARKERS):
+            lights.add(ep_id)
+    if motors:
+        return frozenset(motors)
+    if lights and len(lights) < len(endpoint_entries):
+        all_ids = {
+            endpoint_id_from_entry(entry)
+            for entry in endpoint_entries
+            if endpoint_id_from_entry(entry) is not None
+        }
+        return frozenset(all_ids - lights)
+    return None
+
+
+def _label_blob(*parts: str) -> str:
+    return " ".join(part for part in parts if part).lower()
+
+
+def infer_fan_motor_endpoints(
+    *,
+    power_endpoints: list[int],
+    endpoint_entries: tuple[int | dict[str, Any], ...],
+    supports_light_state: bool,
+    supports_fan_speed: bool,
+    device_name: str,
+    referentiel_i18n: str,
+    referentiel_model: str,
+) -> frozenset[int]:
+    """Best-effort motor endpoint resolution (Siroco+ vs Inspire Radix, …)."""
+    if not power_endpoints:
+        return frozenset()
+
+    from_metadata = motor_endpoints_from_metadata(endpoint_entries)
+    if from_metadata is not None:
+        return from_metadata
+
+    if not supports_light_state:
+        return frozenset(power_endpoints)
+
+    if len(power_endpoints) == 1:
+        return frozenset(power_endpoints)
+
+    sorted_eps = sorted(power_endpoints)
+    labels = _label_blob(device_name, referentiel_i18n, referentiel_model)
+
+    # Inspire Radix: dual LED kit at corners, motor on the middle endpoint.
+    if (
+        len(sorted_eps) == 3
+        and supports_fan_speed
+        and sorted_eps[2] - sorted_eps[0] == 2
+        and "radix" in labels
+    ):
+        return frozenset({sorted_eps[1]})
+
+    # Legacy Siroco+ / Cadix: motor on endpoint 1.
+    if FAN_ENDPOINT in power_endpoints:
+        return frozenset({FAN_ENDPOINT})
+
+    return frozenset({min(power_endpoints)})
+
+
+def fan_light_endpoints_from_motor(
+    power_endpoints: list[int],
+    motor_endpoints: frozenset[int],
+) -> list[int]:
+    return [endpoint for endpoint in power_endpoints if endpoint not in motor_endpoints]

--- a/custom_components/enki/lib/production.py
+++ b/custom_components/enki/lib/production.py
@@ -1,0 +1,28 @@
+"""Solar production value parsers (BFF + Envertech API)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .bff import parse_bff_power
+
+
+def parse_production_value(value: Any) -> float | None:
+    """Normalize power (W) or energy (kWh) readings from Enki micro-services."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        parsed = parse_bff_power({"value": value})
+        if parsed is not None:
+            return parsed
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    if isinstance(value, dict):
+        for key in ("value", "lastReportedValue", "amount"):
+            if key in value:
+                parsed = parse_production_value(value[key])
+                if parsed is not None:
+                    return parsed
+    return None

--- a/custom_components/enki/platforms/light/behavior.py
+++ b/custom_components/enki/platforms/light/behavior.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_TEMP_KELVIN
 
-from ...const import FAN_ENDPOINT
 from ...coordinator import EnkiCoordinator
 from ...entity import EnkiEntity
 
@@ -33,11 +32,12 @@ class EnkiLightBehaviorMixin:
 
     def _uses_endpoint_power(self: EnkiEntity, endpoint_id: int | None) -> bool:
         """True when simple on/off should use per-endpoint power API."""
-        if endpoint_id is None or endpoint_id == FAN_ENDPOINT:
+        if endpoint_id is None:
             return False
         profile = self._device.profile
         if profile.is_fan:
-            # Fan light kits are driven by api-enki-lighting-prod, not power-prod.
+            return False
+        if endpoint_id in profile.fan_motor_endpoints:
             return False
         return len(profile.power_switch_endpoints) > 1
 

--- a/custom_components/enki/sensor.py
+++ b/custom_components/enki/sensor.py
@@ -47,6 +47,8 @@ def _build_sensor_entities(
 
     if _has_power_production_sensor(device):
         entities.append(EnkiPowerProductionSensor(coordinator, device))
+    if _has_energy_production_sensor(device):
+        entities.append(EnkiEnergyProductionSensor(coordinator, device))
     if profile.supports_current_temperature and not profile.is_climate:
         entities.append(EnkiTemperatureSensor(coordinator, device))
     if profile.supports_current_humidity:
@@ -63,13 +65,16 @@ def _build_sensor_entities(
 
 def _has_power_production_sensor(device: EnkiDevice) -> bool:
     profile = device.profile
-    if device.power_production is None:
-        return False
-    return profile.is_inverter or profile.supports_power_production
+    return profile.is_inverter and profile.supports_power_production
+
+
+def _has_energy_production_sensor(device: EnkiDevice) -> bool:
+    profile = device.profile
+    return profile.is_inverter and profile.supports_energy_production
 
 
 class EnkiPowerProductionSensor(EnkiEntity, SensorEntity):
-    """Live solar production from the Enki BFF dashboard."""
+    """Live solar production (W) from BFF dashboard or Envertech API."""
 
     _attr_translation_key = "power_production"
     _attr_device_class = SensorDeviceClass.POWER
@@ -82,15 +87,32 @@ class EnkiPowerProductionSensor(EnkiEntity, SensorEntity):
 
     @property
     def native_value(self) -> float | None:
-        value = self._device.power_production
+        value = self._device.reported.power_production
         if value is None:
-            value = self._device.reported.power_production
+            value = self._device.power_production
         if value is None:
             return None
         try:
             return float(value)
         except (TypeError, ValueError):
             return None
+
+
+class EnkiEnergyProductionSensor(EnkiEntity, SensorEntity):
+    """Cumulative solar energy (kWh) from api-enki-lexman-envertech-prod."""
+
+    _attr_translation_key = "energy_production"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{DOMAIN}-{device.node_id}-energy-production"
+
+    @property
+    def native_value(self) -> float | None:
+        return self._device.reported.energy_production
 
 
 class EnkiTemperatureSensor(EnkiEntity, SensorEntity):

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -80,6 +80,9 @@
       "power_production": {
         "name": "Power production"
       },
+      "energy_production": {
+        "name": "Energy production"
+      },
       "temperature": {
         "name": "Temperature"
       },

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -80,6 +80,9 @@
       "power_production": {
         "name": "Power production"
       },
+      "energy_production": {
+        "name": "Energy production"
+      },
       "temperature": {
         "name": "Temperature"
       },

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -80,6 +80,9 @@
       "power_production": {
         "name": "Production"
       },
+      "energy_production": {
+        "name": "Énergie produite"
+      },
       "temperature": {
         "name": "Température"
       },

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Enki cloud API — engineering notes
 
-This integration talks to the **unofficial** Enki REST API used by the Leroy Merlin / Adeo mobile app. There is no public developer portal for end users; behaviour was inferred from network traffic and existing community work.
+This integration talks to the **unofficial** Enki REST API used by the Leroy Merlin / Adeo mobile app. There is no public developer portal for end users; behaviour was inferred from network traffic and [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component).
 
 ## Authentication
 
@@ -55,7 +55,7 @@ Detection is **capability-based** (referentiel metadata + BFF dashboard), not li
 | Heating / pilot wire / thermostat | `select`, `climate`, `switch`, `binary_sensor` | `api-enki-heating-prod` — `ENKI_HEATING_API_KEY` in `const.py` (APK 2.25.1); if cleared, reads are skipped silently and writes raise an error |
 | Water leak sensors | `binary_sensor`, `sensor` (battery) | `api-enki-water-leak-detector-prod` + `api-enki-battery-health-prod` — keys in `const.py` (APK 2.25.1); same fallback if a key is missing |
 
-Sensor capability paths follow the same pattern as [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki): `GET/POST …/v1/sensors/{node_id}/{kebab-case-capability}` (siren uses `/v1/siren/`).
+Sensor capability paths: `GET/POST …/v1/sensors/{node_id}/{kebab-case-capability}` (siren uses `/v1/siren/`).
 
 Multi-endpoint lights (several circuits on one node) create one HA light entity per BFF `mainChangeCapability` endpoint.
 
@@ -176,6 +176,5 @@ The Enki app also controls alarms via other microservices. Use `scripts/discover
 
 ## References
 
-- Fork base: [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) (lights)
-- Fan / airflow research: community reverse engineering of ESDK ceiling fans
+- [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) (lights)
 - Product docs: [Enki support — Inspire](https://support.enki-home.com/)

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -71,7 +71,7 @@ Scenarios refresh on each coordinator poll. They appear under the virtual device
 
 ## Enki sensors (Lexman, Sedea, …)
 
-Micro-services aligned with [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki) (gateway keys already in `const.py`).
+Gateway keys in `gateway_keys_data.py` (APK 2.25.1).
 
 ### Motion / contact / vibration
 

--- a/tests/unit/test_api_routing.py
+++ b/tests/unit/test_api_routing.py
@@ -110,7 +110,7 @@ async def test_fan_turn_off_uses_airflow_when_speed_state_missing() -> None:
 
 @pytest.mark.asyncio
 async def test_fan_turn_on_uses_power_when_only_check_fan_speed() -> None:
-    """Ae Toit-style fans: check_fan_speed without writable range → power-prod."""
+    """Fans with check_fan_speed but no writable range fall back to power-prod."""
     device = EnkiDevice(
         home_id="home-1",
         device_id="AE_TOIT_1",
@@ -141,6 +141,7 @@ async def test_fan_turn_on_uses_power_when_only_check_fan_speed() -> None:
         "home-1",
         "6a1468f4045591224e5f1686",
         "ON",
+        endpoint=1,
     )
     coordinator.api.async_set_fan_speed.assert_not_called()
 
@@ -174,5 +175,6 @@ async def test_fan_turn_on_falls_back_to_power_without_fan_speed_capability() ->
         "home-1",
         "node-1",
         "ON",
+        endpoint=None,
     )
     coordinator.api.async_set_fan_speed.assert_not_called()

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -52,6 +52,16 @@ def test_is_inverter_device() -> None:
     assert device_is_supported(device) is True
 
 
+def test_is_inverter_without_bff_power() -> None:
+    device = _device(
+        device_type="inverters",
+        capabilities=["check_power_production", "check_energy_production"],
+        power_production=None,
+    )
+    assert is_inverter_device(device) is True
+    assert device.profile.supports_energy_production is True
+
+
 def test_device_uses_power_api_only() -> None:
     device = _device(
         capabilities=["switch_electrical_power", "check_electrical_power"],
@@ -80,6 +90,20 @@ def test_fan_light_endpoints_excludes_motor() -> None:
         main_change_capability_endpoints=[1, 2, 3],
     )
     assert fan_light_endpoints(device) == [2, 3]
+
+
+def test_fan_light_endpoints_radix_motor_on_middle_endpoint() -> None:
+    from enki.domain.capabilities import fan_light_endpoints
+
+    device = _device(
+        device_type="ceiling_fans",
+        device_name="Inspire Radix",
+        capabilities=["change_fan_speed", "change_light_state"],
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[1, 2, 3],
+    )
+    assert fan_light_endpoints(device) == [1, 3]
+    assert device.profile.fan_motor_endpoints == [2]
 
 
 def test_fan_max_speed_from_metadata() -> None:

--- a/tests/unit/test_fan_endpoints.py
+++ b/tests/unit/test_fan_endpoints.py
@@ -1,0 +1,43 @@
+"""Unit tests for fan endpoint resolution."""
+
+from __future__ import annotations
+
+from enki.lib.fan_endpoints import (
+    infer_fan_motor_endpoints,
+    motor_endpoints_from_metadata,
+)
+
+
+def test_motor_endpoints_from_metadata_type_fan() -> None:
+    entries = (
+        {"id": 1, "type": "LIGHTING"},
+        {"id": 2, "type": "FAN"},
+        {"id": 3, "type": "LIGHTING"},
+    )
+    assert motor_endpoints_from_metadata(entries) == frozenset({2})
+
+
+def test_infer_fan_motor_endpoints_radix_by_name() -> None:
+    motors = infer_fan_motor_endpoints(
+        power_endpoints=[1, 2, 3],
+        endpoint_entries=(1, 2, 3),
+        supports_light_state=True,
+        supports_fan_speed=True,
+        device_name="Ventilateur Radix",
+        referentiel_i18n="",
+        referentiel_model="",
+    )
+    assert motors == frozenset({2})
+
+
+def test_infer_fan_motor_endpoints_siroco_default() -> None:
+    motors = infer_fan_motor_endpoints(
+        power_endpoints=[1, 2, 3],
+        endpoint_entries=(1, 2, 3),
+        supports_light_state=True,
+        supports_fan_speed=True,
+        device_name="Inspire Siroco+",
+        referentiel_i18n="",
+        referentiel_model="",
+    )
+    assert motors == frozenset({1})

--- a/tests/unit/test_production.py
+++ b/tests/unit/test_production.py
@@ -1,0 +1,15 @@
+"""Unit tests for solar production parsers."""
+
+from __future__ import annotations
+
+from enki.lib.production import parse_production_value
+
+
+def test_parse_production_value_numeric() -> None:
+    assert parse_production_value(250) == 250.0
+    assert parse_production_value(12.5) == 12.5
+
+
+def test_parse_production_value_string_with_unit() -> None:
+    assert parse_production_value("109 W") == 109.0
+    assert parse_production_value("42.3 kWh") == 42.3


### PR DESCRIPTION
## Summary
- Fix fan light/motor endpoint detection when motor is not BFF endpoint 1 (Inspire Radix)
- Wire `api-enki-lexman-envertech-prod` for `check_power_production` and `check_energy_production`
- Add cumulative energy sensor (kWh); inverter discovery no longer requires BFF dashboard tile
- Clean up external repo references in docs (CyrilP only)

## Test plan
- [x] `pytest tests/unit` — 195 passed
- [x] `ruff check custom_components/enki tests/unit`
- [x] Manual: Inspire Radix — fan motor on endpoint 2, lights on 1+3
- [x] Manual: Envertech inverter — power W + energy kWh sensors