### PR TITLE
feat(migration): migrate legacy CyrilP config entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Per-device detail: [docs/SUPPORTED_DEVICES.md](docs/SUPPORTED_DEVICES.md) · His
 
 Default HACS store (goal): [docs/HACS.md](docs/HACS.md#default-hacs-store)
 
+Upgrading from [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)? See [docs/MIGRATION.md](docs/MIGRATION.md).
+
 ### Add the integration
 
 1. **Settings** → **Devices & services** → **Add integration**

--- a/custom_components/enki/config_flow.py
+++ b/custom_components/enki/config_flow.py
@@ -41,7 +41,19 @@ async def _validate_credentials(hass: HomeAssistant, data: dict[str, Any]) -> No
 class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle Enki config and reconfigure flows."""
 
-    VERSION = 1
+    VERSION = 2
+
+    @staticmethod
+    async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+        """Migrate legacy CyrilP/hass-enki-component config entries."""
+        from .migration import async_migrate_legacy_entry
+
+        if config_entry.version >= 2:
+            return True
+
+        await async_migrate_legacy_entry(hass, config_entry)
+        hass.config_entries.async_update_entry(config_entry, version=2)
+        return True
 
     async def async_step_user(
         self,

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -12,9 +12,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import EnkiAPI
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER
 from .domain.models import EnkiDevice
 from .exceptions import EnkiAuthError, EnkiConnectionError
+from .migration import resolve_scan_interval
 from .notifications import EnkiNotifier, notify_for_connection_error
 from .telemetry import EnkiTelemetryReporter
 
@@ -32,10 +33,7 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         )
         self._notifier = EnkiNotifier(hass, config_entry)
         self._telemetry = EnkiTelemetryReporter(hass, config_entry, self)
-        scan_interval = config_entry.options.get(
-            CONF_SCAN_INTERVAL,
-            DEFAULT_SCAN_INTERVAL,
-        )
+        scan_interval = resolve_scan_interval(config_entry)
         super().__init__(
             hass,
             LOGGER,

--- a/custom_components/enki/migration.py
+++ b/custom_components/enki/migration.py
@@ -1,0 +1,104 @@
+"""Config entry migration from legacy CyrilP/hass-enki-component setups."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import CONF_SCAN_INTERVAL
+
+LEGACY_TITLE_PREFIX = "Enki - "
+LEGACY_POWER_SENSOR_SUFFIX = "-power_production"
+CURRENT_POWER_SENSOR_SUFFIX = "-power-production"
+
+
+def is_legacy_config_entry(config_entry: ConfigEntry) -> bool:
+    """True when the entry still uses the legacy CyrilP config shape."""
+    unique_id = config_entry.unique_id or ""
+    return CONF_SCAN_INTERVAL in config_entry.data or unique_id.startswith(LEGACY_TITLE_PREFIX)
+
+
+def migrate_config_entry_fields(
+    *,
+    data: dict[str, Any],
+    options: dict[str, Any],
+    unique_id: str | None,
+) -> tuple[dict[str, Any], dict[str, Any], str | None]:
+    """Move legacy fields to the current config-entry schema."""
+    migrated_data = dict(data)
+    migrated_options = dict(options)
+    migrated_unique_id = unique_id
+
+    if CONF_SCAN_INTERVAL in migrated_data:
+        migrated_options.setdefault(CONF_SCAN_INTERVAL, migrated_data.pop(CONF_SCAN_INTERVAL))
+
+    username = migrated_data.get(CONF_USERNAME)
+    if username and (
+        migrated_unique_id is None or str(migrated_unique_id).startswith(LEGACY_TITLE_PREFIX)
+    ):
+        migrated_unique_id = str(username).lower()
+
+    return migrated_data, migrated_options, migrated_unique_id
+
+
+def migrate_power_sensor_unique_id(unique_id: str) -> str | None:
+    """Map legacy solar sensor IDs to the current hyphenated suffix."""
+    if not unique_id.endswith(LEGACY_POWER_SENSOR_SUFFIX):
+        return None
+    return unique_id[: -len(LEGACY_POWER_SENSOR_SUFFIX)] + CURRENT_POWER_SENSOR_SUFFIX
+
+
+def migrate_legacy_entity_unique_ids(
+    registry: er.EntityRegistry,
+    entry_id: str,
+) -> None:
+    """Rename legacy entity unique IDs for this config entry."""
+    for entity in er.async_entries_for_config_entry(registry, entry_id):
+        if entity.unique_id is None:
+            continue
+        new_unique_id = migrate_power_sensor_unique_id(entity.unique_id)
+        if new_unique_id is not None:
+            registry.async_update_entity(
+                entity.entity_id,
+                new_unique_id=new_unique_id,
+            )
+
+
+async def async_migrate_legacy_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    """Apply legacy config and entity registry migrations."""
+    data, options, unique_id = migrate_config_entry_fields(
+        data=config_entry.data,
+        options=config_entry.options,
+        unique_id=config_entry.unique_id,
+    )
+    migrate_legacy_entity_unique_ids(er.async_get(hass), config_entry.entry_id)
+
+    if (
+        data == config_entry.data
+        and options == config_entry.options
+        and unique_id == config_entry.unique_id
+    ):
+        return
+
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data=data,
+        options=options,
+        unique_id=unique_id,
+    )
+
+
+def resolve_scan_interval(config_entry: ConfigEntry) -> int:
+    """Read polling interval from options, with legacy data fallback."""
+    from .const import DEFAULT_SCAN_INTERVAL
+
+    interval = config_entry.options.get(CONF_SCAN_INTERVAL)
+    if interval is None:
+        interval = config_entry.data.get(CONF_SCAN_INTERVAL)
+    if isinstance(interval, (int, float)) and interval > 0:
+        return int(interval)
+    return DEFAULT_SCAN_INTERVAL

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,47 @@
+# Migrating from CyrilP/hass-enki-component
+
+Both integrations use the same Home Assistant domain (`enki`) and the same folder (`custom_components/enki`). You are **replacing the code**, not adding a second integration.
+
+## Quick path
+
+1. **HACS** → **Integrations** → **Enki** → **Update**  
+   (or copy `custom_components/enki/` from a [release](https://github.com/cyrilcolinet/enki-integration-hass/releases) manually)
+2. **Restart** Home Assistant
+3. Done — **do not** remove the integration in **Settings → Integrations**
+
+Your email and password stay in the existing config entry. No need to add Enki again.
+
+## HACS updates — automatic?
+
+Custom repositories do **not** update silently by default. HACS shows an **Update** badge when a new release is available — you still click **Update**, then restart HA.
+
+To enable automatic updates: **HACS** → **Integrations** → **Enki** → enable automatic updates (if available in your HACS version).
+
+## What the integration migrates for you (v1.6.16+)
+
+On first start after upgrading, `async_migrate_entry` runs once:
+
+| Legacy (CyrilP) | After migration |
+|---|---|
+| `scan_interval` in config entry **data** | moved to **Options** |
+| Config entry `unique_id` `"Enki - user@email.com"` | normalized to `user@email.com` |
+| Solar sensor `…-power_production` | renamed to `…-power-production` |
+
+Fan and light entities keep the same `unique_id` in most cases — automations should keep working.
+
+## If something looks wrong
+
+- **Polling too fast/slow** — **Enki** → **Configure** → adjust scan interval
+- **Duplicate solar sensor** — remove the orphaned entity (old `power_production` id) in **Settings → Devices & services → Entities**
+- **Stale entities** — **Enki** → **Reload** (or restart HA)
+
+## Do not
+
+- Uninstall the Enki integration before upgrading (you lose the config entry)
+- Add a second Enki integration (same domain — will abort or conflict)
+- Run both CyrilP and cyrilcolinet code at once (only one `custom_components/enki` folder)
+
+## Canonical repo
+
+Active development: **[cyrilcolinet/enki-integration-hass](https://github.com/cyrilcolinet/enki-integration-hass)**  
+Original project: **[CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)** (archived when ready)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ _HA_STUBS = [
     "homeassistant.exceptions",
     "homeassistant.helpers",
     "homeassistant.helpers.device_registry",
+    "homeassistant.helpers.entity_registry",
     "homeassistant.helpers.entity_platform",
     "homeassistant.helpers.update_coordinator",
     "homeassistant.helpers.selector",
@@ -53,6 +54,11 @@ _HA_STUBS = [
 
 for module_name in _HA_STUBS:
     sys.modules.setdefault(module_name, MagicMock())
+
+_ha_const = sys.modules["homeassistant.const"]
+_ha_const.CONF_USERNAME = "username"
+_ha_const.CONF_PASSWORD = "password"
+_ha_const.CONF_SCAN_INTERVAL = "scan_interval"
 
 
 class _HaEntity:

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -1,0 +1,78 @@
+"""Unit tests for legacy config entry migration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from enki.const import CONF_SCAN_INTERVAL
+from enki.migration import (
+    migrate_config_entry_fields,
+    migrate_legacy_entity_unique_ids,
+    migrate_power_sensor_unique_id,
+    resolve_scan_interval,
+)
+
+
+def test_migrate_config_entry_moves_scan_interval_to_options() -> None:
+    data, options, unique_id = migrate_config_entry_fields(
+        data={"username": "user@example.com", "password": "secret", CONF_SCAN_INTERVAL: 60},
+        options={},
+        unique_id="Enki - user@example.com",
+    )
+
+    assert CONF_SCAN_INTERVAL not in data
+    assert options[CONF_SCAN_INTERVAL] == 60
+    assert unique_id == "user@example.com"
+
+
+def test_migrate_config_entry_keeps_existing_options() -> None:
+    data, options, _unique_id = migrate_config_entry_fields(
+        data={"username": "user@example.com", "password": "secret", CONF_SCAN_INTERVAL: 45},
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="user@example.com",
+    )
+
+    assert options[CONF_SCAN_INTERVAL] == 30
+
+
+def test_migrate_power_sensor_unique_id() -> None:
+    assert (
+        migrate_power_sensor_unique_id("enki-abc123-power_production")
+        == "enki-abc123-power-production"
+    )
+    assert migrate_power_sensor_unique_id("enki-abc123-power-production") is None
+
+
+def test_migrate_legacy_entity_unique_ids() -> None:
+    registry = MagicMock()
+    entity = MagicMock(
+        entity_id="sensor.solar_power",
+        unique_id="enki-node1-power_production",
+    )
+
+    with patch(
+        "enki.migration.er.async_entries_for_config_entry",
+        return_value=[entity],
+    ):
+        migrate_legacy_entity_unique_ids(registry, "entry-1")
+
+    registry.async_update_entity.assert_called_once_with(
+        "sensor.solar_power",
+        new_unique_id="enki-node1-power-production",
+    )
+
+
+def test_resolve_scan_interval_prefers_options() -> None:
+    entry = MagicMock()
+    entry.options = {CONF_SCAN_INTERVAL: 45}
+    entry.data = {CONF_SCAN_INTERVAL: 60}
+
+    assert resolve_scan_interval(entry) == 45
+
+
+def test_resolve_scan_interval_falls_back_to_legacy_data() -> None:
+    entry = MagicMock()
+    entry.options = {}
+    entry.data = {CONF_SCAN_INTERVAL: 60}
+
+    assert resolve_scan_interval(entry) == 60


### PR DESCRIPTION
## Summary
- `async_migrate_entry` v1→2 for users upgrading from CyrilP/hass-enki-component
- Move `scan_interval` from config entry data → options
- Normalize legacy `unique_id` (`Enki - email` → `email.lower()`)
- Rename solar entity IDs (`power_production` → `power-production`)
- Coordinator fallback reads legacy `scan_interval` from data until migration runs
- **User guide:** [docs/MIGRATION.md](https://github.com/cyrilcolinet/enki-integration-hass/blob/feat/legacy-config-migration/docs/MIGRATION.md)

No re-entry of credentials required — same domain `enki`, drop-in folder replace.

## Context (#78)
- Canonical repo: cyrilcolinet/enki-integration-hass
- CyrilP archives + README redirect when ready (no maintenance PR on his side)
- Issues closure handled by CyrilP on archive

## Test plan
- [x] `pytest tests/unit` — 194 passed
- [x] ruff check + format
- [ ] Manual: upgrade from CyrilP install, verify scan interval preserved and entities stable