### PR TITLE
chore: Co-authored-by CyrilP repo contributors on migration commits

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: cyrilcolinet

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,131 @@
+name: Publish release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (semver, without v prefix — e.g. 1.6.17)"
+        required: true
+        type: string
+      extra_notes:
+        description: "Optional markdown appended to GitHub-generated release notes"
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: publish-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Bump manifest, push, tag, release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version input
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must be semver X.Y.Z (got: $version)"
+            exit 1
+          fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+          echo "TAG=v$version" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag does not exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+
+      - name: Bump manifest.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          new_version = os.environ["VERSION"]
+          manifest = Path("custom_components/enki/manifest.json")
+          data = json.loads(manifest.read_text())
+          current = str(data.get("version", ""))
+
+          def parse_semver(value: str) -> tuple[int, ...]:
+              match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", value)
+              if not match:
+                  raise ValueError(f"invalid semver: {value}")
+              return tuple(int(part) for part in match.groups())
+
+          if parse_semver(new_version) <= parse_semver(current):
+              print(f"::error::New version must be greater than manifest ({current})")
+              sys.exit(1)
+
+          data["version"] = new_version
+          manifest.write_text(json.dumps(data, indent=2) + "\n")
+          print(f"Bumped manifest {current} -> {new_version}")
+          PY
+
+      - name: Commit and push manifest bump
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add custom_components/enki/manifest.json
+          if git diff --cached --quiet; then
+            echo "::error::Manifest version unchanged"
+            exit 1
+          fi
+          git commit -m "chore: bump manifest to ${VERSION} for release"
+          git push origin "HEAD:main"
+
+      - name: Create GitHub release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXTRA_NOTES: ${{ inputs.extra_notes }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --target main \
+            --title "$TAG" \
+            --generate-notes
+
+          generated="$(gh release view "$TAG" --json body --jq .body)"
+          {
+            printf '%s\n' "$generated"
+            if [ -n "$EXTRA_NOTES" ]; then
+              printf '\n%s\n' "$EXTRA_NOTES"
+            fi
+            printf '\n## Install\n\nHACS → Enki → Update, then restart Home Assistant.\n'
+          } > release-notes.md
+
+          gh release edit "$TAG" --notes-file release-notes.md
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "### Release published"
+            echo ""
+            echo "- Version: \`$VERSION\`"
+            echo "- Tag: [\`$TAG\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/$TAG)"
+            echo "- Manifest bump pushed to \`main\`"
+            echo "- \`Release\` workflow will attach \`enki.zip\` to the release"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,19 @@
+# Contributors
+
+This integration continues the original work on
+[CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) (archived).
+
+## Original repository
+
+Contributors to the CyrilP project (excluding bots):
+
+- [CyrilP](https://github.com/CyrilP)
+- [McGiverGim](https://github.com/McGiverGim) — Míguel Ángel Mulero Martínez
+- [katnion](https://github.com/katnion)
+- [bbird81](https://github.com/bbird81)
+- [kitenoob](https://github.com/kitenoob)
+
+## Current repository
+
+See [GitHub contributors](https://github.com/cyrilcolinet/enki-integration-hass/graphs/contributors)
+for `cyrilcolinet/enki-integration-hass`.

--- a/README.md
+++ b/README.md
@@ -113,14 +113,12 @@ Download a [release](https://github.com/cyrilcolinet/enki-integration-hass/relea
 - 🛠️ [Development & APK keys](docs/DEVELOPMENT.md)
 - 📡 [Opt-in telemetry](docs/TELEMETRY.md)
 - 🏠 [Enki support](https://support.enki-home.com/)
-- 🔗 [Original project — CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
+- 🔗 [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
 
 ## Credits & license
 
 **Community** integration, not affiliated with Leroy Merlin, Adeo, or Enki. Unofficial cloud API, subject to change.
 
-- Fork of [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
-- Sensors / siren: inspired by [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki)
-- Icon: [MarioCadenas/hass-enki-component](https://github.com/MarioCadenas/hass-enki-component)
+- Based on [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
 
 [MIT](LICENSE) license

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Per-device detail: [docs/SUPPORTED_DEVICES.md](docs/SUPPORTED_DEVICES.md) · His
 
 Default HACS store (goal): [docs/HACS.md](docs/HACS.md#default-hacs-store)
 
+Upgrading from [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)? See [docs/MIGRATION.md](docs/MIGRATION.md).
+
 ### Add the integration
 
 1. **Settings** → **Devices & services** → **Add integration**

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisi
 ### Beta
 
 - **Covers** (Evology, Nodon, …) — `cover`
+- **Gate / garage dry contact** (Lexman 83424576, Nodon SIN-4-1-20) — `button` impulse ([#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56))
 - **Water leak** (Lexman) — `binary_sensor`, `sensor` (on-site leak test pending — [#36](https://github.com/cyrilcolinet/enki-integration-hass/issues/36))
 - **Scenarios** (Enki cloud) — `button`
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@
 
 ---
 
-The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisio, Evology, Noirot, Envertech, …) through the **Leroy Merlin cloud**. This integration exposes those devices in Home Assistant using Enki **API capabilities** from the referentiel — like the mobile app — rather than a fixed model list.
+The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisio, Evology, Noirot, Envertech, …) through the **Leroy Merlin cloud**. This integration exposes in Home Assistant **everything visible in the Enki app** — using Enki **API capabilities** from the referentiel, like the mobile app, rather than a fixed model list.
 
 ## Why this integration?
 
 - **Connection** — Enki email + password (OAuth Keycloak)
-- **Requirements** — Working Enki hub, devices visible in the app
-- **Architecture** — Cloud hub (`iot_class: cloud_polling`), Enki micro-services
+- **Requirements** — Enki account; devices **already set up and visible in the Enki app** (Wi‑Fi or via the Enki hub — the hub is not mandatory for all devices)
+- **Before Home Assistant** — Pair and configure devices in the **Enki app first**; this integration does not replace Enki pairing or device setup
+- **Architecture** — Cloud polling (`iot_class: cloud_polling`), Enki micro-services
 - **Detection** — Capability-first: new API-compatible devices without forced updates
 
 > **Out of scope:** third-party Zigbee paired on the hub (Sonoff, Tuya, Aqara, …) → use [Zigbee2MQTT](https://www.zigbee2mqtt.io/) or ZHA. Only Enki / Leroy Merlin brands listed in [`lib/enki_scope.py`](custom_components/enki/lib/enki_scope.py) are imported.
@@ -83,9 +84,10 @@ Default HACS store (goal): [docs/HACS.md](docs/HACS.md#default-hacs-store)
 
 ### Add the integration
 
-1. **Settings** → **Devices & services** → **Add integration**
-2. Search for **Enki** — enter Enki email and password
-3. Entities appear after the first poll (~30 s)
+1. In the **Enki app**, finish pairing and configuration for every device you want in Home Assistant
+2. **Settings** → **Devices & services** → **Add integration**
+3. Search for **Enki** — enter Enki email and password
+4. Entities appear after the first poll (~30 s)
 
 ### Manual install
 

--- a/custom_components/enki/__init__.py
+++ b/custom_components/enki/__init__.py
@@ -38,6 +38,13 @@ PLATFORMS: list[Platform] = [
 type EnkiConfigEntry = ConfigEntry[EnkiCoordinator]
 
 
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate config entries (required on this module for HA 2026.x+)."""
+    from .migration import async_migrate_entry as migrate_entry
+
+    return await migrate_entry(hass, config_entry)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: EnkiConfigEntry) -> bool:
     from .coordinator import EnkiCoordinator
 

--- a/custom_components/enki/api/capability_routing.py
+++ b/custom_components/enki/api/capability_routing.py
@@ -65,4 +65,16 @@ CAPABILITY_READS: tuple[CapabilityRead, ...] = (
     ),
     CapabilityRead("presence_detector", "check_occupancy", "occupancy"),
     CapabilityRead("presence_detector", "check_occupancy_mode", "occupancy_mode"),
+    CapabilityRead(
+        "lexman_envertech",
+        "check_power_production",
+        "power_production",
+        skip=lambda profile: not profile.is_inverter,
+    ),
+    CapabilityRead(
+        "lexman_envertech",
+        "check_energy_production",
+        "energy_production",
+        skip=lambda profile: not profile.is_inverter,
+    ),
 )

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -27,6 +27,7 @@ from ..lib.conversion import (
     normalize_power_state,
 )
 from ..lib.enki_scope import device_in_enki_scope
+from ..lib.production import parse_production_value
 from ..lib.shutter import normalize_shutter_position
 from .auth import EnkiAuthSession
 from .capability_routing import CAPABILITY_READS, CapabilityRead
@@ -253,9 +254,9 @@ class EnkiAPI:
         bff_type = metadata.get("deviceType", "")
         main_change_capability = metadata.get("mainChangeCapability") or {}
         main_change_endpoints = [
-            endpoint.get("id")
-            for endpoint in main_change_capability.get("endpoints", [])
-            if endpoint.get("id") is not None
+            endpoint
+            for endpoint in (main_change_capability.get("endpoints") or [])
+            if isinstance(endpoint, dict) and endpoint.get("id") is not None
         ]
 
         node_info = await http.get_node(home_id, node_id)
@@ -267,6 +268,7 @@ class EnkiAPI:
 
         title = item.get("title") or {}
         device_name = title.get("label") or node_id
+        model = _referentiel_model(node_info, device_info)
 
         skeleton = EnkiDevice(
             home_id=home_id,
@@ -282,6 +284,8 @@ class EnkiAPI:
             main_change_capability_id=metadata.get("mainChangeCapabilityId"),
             main_change_capability_endpoints=main_change_endpoints,
             power_production=power_production,
+            referentiel_i18n=str(device_info.get("i18n") or ""),
+            referentiel_model=str(model or ""),
         )
         manufacturer = (
             node_info.get("manufacturerId")
@@ -302,7 +306,6 @@ class EnkiAPI:
         else:
             supported = integration_supports_device(skeleton)
 
-        model = _referentiel_model(node_info, device_info)
         preliminary_firmware = node_info.get("version") or device_info.get("version")
         record = build_discovery_record(
             device_type=device_type,
@@ -374,6 +377,8 @@ class EnkiAPI:
                 main_change_capability_id=metadata.get("mainChangeCapabilityId"),
                 main_change_capability_endpoints=main_change_endpoints,
                 power_production=power_production,
+                referentiel_i18n=str(device_info.get("i18n") or ""),
+                referentiel_model=str(model or ""),
             ),
             record,
         )
@@ -471,8 +476,8 @@ class EnkiAPI:
                     err=err,
                 )
 
-        if profile.is_inverter:
-            state["power_production"] = device.power_production
+        if profile.is_inverter and device.power_production is not None:
+            state.setdefault("power_production", device.power_production)
 
         await self._append_capability_states(http, home_id, node_id, profile, state)
         return state
@@ -515,7 +520,12 @@ class EnkiAPI:
                 )
                 return None
             if data and "lastReportedValue" in data:
-                return read.state_key, data["lastReportedValue"]
+                value = data["lastReportedValue"]
+                if read.state_key in {"power_production", "energy_production"}:
+                    parsed = parse_production_value(value)
+                    if parsed is not None:
+                        return read.state_key, parsed
+                return read.state_key, value
             return None
 
         results = await asyncio.gather(*(read_one(read) for read in CAPABILITY_READS))

--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -720,6 +720,11 @@ class EnkiAPI:
         http = await self._get_http()
         await http.switch_electrical_power(home_id, node_id, value, endpoint=endpoint)
 
+    async def async_power_on_with_timer(self, home_id: str, node_id: str) -> None:
+        """Fire a timed dry-contact impulse (power_on_with_timer capability)."""
+        http = await self._get_http()
+        await http.power_on_with_timer(home_id, node_id)
+
     async def async_set_fan_rotation(
         self,
         home_id: str,

--- a/custom_components/enki/api/gateway_registry.py
+++ b/custom_components/enki/api/gateway_registry.py
@@ -289,10 +289,10 @@ ENKI_MICRO_SERVICES: tuple[EnkiMicroService, ...] = (
     EnkiMicroService(
         "api-enki-lexman-envertech-prod",
         "ENKI_LEXMAN_ENVERTECH_API_KEY",
-        "",
+        "lexman_envertech",
         "/api-enki-lexman-envertech-prod/v1/energy-production",
-        wired=False,
-        notes="",
+        wired=True,
+        notes="Lexman solar inverters (check-power/energy-production)",
     ),
     EnkiMicroService(
         "api-enki-lighting-prod",
@@ -647,7 +647,9 @@ LEGACY_SLUG_ALIASES: dict[str, str] = {
     "api-enki-access-and-motorizations-prod": "api-enki-rolling-prod",
 }
 
-OPTIONAL_KEY_TRANSPORT_IDS = frozenset({"heating", "water_sensor", "motorization", "ota", "esdk"})
+OPTIONAL_KEY_TRANSPORT_IDS = frozenset(
+    {"heating", "water_sensor", "motorization", "ota", "esdk", "lexman_envertech"}
+)
 
 WIRED_PATH_PREFIXES: dict[str, str] = {
     svc.transport_id: svc.path_prefix

--- a/custom_components/enki/api/transport.py
+++ b/custom_components/enki/api/transport.py
@@ -270,6 +270,14 @@ class EnkiHttpClient:
             json={"value": value},
         )
 
+    async def power_on_with_timer(self, home_id: str, node_id: str) -> None:
+        """Timed dry-contact impulse (Lexman/Nodon gate receiver, APK mbj.e)."""
+        await self.post_command(
+            "power",
+            f"/api-enki-power-prod/v1/power/{node_id}/power-on-with-timer",
+            home_id=home_id,
+        )
+
     async def airflow_get(
         self,
         home_id: str,

--- a/custom_components/enki/button.py
+++ b/custom_components/enki/button.py
@@ -58,11 +58,16 @@ async def async_setup_entry(
     entry.async_on_unload(remove_listener)
 
     shutter_entities: list[EnkiShutterPresetButton] = []
+    impulse_entities: list[EnkiImpulseRelayButton] = []
     for device in coordinator.data or []:
         for preset in shutter_preset_options(device.profile.possible_values):
             shutter_entities.append(EnkiShutterPresetButton(coordinator, device, preset))
+        if device.profile.is_impulse_relay:
+            impulse_entities.append(EnkiImpulseRelayButton(coordinator, device))
     if shutter_entities:
         async_add_entities(shutter_entities)
+    if impulse_entities:
+        async_add_entities(impulse_entities)
 
 
 class EnkiScenarioButton(CoordinatorEntity[EnkiCoordinator], ButtonEntity):
@@ -138,4 +143,21 @@ class EnkiShutterPresetButton(EnkiEntity, ButtonEntity):
             self._device.home_id,
             self._device.node_id,
             self._preset,
+        )
+
+
+class EnkiImpulseRelayButton(EnkiEntity, ButtonEntity):
+    """Triggers a timed dry-contact impulse (gate, garage, water heater relay)."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "impulse_relay"
+
+    def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{DOMAIN}-{device.node_id}-impulse"
+
+    async def async_press(self) -> None:
+        await self.coordinator.api.async_power_on_with_timer(
+            self._device.home_id,
+            self._device.node_id,
         )

--- a/custom_components/enki/config_flow.py
+++ b/custom_components/enki/config_flow.py
@@ -46,14 +46,9 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
         """Migrate legacy CyrilP/hass-enki-component config entries."""
-        from .migration import async_migrate_legacy_entry
+        from .migration import async_migrate_entry as migrate_entry
 
-        if config_entry.version >= 2:
-            return True
-
-        await async_migrate_legacy_entry(hass, config_entry)
-        hass.config_entries.async_update_entry(config_entry, version=2)
-        return True
+        return await migrate_entry(hass, config_entry)
 
     async def async_step_user(
         self,

--- a/custom_components/enki/config_flow.py
+++ b/custom_components/enki/config_flow.py
@@ -41,7 +41,19 @@ async def _validate_credentials(hass: HomeAssistant, data: dict[str, Any]) -> No
 class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle Enki config and reconfigure flows."""
 
-    VERSION = 1
+    VERSION = 2
+
+    @staticmethod
+    async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+        """Migrate legacy CyrilP/hass-enki-component config entries."""
+        from .migration import async_migrate_legacy_entry
+
+        if config_entry.version >= 2:
+            return True
+
+        await async_migrate_legacy_entry(hass, config_entry)
+        hass.config_entries.async_update_entry(config_entry, version=2)
+        return True
 
     async def async_step_user(
         self,

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -12,9 +12,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import EnkiAPI
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER
 from .domain.models import EnkiDevice
 from .exceptions import EnkiAuthError, EnkiConnectionError
+from .migration import resolve_scan_interval
 from .notifications import EnkiNotifier, notify_for_connection_error
 from .telemetry import EnkiTelemetryReporter
 
@@ -32,10 +33,7 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         )
         self._notifier = EnkiNotifier(hass, config_entry)
         self._telemetry = EnkiTelemetryReporter(hass, config_entry, self)
-        scan_interval = config_entry.options.get(
-            CONF_SCAN_INTERVAL,
-            DEFAULT_SCAN_INTERVAL,
-        )
+        scan_interval = resolve_scan_interval(config_entry)
         super().__init__(
             hass,
             LOGGER,

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -10,7 +10,11 @@ from ..const import (
     DEVICE_TYPE_FANS,
     DEVICE_TYPE_INVERTERS,
     DEVICE_TYPE_LIGHTS,
-    FAN_ENDPOINT,
+)
+from ..lib.fan_endpoints import (
+    endpoint_id_from_entry,
+    fan_light_endpoints_from_motor,
+    infer_fan_motor_endpoints,
 )
 from .models import EnkiDevice
 
@@ -49,19 +53,21 @@ class EnkiCapabilityProfile:
     bff_device_type: str = ""
     main_change_capability_id: str | None = None
     main_change_capability_endpoints: tuple[int, ...] = ()
+    endpoint_entries: tuple[int | dict[str, Any], ...] = ()
+    device_name: str = ""
+    referentiel_i18n: str = ""
+    referentiel_model: str = ""
     power_production: float | None = None
 
     @classmethod
     def from_device(cls, device: EnkiDevice) -> EnkiCapabilityProfile:
         """Build a profile snapshot from a discovered device."""
+        endpoint_entries = tuple(device.main_change_capability_endpoints)
         endpoints: list[int] = []
-        for endpoint in device.main_change_capability_endpoints:
-            if isinstance(endpoint, int):
-                endpoints.append(endpoint)
-            elif isinstance(endpoint, dict):
-                endpoint_id = endpoint.get("id")
-                if isinstance(endpoint_id, int):
-                    endpoints.append(endpoint_id)
+        for entry in endpoint_entries:
+            endpoint_id = endpoint_id_from_entry(entry)
+            if endpoint_id is not None:
+                endpoints.append(endpoint_id)
         return cls(
             device_type=device.device_type,
             capabilities=frozenset(capabilities_set(device.capabilities)),
@@ -69,6 +75,10 @@ class EnkiCapabilityProfile:
             bff_device_type=device.bff_device_type,
             main_change_capability_id=device.main_change_capability_id,
             main_change_capability_endpoints=tuple(sorted(set(endpoints))),
+            endpoint_entries=endpoint_entries,
+            device_name=device.device_name,
+            referentiel_i18n=device.referentiel_i18n,
+            referentiel_model=device.referentiel_model,
             power_production=device.power_production,
         )
 
@@ -112,7 +122,7 @@ class EnkiCapabilityProfile:
 
     @property
     def supports_fan_speed_control(self) -> bool:
-        """True when referentiel defines a fan speed range (CyrilP/hass-enki-component)."""
+        """True when referentiel defines a writable fan speed range."""
         return self.supports_fan_speed and self.fan_max_speed is not None
 
     @property
@@ -136,6 +146,10 @@ class EnkiCapabilityProfile:
     @property
     def supports_power_production(self) -> bool:
         return "check_power_production" in self.capabilities
+
+    @property
+    def supports_energy_production(self) -> bool:
+        return "check_energy_production" in self.capabilities
 
     @property
     def supports_shutter_position(self) -> bool:
@@ -376,10 +390,10 @@ class EnkiCapabilityProfile:
 
     @property
     def is_inverter(self) -> bool:
-        """Solar inverters with live production on the BFF dashboard."""
+        """Solar inverters (Lexman Envertech, …)."""
         if self.device_type in {DEVICE_TYPE_INVERTERS, "inverters"}:
-            return self.power_production is not None
-        return self.supports_power_production and self.power_production is not None
+            return self.supports_power_production or self.supports_energy_production
+        return self.supports_power_production or self.supports_energy_production
 
     @property
     def is_cover(self) -> bool:
@@ -485,20 +499,41 @@ class EnkiCapabilityProfile:
         return list(self.main_change_capability_endpoints)
 
     @property
+    def _fan_motor_endpoint_ids(self) -> frozenset[int]:
+        if self.device_type != DEVICE_TYPE_FANS and not self.is_fan:
+            return frozenset()
+        if self.main_change_capability_id != "switch_electrical_power":
+            return frozenset()
+        return infer_fan_motor_endpoints(
+            power_endpoints=list(self.main_change_capability_endpoints),
+            endpoint_entries=self.endpoint_entries,
+            supports_light_state=self.supports_light_state,
+            supports_fan_speed=self.supports_fan_speed,
+            device_name=self.device_name,
+            referentiel_i18n=self.referentiel_i18n,
+            referentiel_model=self.referentiel_model,
+        )
+
+    @property
     def fan_light_endpoints(self) -> list[int]:
         """Light kit endpoints on ceiling fans (excludes the motor endpoint)."""
         if self.device_type != DEVICE_TYPE_FANS and not self.is_fan:
             return []
-        return [endpoint for endpoint in self.power_switch_endpoints if endpoint != FAN_ENDPOINT]
+        return fan_light_endpoints_from_motor(
+            list(self.power_switch_endpoints),
+            self._fan_motor_endpoint_ids,
+        )
 
     @property
     def fan_motor_endpoints(self) -> list[int]:
         """Power-prod endpoints that are not light kit circuits."""
         if self.main_change_capability_id != "switch_electrical_power":
             return []
-        light_endpoints = set(self.fan_light_endpoints)
+        motor_ids = self._fan_motor_endpoint_ids
         return [
-            endpoint for endpoint in self.power_switch_endpoints if endpoint not in light_endpoints
+            endpoint
+            for endpoint in self.power_switch_endpoints
+            if endpoint in motor_ids
         ]
 
     @property

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -190,6 +190,10 @@ class EnkiCapabilityProfile:
         return "execute_preset" in self.capabilities
 
     @property
+    def supports_power_on_with_timer(self) -> bool:
+        return "power_on_with_timer" in self.capabilities
+
+    @property
     def supports_current_temperature(self) -> bool:
         return _supports(
             self.capabilities,
@@ -403,6 +407,11 @@ class EnkiCapabilityProfile:
         return self.supports_shutter_position
 
     @property
+    def is_impulse_relay(self) -> bool:
+        """Dry-contact gate/garage receivers (timed impulse via power-prod)."""
+        return self.supports_power_on_with_timer
+
+    @property
     def is_environment_sensor(self) -> bool:
         """Temperature, humidity, illuminance, or battery level sensors (not thermostats)."""
         if self.supports_thermostat:
@@ -470,6 +479,7 @@ class EnkiCapabilityProfile:
             or self.is_climate
             or self.is_pilot_wire
             or self.supports_vibration_sensibility
+            or self.is_impulse_relay
         )
 
     @property

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -530,11 +530,7 @@ class EnkiCapabilityProfile:
         if self.main_change_capability_id != "switch_electrical_power":
             return []
         motor_ids = self._fan_motor_endpoint_ids
-        return [
-            endpoint
-            for endpoint in self.power_switch_endpoints
-            if endpoint in motor_ids
-        ]
+        return [endpoint for endpoint in self.power_switch_endpoints if endpoint in motor_ids]
 
     @property
     def fan_motor_endpoint(self) -> int | None:

--- a/custom_components/enki/domain/models.py
+++ b/custom_components/enki/domain/models.py
@@ -28,6 +28,8 @@ class EnkiDevice:
     main_change_capability_id: str | None = None
     main_change_capability_endpoints: list[int | dict[str, Any]] = field(default_factory=list)
     power_production: float | None = None
+    referentiel_i18n: str = ""
+    referentiel_model: str = ""
 
     @property
     def is_active(self) -> bool:

--- a/custom_components/enki/domain/state.py
+++ b/custom_components/enki/domain/state.py
@@ -112,6 +112,10 @@ class EnkiDeviceState:
         return None
 
     @property
+    def energy_production(self) -> float | None:
+        return _as_float(self._data.get("energy_production"))
+
+    @property
     def shutter_position(self) -> int | None:
         from ..lib.shutter import normalize_shutter_position
 

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -55,6 +55,7 @@ _CAPABILITY_PROBES: dict[str, str] = {
     "check_motion_detection": "supports_motion_detection",
     "check_motion_detector_state": "supports_motion_detection",
     "check_power_production": "supports_power_production",
+    "check_energy_production": "supports_energy_production",
     "check_shutter_opening": "supports_shutter_opening",
     "check_shutter_position": "supports_shutter_position",
     "check_siren_global_state": "supports_siren",

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -37,6 +37,7 @@ _CAPABILITY_PROBES: dict[str, str] = {
     "change_roller_shutter_mode": "supports_roller_shutter_mode",
     "check_roller_shutter_mode": "supports_roller_shutter_mode",
     "execute_preset": "supports_shutter_preset",
+    "power_on_with_timer": "supports_power_on_with_timer",
     "change_vibration_sensibility_level": "supports_vibration_sensibility",
     "check_airflow_mode": "supports_airflow_mode",
     "check_battery_health": "supports_battery_health",

--- a/custom_components/enki/domain/telemetry_enrichment.py
+++ b/custom_components/enki/domain/telemetry_enrichment.py
@@ -28,6 +28,8 @@ def ha_platforms_for_profile(profile: EnkiCapabilityProfile) -> list[str]:
         platforms.append("sensor")
     if profile.is_cover:
         platforms.append("cover")
+    if profile.supports_shutter_preset:
+        platforms.append("button")
     if profile.is_climate:
         platforms.append("climate")
     if profile.is_pilot_wire:

--- a/custom_components/enki/domain/telemetry_enrichment.py
+++ b/custom_components/enki/domain/telemetry_enrichment.py
@@ -28,7 +28,7 @@ def ha_platforms_for_profile(profile: EnkiCapabilityProfile) -> list[str]:
         platforms.append("sensor")
     if profile.is_cover:
         platforms.append("cover")
-    if profile.supports_shutter_preset:
+    if profile.supports_shutter_preset or profile.supports_power_on_with_timer:
         platforms.append("button")
     if profile.is_climate:
         platforms.append("climate")

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -199,12 +199,14 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         self.coordinator.update_cached_value(node_id, "fan_speed", speed)
 
     async def _set_motor_power(self, power: str) -> None:
-        """ON/OFF fans without speed range — global power API (CyrilP/hass-enki-component)."""
+        """ON/OFF fans without speed range — per-endpoint or global power API."""
         node_id = self._device.node_id
+        motor_endpoint = self._device.profile.fan_motor_endpoint
         await self.coordinator.api.async_switch_electrical_power(
             self._device.home_id,
             node_id,
             power,
+            endpoint=motor_endpoint,
         )
         self.coordinator.update_cached_value(node_id, "electrical_power", power)
         self.coordinator.update_cached_value(node_id, "power", power)

--- a/custom_components/enki/lib/conversion.py
+++ b/custom_components/enki/lib/conversion.py
@@ -56,7 +56,7 @@ def percentage_to_fan_speed(percentage: int, max_speed: int) -> int:
 
 
 def fan_speed_to_percentage(speed: int, max_speed: int) -> int:
-    """Map Enki fan speed to HA percentage (linear, matches CyrilP/hass-enki-component)."""
+    """Map Enki fan speed to HA percentage (linear 1…max)."""
     if speed <= 0 or max_speed <= 0:
         return 0
     return int(round(speed * 100 / max_speed))

--- a/custom_components/enki/lib/fan_endpoints.py
+++ b/custom_components/enki/lib/fan_endpoints.py
@@ -1,0 +1,108 @@
+"""Resolve fan motor vs light-kit endpoints on multi-endpoint ceiling fans."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..const import FAN_ENDPOINT
+
+_FAN_METADATA_KEYS = ("type", "endpointType", "category", "role", "label")
+_FAN_TYPE_MARKERS = frozenset({"fan", "motor", "ventilation", "vmc"})
+_LIGHT_TYPE_MARKERS = frozenset({"light", "lighting", "dimmer", "lamp"})
+
+
+def endpoint_id_from_entry(entry: int | dict[str, Any]) -> int | None:
+    if isinstance(entry, int):
+        return entry
+    if isinstance(entry, dict):
+        raw = entry.get("id")
+        if isinstance(raw, int):
+            return raw
+    return None
+
+
+def _normalize_marker(value: object) -> str:
+    return str(value).strip().lower() if value is not None else ""
+
+
+def motor_endpoints_from_metadata(
+    endpoint_entries: tuple[int | dict[str, Any], ...],
+) -> frozenset[int] | None:
+    """Return motor endpoint IDs when BFF endpoint dicts carry type metadata."""
+    motors: set[int] = set()
+    lights: set[int] = set()
+    for entry in endpoint_entries:
+        ep_id = endpoint_id_from_entry(entry)
+        if ep_id is None or not isinstance(entry, dict):
+            continue
+        marker = ""
+        for key in _FAN_METADATA_KEYS:
+            marker = marker or _normalize_marker(entry.get(key))
+        if any(token in marker for token in _FAN_TYPE_MARKERS):
+            motors.add(ep_id)
+        elif any(token in marker for token in _LIGHT_TYPE_MARKERS):
+            lights.add(ep_id)
+    if motors:
+        return frozenset(motors)
+    if lights and len(lights) < len(endpoint_entries):
+        all_ids = {
+            endpoint_id_from_entry(entry)
+            for entry in endpoint_entries
+            if endpoint_id_from_entry(entry) is not None
+        }
+        return frozenset(all_ids - lights)
+    return None
+
+
+def _label_blob(*parts: str) -> str:
+    return " ".join(part for part in parts if part).lower()
+
+
+def infer_fan_motor_endpoints(
+    *,
+    power_endpoints: list[int],
+    endpoint_entries: tuple[int | dict[str, Any], ...],
+    supports_light_state: bool,
+    supports_fan_speed: bool,
+    device_name: str,
+    referentiel_i18n: str,
+    referentiel_model: str,
+) -> frozenset[int]:
+    """Best-effort motor endpoint resolution (Siroco+ vs Inspire Radix, …)."""
+    if not power_endpoints:
+        return frozenset()
+
+    from_metadata = motor_endpoints_from_metadata(endpoint_entries)
+    if from_metadata is not None:
+        return from_metadata
+
+    if not supports_light_state:
+        return frozenset(power_endpoints)
+
+    if len(power_endpoints) == 1:
+        return frozenset(power_endpoints)
+
+    sorted_eps = sorted(power_endpoints)
+    labels = _label_blob(device_name, referentiel_i18n, referentiel_model)
+
+    # Inspire Radix: dual LED kit at corners, motor on the middle endpoint.
+    if (
+        len(sorted_eps) == 3
+        and supports_fan_speed
+        and sorted_eps[2] - sorted_eps[0] == 2
+        and "radix" in labels
+    ):
+        return frozenset({sorted_eps[1]})
+
+    # Legacy Siroco+ / Cadix: motor on endpoint 1.
+    if FAN_ENDPOINT in power_endpoints:
+        return frozenset({FAN_ENDPOINT})
+
+    return frozenset({min(power_endpoints)})
+
+
+def fan_light_endpoints_from_motor(
+    power_endpoints: list[int],
+    motor_endpoints: frozenset[int],
+) -> list[int]:
+    return [endpoint for endpoint in power_endpoints if endpoint not in motor_endpoints]

--- a/custom_components/enki/lib/production.py
+++ b/custom_components/enki/lib/production.py
@@ -1,0 +1,28 @@
+"""Solar production value parsers (BFF + Envertech API)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .bff import parse_bff_power
+
+
+def parse_production_value(value: Any) -> float | None:
+    """Normalize power (W) or energy (kWh) readings from Enki micro-services."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        parsed = parse_bff_power({"value": value})
+        if parsed is not None:
+            return parsed
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    if isinstance(value, dict):
+        for key in ("value", "lastReportedValue", "amount"):
+            if key in value:
+                parsed = parse_production_value(value[key])
+                if parsed is not None:
+                    return parsed
+    return None

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.18"
+  "version": "1.6.19"
 }

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.17"
+  "version": "1.6.18"
 }

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.16"
+  "version": "1.6.17"
 }

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.15"
+  "version": "1.6.16"
 }

--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/cyrilcolinet/enki-integration-hass/issues",
   "loggers": ["enki"],
   "requirements": ["aiohttp>=3.9"],
-  "version": "1.6.14"
+  "version": "1.6.15"
 }

--- a/custom_components/enki/migration.py
+++ b/custom_components/enki/migration.py
@@ -92,6 +92,20 @@ async def async_migrate_legacy_entry(hass: HomeAssistant, config_entry: ConfigEn
     )
 
 
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate a config entry to the current schema.
+
+    Home Assistant 2026.x resolves this on the integration module (__init__.py),
+    not on the config flow class.
+    """
+    if config_entry.version >= 2:
+        return True
+
+    await async_migrate_legacy_entry(hass, config_entry)
+    hass.config_entries.async_update_entry(config_entry, version=2)
+    return True
+
+
 def resolve_scan_interval(config_entry: ConfigEntry) -> int:
     """Read polling interval from options, with legacy data fallback."""
     from .const import DEFAULT_SCAN_INTERVAL

--- a/custom_components/enki/migration.py
+++ b/custom_components/enki/migration.py
@@ -1,0 +1,104 @@
+"""Config entry migration from legacy CyrilP/hass-enki-component setups."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import CONF_SCAN_INTERVAL
+
+LEGACY_TITLE_PREFIX = "Enki - "
+LEGACY_POWER_SENSOR_SUFFIX = "-power_production"
+CURRENT_POWER_SENSOR_SUFFIX = "-power-production"
+
+
+def is_legacy_config_entry(config_entry: ConfigEntry) -> bool:
+    """True when the entry still uses the legacy CyrilP config shape."""
+    unique_id = config_entry.unique_id or ""
+    return CONF_SCAN_INTERVAL in config_entry.data or unique_id.startswith(LEGACY_TITLE_PREFIX)
+
+
+def migrate_config_entry_fields(
+    *,
+    data: dict[str, Any],
+    options: dict[str, Any],
+    unique_id: str | None,
+) -> tuple[dict[str, Any], dict[str, Any], str | None]:
+    """Move legacy fields to the current config-entry schema."""
+    migrated_data = dict(data)
+    migrated_options = dict(options)
+    migrated_unique_id = unique_id
+
+    if CONF_SCAN_INTERVAL in migrated_data:
+        migrated_options.setdefault(CONF_SCAN_INTERVAL, migrated_data.pop(CONF_SCAN_INTERVAL))
+
+    username = migrated_data.get(CONF_USERNAME)
+    if username and (
+        migrated_unique_id is None or str(migrated_unique_id).startswith(LEGACY_TITLE_PREFIX)
+    ):
+        migrated_unique_id = str(username).lower()
+
+    return migrated_data, migrated_options, migrated_unique_id
+
+
+def migrate_power_sensor_unique_id(unique_id: str) -> str | None:
+    """Map legacy solar sensor IDs to the current hyphenated suffix."""
+    if not unique_id.endswith(LEGACY_POWER_SENSOR_SUFFIX):
+        return None
+    return unique_id[: -len(LEGACY_POWER_SENSOR_SUFFIX)] + CURRENT_POWER_SENSOR_SUFFIX
+
+
+def migrate_legacy_entity_unique_ids(
+    registry: er.EntityRegistry,
+    entry_id: str,
+) -> None:
+    """Rename legacy entity unique IDs for this config entry."""
+    for entity in er.async_entries_for_config_entry(registry, entry_id):
+        if entity.unique_id is None:
+            continue
+        new_unique_id = migrate_power_sensor_unique_id(entity.unique_id)
+        if new_unique_id is not None:
+            registry.async_update_entity(
+                entity.entity_id,
+                new_unique_id=new_unique_id,
+            )
+
+
+async def async_migrate_legacy_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    """Apply legacy config and entity registry migrations."""
+    data, options, unique_id = migrate_config_entry_fields(
+        data=config_entry.data,
+        options=config_entry.options,
+        unique_id=config_entry.unique_id,
+    )
+    migrate_legacy_entity_unique_ids(er.async_get(hass), config_entry.entry_id)
+
+    if (
+        data == config_entry.data
+        and options == config_entry.options
+        and unique_id == config_entry.unique_id
+    ):
+        return
+
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data=data,
+        options=options,
+        unique_id=unique_id,
+    )
+
+
+def resolve_scan_interval(config_entry: ConfigEntry) -> int:
+    """Read polling interval from options, with legacy data fallback."""
+    from .const import DEFAULT_SCAN_INTERVAL
+
+    interval = config_entry.options.get(CONF_SCAN_INTERVAL)
+    if interval is None:
+        interval = config_entry.data.get(CONF_SCAN_INTERVAL)
+    if isinstance(interval, (int, float)) and interval > 0:
+        return int(interval)
+    return DEFAULT_SCAN_INTERVAL

--- a/custom_components/enki/platforms/light/behavior.py
+++ b/custom_components/enki/platforms/light/behavior.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_COLOR_TEMP_KELVIN
 
-from ...const import FAN_ENDPOINT
 from ...coordinator import EnkiCoordinator
 from ...entity import EnkiEntity
 
@@ -33,11 +32,12 @@ class EnkiLightBehaviorMixin:
 
     def _uses_endpoint_power(self: EnkiEntity, endpoint_id: int | None) -> bool:
         """True when simple on/off should use per-endpoint power API."""
-        if endpoint_id is None or endpoint_id == FAN_ENDPOINT:
+        if endpoint_id is None:
             return False
         profile = self._device.profile
         if profile.is_fan:
-            # Fan light kits are driven by api-enki-lighting-prod, not power-prod.
+            return False
+        if endpoint_id in profile.fan_motor_endpoints:
             return False
         return len(profile.power_switch_endpoints) > 1
 

--- a/custom_components/enki/sensor.py
+++ b/custom_components/enki/sensor.py
@@ -47,6 +47,8 @@ def _build_sensor_entities(
 
     if _has_power_production_sensor(device):
         entities.append(EnkiPowerProductionSensor(coordinator, device))
+    if _has_energy_production_sensor(device):
+        entities.append(EnkiEnergyProductionSensor(coordinator, device))
     if profile.supports_current_temperature and not profile.is_climate:
         entities.append(EnkiTemperatureSensor(coordinator, device))
     if profile.supports_current_humidity:
@@ -63,13 +65,16 @@ def _build_sensor_entities(
 
 def _has_power_production_sensor(device: EnkiDevice) -> bool:
     profile = device.profile
-    if device.power_production is None:
-        return False
-    return profile.is_inverter or profile.supports_power_production
+    return profile.is_inverter and profile.supports_power_production
+
+
+def _has_energy_production_sensor(device: EnkiDevice) -> bool:
+    profile = device.profile
+    return profile.is_inverter and profile.supports_energy_production
 
 
 class EnkiPowerProductionSensor(EnkiEntity, SensorEntity):
-    """Live solar production from the Enki BFF dashboard."""
+    """Live solar production (W) from BFF dashboard or Envertech API."""
 
     _attr_translation_key = "power_production"
     _attr_device_class = SensorDeviceClass.POWER
@@ -82,15 +87,32 @@ class EnkiPowerProductionSensor(EnkiEntity, SensorEntity):
 
     @property
     def native_value(self) -> float | None:
-        value = self._device.power_production
+        value = self._device.reported.power_production
         if value is None:
-            value = self._device.reported.power_production
+            value = self._device.power_production
         if value is None:
             return None
         try:
             return float(value)
         except (TypeError, ValueError):
             return None
+
+
+class EnkiEnergyProductionSensor(EnkiEntity, SensorEntity):
+    """Cumulative solar energy (kWh) from api-enki-lexman-envertech-prod."""
+
+    _attr_translation_key = "energy_production"
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{DOMAIN}-{device.node_id}-energy-production"
+
+    @property
+    def native_value(self) -> float | None:
+        return self._device.reported.energy_production
 
 
 class EnkiTemperatureSensor(EnkiEntity, SensorEntity):

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -105,6 +105,9 @@
       },
       "shutter_preset": {
         "name": "{preset}"
+      },
+      "impulse_relay": {
+        "name": "Trigger"
       }
     },
     "binary_sensor": {

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -80,6 +80,9 @@
       "power_production": {
         "name": "Power production"
       },
+      "energy_production": {
+        "name": "Energy production"
+      },
       "temperature": {
         "name": "Temperature"
       },

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -105,6 +105,9 @@
       },
       "shutter_preset": {
         "name": "{preset}"
+      },
+      "impulse_relay": {
+        "name": "Trigger"
       }
     },
     "binary_sensor": {

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -80,6 +80,9 @@
       "power_production": {
         "name": "Power production"
       },
+      "energy_production": {
+        "name": "Energy production"
+      },
       "temperature": {
         "name": "Temperature"
       },

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -105,6 +105,9 @@
       },
       "shutter_preset": {
         "name": "{preset}"
+      },
+      "impulse_relay": {
+        "name": "Déclencher"
       }
     },
     "binary_sensor": {

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -80,6 +80,9 @@
       "power_production": {
         "name": "Production"
       },
+      "energy_production": {
+        "name": "Énergie produite"
+      },
       "temperature": {
         "name": "Température"
       },

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Enki cloud API — engineering notes
 
-This integration talks to the **unofficial** Enki REST API used by the Leroy Merlin / Adeo mobile app. There is no public developer portal for end users; behaviour was inferred from network traffic and existing community work.
+This integration talks to the **unofficial** Enki REST API used by the Leroy Merlin / Adeo mobile app. There is no public developer portal for end users; behaviour was inferred from network traffic and [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component).
 
 ## Authentication
 
@@ -55,7 +55,7 @@ Detection is **capability-based** (referentiel metadata + BFF dashboard), not li
 | Heating / pilot wire / thermostat | `select`, `climate`, `switch`, `binary_sensor` | `api-enki-heating-prod` — `ENKI_HEATING_API_KEY` in `const.py` (APK 2.25.1); if cleared, reads are skipped silently and writes raise an error |
 | Water leak sensors | `binary_sensor`, `sensor` (battery) | `api-enki-water-leak-detector-prod` + `api-enki-battery-health-prod` — keys in `const.py` (APK 2.25.1); same fallback if a key is missing |
 
-Sensor capability paths follow the same pattern as [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki): `GET/POST …/v1/sensors/{node_id}/{kebab-case-capability}` (siren uses `/v1/siren/`).
+Sensor capability paths: `GET/POST …/v1/sensors/{node_id}/{kebab-case-capability}` (siren uses `/v1/siren/`).
 
 Multi-endpoint lights (several circuits on one node) create one HA light entity per BFF `mainChangeCapability` endpoint.
 
@@ -176,6 +176,5 @@ The Enki app also controls alarms via other microservices. Use `scripts/discover
 
 ## References
 
-- Fork base: [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) (lights)
-- Fan / airflow research: community reverse engineering of ESDK ceiling fans
+- [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) (lights)
 - Product docs: [Enki support — Inspire](https://support.enki-home.com/)

--- a/docs/API.md
+++ b/docs/API.md
@@ -101,6 +101,18 @@ Commands:
 
 Gateway key: `ENKI_ACCESS_MOTORIZATION_API_KEY` in `const.py` (filled from APK 2.25.1). Legacy path `api-enki-access-and-motorizations-prod` is obsolete. See [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md) for validation with mitmproxy.
 
+### Dry-contact gate / garage receiver (Lexman 83424576, Nodon SIN-4-1-20) — beta
+
+**Referentiel capability:** `power_on_with_timer` only (Mpulse mode — timed impulse, no state read).
+
+**HA entity:** `button` “Trigger”
+
+| Command | Endpoint | Notes |
+|---------|----------|-------|
+| Impulse | `POST …/power-on-with-timer` | **No body** — `api-enki-power-prod` (APK `mbj.e`) |
+
+Gateway key: `ENKI_POWER_API_KEY` (same as outlets). Distinct from roller shutters (`api-enki-rolling-prod`).
+
 ### Standard lights (Eglo V-Link, Lexman, etc.)
 
 | Capability | Parameter | Wire format |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,47 @@
+# Migrating from CyrilP/hass-enki-component
+
+Both integrations use the same Home Assistant domain (`enki`) and the same folder (`custom_components/enki`). You are **replacing the code**, not adding a second integration.
+
+## Quick path
+
+1. **HACS** → **Integrations** → **Enki** → **Update**  
+   (or copy `custom_components/enki/` from a [release](https://github.com/cyrilcolinet/enki-integration-hass/releases) manually)
+2. **Restart** Home Assistant
+3. Done — **do not** remove the integration in **Settings → Integrations**
+
+Your email and password stay in the existing config entry. No need to add Enki again.
+
+## HACS updates — automatic?
+
+Custom repositories do **not** update silently by default. HACS shows an **Update** badge when a new release is available — you still click **Update**, then restart HA.
+
+To enable automatic updates: **HACS** → **Integrations** → **Enki** → enable automatic updates (if available in your HACS version).
+
+## What the integration migrates for you (v1.6.16+)
+
+On first start after upgrading, `async_migrate_entry` runs once:
+
+| Legacy (CyrilP) | After migration |
+|---|---|
+| `scan_interval` in config entry **data** | moved to **Options** |
+| Config entry `unique_id` `"Enki - user@email.com"` | normalized to `user@email.com` |
+| Solar sensor `…-power_production` | renamed to `…-power-production` |
+
+Fan and light entities keep the same `unique_id` in most cases — automations should keep working.
+
+## If something looks wrong
+
+- **Polling too fast/slow** — **Enki** → **Configure** → adjust scan interval
+- **Duplicate solar sensor** — remove the orphaned entity (old `power_production` id) in **Settings → Devices & services → Entities**
+- **Stale entities** — **Enki** → **Reload** (or restart HA)
+
+## Do not
+
+- Uninstall the Enki integration before upgrading (you lose the config entry)
+- Add a second Enki integration (same domain — will abort or conflict)
+- Run both CyrilP and cyrilcolinet code at once (only one `custom_components/enki` folder)
+
+## Canonical repo
+
+Active development: **[cyrilcolinet/enki-integration-hass](https://github.com/cyrilcolinet/enki-integration-hass)**  
+Original project: **[CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)** (archived when ready)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -44,4 +44,4 @@ Fan and light entities keep the same `unique_id` in most cases — automations s
 ## Canonical repo
 
 Active development: **[cyrilcolinet/enki-integration-hass](https://github.com/cyrilcolinet/enki-integration-hass)**  
-Original project: **[CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)** (archived when ready)
+Original project: **[CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)** (archived — README redirects here)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,4 +28,6 @@ Short version: [README](../README.md) · detailed view below.
 | ⏳ Not planned | Enki alarm | no API identified |
 | ✅ Prerequisite OK | Default HACS store | CI HACS + Hassfest green, releases published — [PR to `hacs/default`](HACS.md#default-hacs-store) |
 
+**In scope:** devices visible in the Enki app (Wi‑Fi or via the Enki hub). **Setup:** configure them in the Enki app before adding this integration in Home Assistant.
+
 **Out of scope:** third-party Zigbee on the hub (Sonoff, Tuya, Aqara, IKEA, …) → [Zigbee2MQTT](https://www.zigbee2mqtt.io/) or ZHA. Only **Enki / Leroy Merlin** brands in [`lib/enki_scope.py`](../custom_components/enki/lib/enki_scope.py) are imported.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@ Short version: [README](../README.md) · detailed view below.
 | | |
 |---|---|
 | **Latest GitHub release** | [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) |
-| **Repository `manifest.json`** | 1.6.17 |
+| **Repository `manifest.json`** | 1.6.18 |
 
 ## Status by device
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@ Short version: [README](../README.md) · detailed view below.
 | | |
 |---|---|
 | **Latest GitHub release** | [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) |
-| **Repository `manifest.json`** | 1.6.18 |
+| **Repository `manifest.json`** | 1.6.19 |
 
 ## Status by device
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@ Short version: [README](../README.md) · detailed view below.
 | | |
 |---|---|
 | **Latest GitHub release** | [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases/latest) |
-| **Repository `manifest.json`** | 1.6.14 |
+| **Repository `manifest.json`** | 1.6.17 |
 
 ## Status by device
 
@@ -22,6 +22,7 @@ Short version: [README](../README.md) · detailed view below.
 | ✅ Supported | Equation pilot wire | `select` (comfort / eco / frost / off); stable since **v1.6.8** (`thermostat-prod`) |
 | ✅ Supported | Noirot radiator | `climate` + window / presence detection; stable since **v1.6.8** (`thermostat-prod` + `presence-detector-prod`) |
 | 🔬 Beta | Roller shutters (Evology, Nodon, …) | `cover` “Shutter (beta)” if active in the app; `ENKI_ACCESS_MOTORIZATION_API_KEY` (APK 2.25.1); limited real-world testing |
+| 🔬 Beta | Lexman / Nodon dry-contact gate receiver | `button` “Trigger” via `power_on_with_timer` (`api-enki-power-prod`); Mpulse mode — field test [#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56) |
 | 🔬 Beta | Lexman water leak detector | leak `binary_sensor` + battery `sensor`; reads OK remotely — on-site wet test pending ([#36](https://github.com/cyrilcolinet/enki-integration-hass/issues/36)) |
 | 🔜 Soon | ACOVA ARLAN radiators | manufacturer allowlist OK, no test hardware |
 | 🔬 Beta | Enki scenarios (“Open living room”, …) | `button` (v1.6.0+) |

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -156,6 +156,27 @@ Contributor network feedback: [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md).
 3. Test open / close / position vs the Enki mobile app.
 4. Report results (model, HA version, integration version, `enki` log excerpt if it fails).
 
+## Dry-contact gate / garage receiver — beta (Lexman, Nodon)
+
+**HA entity:** `button` “Trigger” / “Déclencher”
+
+| Product | Notes |
+|---------|--------|
+| [Lexman 83424576](https://www.leroymerlin.fr/produits/module-connecte-portail-porte-de-garage-lexman-83424576.html) | Rebaged Nodon SIN-4-1-20; referentiel type `access_and_motorizations` |
+| Capability | `power_on_with_timer` only (no position/opening — **not** a `cover`) |
+| Enki app mode | **Mpulse** — contact closes for a few seconds then reopens (timed impulse) |
+
+**API:** `POST api-enki-power-prod/v1/power/{nodeId}/power-on-with-timer` — no body. Same gateway key as outlets (`ENKI_POWER_API_KEY`). Detail: [API.md](API.md#dry-contact-gate--garage-receiver-lexman-83424576-nodon-sin-4-1-20--beta).
+
+**Since v1.6.17.** Field feedback: [#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56).
+
+### For testers (gate / dry contact)
+
+1. Update the Enki integration (**v1.6.17+**) via HACS, then restart Home Assistant.
+2. Open the gate receiver device — look for a **Trigger** button entity.
+3. Press it and confirm the gate (or water heater relay) behaves like a single tap in the Enki app.
+4. Report model, integration version, and any error in `enki` logs.
+
 ## Cross-cutting features
 
 - **OAuth auth** — Keycloak refresh token; HA notification on invalid credentials
@@ -180,7 +201,7 @@ Reads are best-effort (404 skipped) and driven by referentiel capabilities, not 
 | Status | Topic |
 |--------|--------|
 | ✅ Stable | Heating (Noirot, pilot wire, Equation relay) since v1.6.8 |
-| 🔬 Beta | Covers, Lexman water leak (on-site test), scenarios — feedback welcome |
+| 🔬 Beta | Covers, dry-contact gate receiver, Lexman water leak (on-site test), scenarios — feedback welcome |
 | Soon | ACOVA ARLAN radiators (same heating API if capabilities match) |
 | Not planned | Enki alarm (no API identified) |
 | Out of scope | Enki pairing and device setup, Leroy Merlin account management → [Enki support](https://support.enki-home.com/) (configure devices in the app before HA) |

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -71,7 +71,7 @@ Scenarios refresh on each coordinator poll. They appear under the virtual device
 
 ## Enki sensors (Lexman, Sedea, …)
 
-Micro-services aligned with [StephaneBranly/ha-enki](https://github.com/StephaneBranly/ha-enki) (gateway keys already in `const.py`).
+Gateway keys in `gateway_keys_data.py` (APK 2.25.1).
 
 ### Motion / contact / vibration
 

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -13,7 +13,11 @@ Summary: [ROADMAP.md](ROADMAP.md)
 
 This integration covers **only the Enki / Leroy Merlin ecosystem**: Lexman, Equation, Inspire, Noirot, Edisio, Eglo, Sedea, Evology, Nodon, ACOVA, Envertech, etc. (exact list: [`lib/enki_scope.py`](../custom_components/enki/lib/enki_scope.py)).
 
-**Important:** many of these devices use **Zigbee radio** via the Enki hub — that is expected and in scope. However, any **third-party Zigbee** on the hub (Sonoff, Tuya, Aqara, IKEA, …) or any node **without a known Enki manufacturer** is **skipped** at discovery: integrate them via **Zigbee2MQTT** or **ZHA**, not this repo.
+**In scope:** anything **visible and working in the Enki app** — Wi‑Fi devices (no hub required) and Zigbee devices paired on the Enki hub.
+
+**Setup order:** pair and configure devices in the **Enki app first**, then add this integration in Home Assistant. HA does not replace Enki pairing or device configuration.
+
+**Skipped at discovery:** **third-party Zigbee** on the hub (Sonoff, Tuya, Aqara, IKEA, …) or any node **without a known Enki manufacturer** — integrate them via **Zigbee2MQTT** or **ZHA**, not this repo.
 
 ## Inspire ceiling fans (Siroco+, Aruba+, Cadix, Radix, …)
 
@@ -179,6 +183,6 @@ Reads are best-effort (404 skipped) and driven by referentiel capabilities, not 
 | 🔬 Beta | Covers, Lexman water leak (on-site test), scenarios — feedback welcome |
 | Soon | ACOVA ARLAN radiators (same heating API if capabilities match) |
 | Not planned | Enki alarm (no API identified) |
-| Out of scope | Enki hub, pairing, Leroy Merlin account → [Enki support](https://support.enki-home.com/) |
+| Out of scope | Enki pairing and device setup, Leroy Merlin account management → [Enki support](https://support.enki-home.com/) (configure devices in the app before HA) |
 
 API documentation: [API.md](API.md)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ aioresponses==0.7.9
 pytest==9.1.1
 pytest-asyncio==1.4.0
 ruff==0.15.21
+voluptuous>=0.15.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ aiohttp==3.14.1
 aioresponses==0.7.9
 pytest==9.1.1
 pytest-asyncio==1.4.0
-ruff==0.15.20
+ruff==0.15.21

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,33 @@ _HA_STUBS = [
 for module_name in _HA_STUBS:
     sys.modules.setdefault(module_name, MagicMock())
 
+_config_entries = sys.modules["homeassistant.config_entries"]
+
+
+class _ConfigFlow:
+    """Minimal ConfigFlow stand-in so EnkiConfigFlow is a real class in tests."""
+
+    VERSION = 1
+    domain: str | None = None
+
+    def __init_subclass__(cls, domain: str | None = None, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        if domain is not None:
+            cls.domain = domain
+
+    @staticmethod
+    async def async_migrate_entry(hass, config_entry):
+        return True
+
+
+class _OptionsFlow:
+    """Minimal OptionsFlow stand-in for config_flow imports."""
+
+
+_config_entries.ConfigFlow = _ConfigFlow
+_config_entries.OptionsFlow = _OptionsFlow
+_config_entries.ConfigFlowResult = dict
+
 _ha_const = sys.modules["homeassistant.const"]
 _ha_const.CONF_USERNAME = "username"
 _ha_const.CONF_PASSWORD = "password"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ _HA_STUBS = [
     "homeassistant.exceptions",
     "homeassistant.helpers",
     "homeassistant.helpers.device_registry",
+    "homeassistant.helpers.entity_registry",
     "homeassistant.helpers.entity_platform",
     "homeassistant.helpers.update_coordinator",
     "homeassistant.helpers.selector",
@@ -53,6 +54,11 @@ _HA_STUBS = [
 
 for module_name in _HA_STUBS:
     sys.modules.setdefault(module_name, MagicMock())
+
+_ha_const = sys.modules["homeassistant.const"]
+_ha_const.CONF_USERNAME = "username"
+_ha_const.CONF_PASSWORD = "password"
+_ha_const.CONF_SCAN_INTERVAL = "scan_interval"
 
 
 class _HaEntity:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,8 @@ _HA_STUBS = [
     "homeassistant.components.diagnostics",
     "homeassistant.components.persistent_notification",
     "homeassistant.components.sensor",
+    "homeassistant.components.cover",
+    "homeassistant.components.button",
     "homeassistant.util",
 ]
 
@@ -58,10 +60,16 @@ for module_name in _HA_STUBS:
 class _HaEntity:
     """Minimal HA Entity stand-in for unit tests."""
 
+    def async_write_ha_state(self) -> None:
+        return None
+
 
 class _CoordinatorEntity(_HaEntity):
     def __init__(self, coordinator):
         self.coordinator = coordinator
+
+    def _handle_coordinator_update(self) -> None:
+        self.async_write_ha_state()
 
     def __class_getitem__(cls, _item):
         return cls
@@ -116,3 +124,24 @@ _percentage = MagicMock()
 _percentage.ordered_list_item_to_percentage = _ordered_list_item_to_percentage
 _percentage.percentage_to_ordered_list_item = _percentage_to_ordered_list_item
 sys.modules["homeassistant.util.percentage"] = _percentage
+
+_cover = sys.modules["homeassistant.components.cover"]
+
+
+class _CoverEntityFeature:
+    OPEN = 1
+    CLOSE = 2
+    SET_POSITION = 4
+    STOP = 8
+
+
+class _CoverDeviceClass:
+    SHUTTER = "shutter"
+
+
+_cover.CoverEntity = _HaEntity
+_cover.CoverEntityFeature = _CoverEntityFeature
+_cover.CoverDeviceClass = _CoverDeviceClass
+
+_button = sys.modules["homeassistant.components.button"]
+_button.ButtonEntity = _HaEntity

--- a/tests/unit/test_api_routing.py
+++ b/tests/unit/test_api_routing.py
@@ -110,7 +110,7 @@ async def test_fan_turn_off_uses_airflow_when_speed_state_missing() -> None:
 
 @pytest.mark.asyncio
 async def test_fan_turn_on_uses_power_when_only_check_fan_speed() -> None:
-    """Ae Toit-style fans: check_fan_speed without writable range → power-prod."""
+    """Fans with check_fan_speed but no writable range fall back to power-prod."""
     device = EnkiDevice(
         home_id="home-1",
         device_id="AE_TOIT_1",
@@ -141,6 +141,7 @@ async def test_fan_turn_on_uses_power_when_only_check_fan_speed() -> None:
         "home-1",
         "6a1468f4045591224e5f1686",
         "ON",
+        endpoint=1,
     )
     coordinator.api.async_set_fan_speed.assert_not_called()
 
@@ -174,5 +175,6 @@ async def test_fan_turn_on_falls_back_to_power_without_fan_speed_capability() ->
         "home-1",
         "node-1",
         "ON",
+        endpoint=None,
     )
     coordinator.api.async_set_fan_speed.assert_not_called()

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -52,6 +52,16 @@ def test_is_inverter_device() -> None:
     assert device_is_supported(device) is True
 
 
+def test_is_inverter_without_bff_power() -> None:
+    device = _device(
+        device_type="inverters",
+        capabilities=["check_power_production", "check_energy_production"],
+        power_production=None,
+    )
+    assert is_inverter_device(device) is True
+    assert device.profile.supports_energy_production is True
+
+
 def test_device_uses_power_api_only() -> None:
     device = _device(
         capabilities=["switch_electrical_power", "check_electrical_power"],
@@ -80,6 +90,20 @@ def test_fan_light_endpoints_excludes_motor() -> None:
         main_change_capability_endpoints=[1, 2, 3],
     )
     assert fan_light_endpoints(device) == [2, 3]
+
+
+def test_fan_light_endpoints_radix_motor_on_middle_endpoint() -> None:
+    from enki.domain.capabilities import fan_light_endpoints
+
+    device = _device(
+        device_type="ceiling_fans",
+        device_name="Inspire Radix",
+        capabilities=["change_fan_speed", "change_light_state"],
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[1, 2, 3],
+    )
+    assert fan_light_endpoints(device) == [1, 3]
+    assert device.profile.fan_motor_endpoints == [2]
 
 
 def test_fan_max_speed_from_metadata() -> None:

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -125,3 +125,14 @@ def test_supports_fan_speed_control_requires_change_and_range() -> None:
     )
     assert with_change.profile.supports_fan_speed_control is True
     assert check_only.profile.supports_fan_speed_control is False
+
+
+def test_impulse_relay_supported_not_cover() -> None:
+    device = _device(
+        device_type="access_and_motorizations",
+        capabilities=["power_on_with_timer"],
+    )
+    profile = device.profile
+    assert profile.is_impulse_relay is True
+    assert profile.is_cover is False
+    assert device_is_supported(device) is True

--- a/tests/unit/test_config_flow_migration.py
+++ b/tests/unit/test_config_flow_migration.py
@@ -1,0 +1,208 @@
+"""Config-flow migration tests for legacy CyrilP config entries (v1→v2)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from enki import async_migrate_entry as init_async_migrate_entry
+from enki.config_flow import EnkiConfigFlow
+from enki.const import CONF_SCAN_INTERVAL
+from enki.migration import async_migrate_entry, is_legacy_config_entry
+
+
+@dataclass
+class FakeConfigEntry:
+    """Minimal config entry stand-in with mutable fields like HA storage."""
+
+    entry_id: str
+    version: int
+    data: dict
+    options: dict
+    unique_id: str | None
+    title: str = "Enki – user@example.com"
+    updates: list[dict] = field(default_factory=list)
+
+
+def _apply_config_entry_update(
+    entry: FakeConfigEntry,
+    *,
+    data: dict | None = None,
+    options: dict | None = None,
+    unique_id: str | None = None,
+    version: int | None = None,
+) -> None:
+    payload: dict = {}
+    if data is not None:
+        entry.data = data
+        payload["data"] = data
+    if options is not None:
+        entry.options = options
+        payload["options"] = options
+    if unique_id is not None:
+        entry.unique_id = unique_id
+        payload["unique_id"] = unique_id
+    if version is not None:
+        entry.version = version
+        payload["version"] = version
+    entry.updates.append(payload)
+
+
+def _fake_hass() -> MagicMock:
+    hass = MagicMock()
+
+    def async_update_entry(entry: FakeConfigEntry, **kwargs) -> None:
+        _apply_config_entry_update(entry, **kwargs)
+
+    hass.config_entries.async_update_entry = async_update_entry
+    return hass
+
+
+def _legacy_v1_entry() -> FakeConfigEntry:
+    return FakeConfigEntry(
+        entry_id="legacy-entry-1",
+        version=1,
+        title="Enki - cyrilcolinet.pro@gmail.com",
+        data={
+            CONF_USERNAME: "cyrilcolinet.pro@gmail.com",
+            CONF_PASSWORD: "secret",
+            CONF_SCAN_INTERVAL: 45,
+        },
+        options={},
+        unique_id="Enki - cyrilcolinet.pro@gmail.com",
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_v1_entry_migrates_fields_and_version() -> None:
+    # Given
+    hass = _fake_hass()
+    entry = _legacy_v1_entry()
+    registry = MagicMock()
+
+    # When
+    with (
+        patch("enki.migration.er.async_get", return_value=registry),
+        patch("enki.migration.er.async_entries_for_config_entry", return_value=[]),
+    ):
+        result = await async_migrate_entry(hass, entry)
+
+    # Then
+    assert result is True
+    assert entry.version == 2
+    assert CONF_SCAN_INTERVAL not in entry.data
+    assert entry.options[CONF_SCAN_INTERVAL] == 45
+    assert entry.unique_id == "cyrilcolinet.pro@gmail.com"
+    assert entry.data[CONF_USERNAME] == "cyrilcolinet.pro@gmail.com"
+    assert len(entry.updates) == 2
+    assert entry.updates[0]["options"][CONF_SCAN_INTERVAL] == 45
+    assert entry.updates[1]["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_legacy_v1_entry_keeps_existing_scan_interval_option() -> None:
+    # Given
+    hass = _fake_hass()
+    entry = FakeConfigEntry(
+        entry_id="legacy-entry-2",
+        version=1,
+        data={
+            CONF_USERNAME: "user@example.com",
+            CONF_PASSWORD: "secret",
+            CONF_SCAN_INTERVAL: 60,
+        },
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="user@example.com",
+    )
+
+    # When
+    with (
+        patch("enki.migration.er.async_get", return_value=MagicMock()),
+        patch("enki.migration.er.async_entries_for_config_entry", return_value=[]),
+    ):
+        await async_migrate_entry(hass, entry)
+
+    # Then
+    assert entry.options[CONF_SCAN_INTERVAL] == 30
+    assert CONF_SCAN_INTERVAL not in entry.data
+
+
+@pytest.mark.asyncio
+async def test_legacy_v1_entry_renames_solar_entity_unique_id() -> None:
+    # Given
+    hass = _fake_hass()
+    entry = _legacy_v1_entry()
+    solar_entity = SimpleNamespace(
+        entity_id="sensor.enki_solar_power",
+        unique_id="enki-node1-power_production",
+    )
+    registry = MagicMock()
+
+    # When
+    with (
+        patch("enki.migration.er.async_get", return_value=registry),
+        patch(
+            "enki.migration.er.async_entries_for_config_entry",
+            return_value=[solar_entity],
+        ),
+    ):
+        await async_migrate_entry(hass, entry)
+
+    # Then
+    registry.async_update_entity.assert_called_once_with(
+        "sensor.enki_solar_power",
+        new_unique_id="enki-node1-power-production",
+    )
+
+
+
+
+@pytest.mark.asyncio
+async def test_config_flow_async_migrate_entry_runs_full_migration() -> None:
+    # Given
+    hass = _fake_hass()
+    entry = _legacy_v1_entry()
+
+    # When
+    with (
+        patch("enki.migration.er.async_get", return_value=MagicMock()),
+        patch("enki.migration.er.async_entries_for_config_entry", return_value=[]),
+    ):
+        result = await EnkiConfigFlow.async_migrate_entry(hass, entry)
+
+    # Then
+    assert result is True
+    assert entry.version == 2
+    assert entry.unique_id == "cyrilcolinet.pro@gmail.com"
+
+
+@pytest.mark.asyncio
+async def test_init_async_migrate_entry_runs_full_migration() -> None:
+    # Given
+    hass = _fake_hass()
+    entry = _legacy_v1_entry()
+
+    # When
+    with (
+        patch("enki.migration.er.async_get", return_value=MagicMock()),
+        patch("enki.migration.er.async_entries_for_config_entry", return_value=[]),
+    ):
+        result = await init_async_migrate_entry(hass, entry)
+
+    # Then
+    assert result is True
+    assert entry.version == 2
+    assert CONF_SCAN_INTERVAL in entry.options
+
+
+def test_is_legacy_config_entry_detects_cyrilp_shape() -> None:
+    entry = _legacy_v1_entry()
+    assert is_legacy_config_entry(entry) is True
+
+    entry.version = 2
+    entry.data.pop(CONF_SCAN_INTERVAL)
+    entry.unique_id = "cyrilcolinet.pro@gmail.com"
+    assert is_legacy_config_entry(entry) is False

--- a/tests/unit/test_config_flow_migration.py
+++ b/tests/unit/test_config_flow_migration.py
@@ -7,11 +7,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from enki import async_migrate_entry as init_async_migrate_entry
 from enki.config_flow import EnkiConfigFlow
 from enki.const import CONF_SCAN_INTERVAL
 from enki.migration import async_migrate_entry, is_legacy_config_entry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 
 @dataclass
@@ -156,8 +156,6 @@ async def test_legacy_v1_entry_renames_solar_entity_unique_id() -> None:
         "sensor.enki_solar_power",
         new_unique_id="enki-node1-power-production",
     )
-
-
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cover_entities.py
+++ b/tests/unit/test_cover_entities.py
@@ -1,0 +1,154 @@
+"""Unit tests for Enki cover and shutter preset button entities."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.button import EnkiShutterPresetButton
+from enki.cover import EnkiCoverEntity
+from enki.domain.models import EnkiDevice
+from homeassistant.components.cover import CoverEntityFeature
+
+
+def _cover_device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-1",
+        "device_name": "VR Salon",
+        "device_type": "access_and_motorizations",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [
+            "change_shutter_position",
+            "check_shutter_position",
+            "stop_change_shutter_position",
+            "check_roller_shutter_state",
+        ],
+        "last_reported_value": {
+            "shutter_position": 42,
+            "shutter_opening": "OPEN",
+            "roller_shutter_state": "OPENING",
+        },
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _coordinator_for_device(device: EnkiDevice) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.data = [device]
+    coordinator.get_device_by_node = lambda node_id: next(
+        (entry for entry in coordinator.data if entry.node_id == node_id),
+        None,
+    )
+    coordinator.update_cached_value = MagicMock()
+    coordinator.api.async_set_shutter_position = AsyncMock()
+    coordinator.api.async_stop_shutter = AsyncMock()
+    coordinator.api.async_execute_shutter_preset = AsyncMock()
+    return coordinator
+
+
+def test_cover_supported_features_with_position_and_stop() -> None:
+    device = _cover_device()
+    entity = EnkiCoverEntity(_coordinator_for_device(device), device)
+
+    features = entity.supported_features
+    assert features & CoverEntityFeature.OPEN
+    assert features & CoverEntityFeature.CLOSE
+    assert features & CoverEntityFeature.SET_POSITION
+    assert features & CoverEntityFeature.STOP
+
+
+def test_cover_supported_features_without_position() -> None:
+    device = _cover_device(
+        capabilities=["check_shutter_opening"],
+        last_reported_value={"shutter_opening": "CLOSED"},
+    )
+    entity = EnkiCoverEntity(_coordinator_for_device(device), device)
+
+    features = entity.supported_features
+    assert features & CoverEntityFeature.OPEN
+    assert features & CoverEntityFeature.CLOSE
+    assert not (features & CoverEntityFeature.SET_POSITION)
+    assert not (features & CoverEntityFeature.STOP)
+
+
+def test_cover_state_properties() -> None:
+    device = _cover_device()
+    entity = EnkiCoverEntity(_coordinator_for_device(device), device)
+
+    assert entity.current_cover_position == 42
+    assert entity.is_closed is False
+    assert entity.is_opening is True
+    assert entity.is_closing is False
+
+
+def test_cover_is_closed_from_position_when_opening_missing() -> None:
+    device = _cover_device(
+        last_reported_value={"shutter_position": 0},
+    )
+    entity = EnkiCoverEntity(_coordinator_for_device(device), device)
+
+    assert entity.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_cover_open_sets_full_position() -> None:
+    device = _cover_device()
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiCoverEntity(coordinator, device)
+
+    await entity.async_open_cover()
+
+    coordinator.api.async_set_shutter_position.assert_awaited_once_with("home-1", "node-1", 100)
+    coordinator.update_cached_value.assert_any_call("node-1", "shutter_position", 100)
+    coordinator.update_cached_value.assert_any_call("node-1", "shutter_opening", "OPEN")
+
+
+@pytest.mark.asyncio
+async def test_cover_close_sets_zero_position() -> None:
+    device = _cover_device()
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiCoverEntity(coordinator, device)
+
+    await entity.async_close_cover()
+
+    coordinator.api.async_set_shutter_position.assert_awaited_once_with("home-1", "node-1", 0)
+    coordinator.update_cached_value.assert_any_call("node-1", "shutter_opening", "CLOSED")
+
+
+@pytest.mark.asyncio
+async def test_cover_stop_calls_api_and_caches_state() -> None:
+    device = _cover_device()
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiCoverEntity(coordinator, device)
+
+    await entity.async_stop_cover()
+
+    coordinator.api.async_stop_shutter.assert_awaited_once_with("home-1", "node-1")
+    coordinator.update_cached_value.assert_called_once_with(
+        "node-1",
+        "roller_shutter_state",
+        "STOPPED",
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutter_preset_button_press() -> None:
+    device = _cover_device(
+        capabilities=["execute_preset"],
+        possible_values={"execute_preset": {"values": ["MORNING"]}},
+    )
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiShutterPresetButton(coordinator, device, "MORNING")
+
+    await entity.async_press()
+
+    coordinator.api.async_execute_shutter_preset.assert_awaited_once_with(
+        "home-1",
+        "node-1",
+        "MORNING",
+    )

--- a/tests/unit/test_cover_entities.py
+++ b/tests/unit/test_cover_entities.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from enki.button import EnkiShutterPresetButton
+from enki.button import EnkiImpulseRelayButton, EnkiShutterPresetButton
 from enki.cover import EnkiCoverEntity
 from enki.domain.models import EnkiDevice
 from homeassistant.components.cover import CoverEntityFeature
@@ -48,6 +48,7 @@ def _coordinator_for_device(device: EnkiDevice) -> MagicMock:
     coordinator.api.async_set_shutter_position = AsyncMock()
     coordinator.api.async_stop_shutter = AsyncMock()
     coordinator.api.async_execute_shutter_preset = AsyncMock()
+    coordinator.api.async_power_on_with_timer = AsyncMock()
     return coordinator
 
 
@@ -152,3 +153,14 @@ async def test_shutter_preset_button_press() -> None:
         "node-1",
         "MORNING",
     )
+
+
+@pytest.mark.asyncio
+async def test_impulse_relay_button_press() -> None:
+    device = _cover_device(capabilities=["power_on_with_timer"])
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiImpulseRelayButton(coordinator, device)
+
+    await entity.async_press()
+
+    coordinator.api.async_power_on_with_timer.assert_awaited_once_with("home-1", "node-1")

--- a/tests/unit/test_fan_endpoints.py
+++ b/tests/unit/test_fan_endpoints.py
@@ -1,0 +1,43 @@
+"""Unit tests for fan endpoint resolution."""
+
+from __future__ import annotations
+
+from enki.lib.fan_endpoints import (
+    infer_fan_motor_endpoints,
+    motor_endpoints_from_metadata,
+)
+
+
+def test_motor_endpoints_from_metadata_type_fan() -> None:
+    entries = (
+        {"id": 1, "type": "LIGHTING"},
+        {"id": 2, "type": "FAN"},
+        {"id": 3, "type": "LIGHTING"},
+    )
+    assert motor_endpoints_from_metadata(entries) == frozenset({2})
+
+
+def test_infer_fan_motor_endpoints_radix_by_name() -> None:
+    motors = infer_fan_motor_endpoints(
+        power_endpoints=[1, 2, 3],
+        endpoint_entries=(1, 2, 3),
+        supports_light_state=True,
+        supports_fan_speed=True,
+        device_name="Ventilateur Radix",
+        referentiel_i18n="",
+        referentiel_model="",
+    )
+    assert motors == frozenset({2})
+
+
+def test_infer_fan_motor_endpoints_siroco_default() -> None:
+    motors = infer_fan_motor_endpoints(
+        power_endpoints=[1, 2, 3],
+        endpoint_entries=(1, 2, 3),
+        supports_light_state=True,
+        supports_fan_speed=True,
+        device_name="Inspire Siroco+",
+        referentiel_i18n="",
+        referentiel_model="",
+    )
+    assert motors == frozenset({1})

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from enki.const import CONF_SCAN_INTERVAL
 from enki.migration import (
+    async_migrate_entry,
     migrate_config_entry_fields,
     migrate_legacy_entity_unique_ids,
     migrate_power_sensor_unique_id,
@@ -76,3 +78,36 @@ def test_resolve_scan_interval_falls_back_to_legacy_data() -> None:
     entry.data = {CONF_SCAN_INTERVAL: 60}
 
     assert resolve_scan_interval(entry) == 60
+
+
+@pytest.mark.asyncio
+async def test_async_migrate_entry_bumps_version_for_legacy_entry() -> None:
+    # Given
+    hass = MagicMock()
+    config_entry = MagicMock(version=1, data={}, options={}, unique_id="user@example.com")
+    hass.config_entries.async_update_entry = MagicMock()
+
+    # When
+    with patch("enki.migration.async_migrate_legacy_entry", return_value=None) as migrate_legacy:
+        result = await async_migrate_entry(hass, config_entry)
+
+    # Then
+    assert result is True
+    migrate_legacy.assert_awaited_once_with(hass, config_entry)
+    hass.config_entries.async_update_entry.assert_called_once_with(config_entry, version=2)
+
+
+@pytest.mark.asyncio
+async def test_async_migrate_entry_noop_when_already_current() -> None:
+    # Given
+    hass = MagicMock()
+    config_entry = MagicMock(version=2)
+
+    # When
+    with patch("enki.migration.async_migrate_legacy_entry") as migrate_legacy:
+        result = await async_migrate_entry(hass, config_entry)
+
+    # Then
+    assert result is True
+    migrate_legacy.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -1,0 +1,78 @@
+"""Unit tests for legacy config entry migration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from enki.const import CONF_SCAN_INTERVAL
+from enki.migration import (
+    migrate_config_entry_fields,
+    migrate_legacy_entity_unique_ids,
+    migrate_power_sensor_unique_id,
+    resolve_scan_interval,
+)
+
+
+def test_migrate_config_entry_moves_scan_interval_to_options() -> None:
+    data, options, unique_id = migrate_config_entry_fields(
+        data={"username": "user@example.com", "password": "secret", CONF_SCAN_INTERVAL: 60},
+        options={},
+        unique_id="Enki - user@example.com",
+    )
+
+    assert CONF_SCAN_INTERVAL not in data
+    assert options[CONF_SCAN_INTERVAL] == 60
+    assert unique_id == "user@example.com"
+
+
+def test_migrate_config_entry_keeps_existing_options() -> None:
+    data, options, _unique_id = migrate_config_entry_fields(
+        data={"username": "user@example.com", "password": "secret", CONF_SCAN_INTERVAL: 45},
+        options={CONF_SCAN_INTERVAL: 30},
+        unique_id="user@example.com",
+    )
+
+    assert options[CONF_SCAN_INTERVAL] == 30
+
+
+def test_migrate_power_sensor_unique_id() -> None:
+    assert (
+        migrate_power_sensor_unique_id("enki-abc123-power_production")
+        == "enki-abc123-power-production"
+    )
+    assert migrate_power_sensor_unique_id("enki-abc123-power-production") is None
+
+
+def test_migrate_legacy_entity_unique_ids() -> None:
+    registry = MagicMock()
+    entity = MagicMock(
+        entity_id="sensor.solar_power",
+        unique_id="enki-node1-power_production",
+    )
+
+    with patch(
+        "enki.migration.er.async_entries_for_config_entry",
+        return_value=[entity],
+    ):
+        migrate_legacy_entity_unique_ids(registry, "entry-1")
+
+    registry.async_update_entity.assert_called_once_with(
+        "sensor.solar_power",
+        new_unique_id="enki-node1-power-production",
+    )
+
+
+def test_resolve_scan_interval_prefers_options() -> None:
+    entry = MagicMock()
+    entry.options = {CONF_SCAN_INTERVAL: 45}
+    entry.data = {CONF_SCAN_INTERVAL: 60}
+
+    assert resolve_scan_interval(entry) == 45
+
+
+def test_resolve_scan_interval_falls_back_to_legacy_data() -> None:
+    entry = MagicMock()
+    entry.options = {}
+    entry.data = {CONF_SCAN_INTERVAL: 60}
+
+    assert resolve_scan_interval(entry) == 60

--- a/tests/unit/test_power_on_with_timer.py
+++ b/tests/unit/test_power_on_with_timer.py
@@ -1,0 +1,21 @@
+"""Unit tests for power_on_with_timer dry-contact API routing."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.api.client import EnkiAPI
+
+
+@pytest.mark.asyncio
+async def test_power_on_with_timer_posts_without_body() -> None:
+    api = EnkiAPI("user@example.com", "secret")
+    http = MagicMock()
+    http.power_on_with_timer = AsyncMock()
+    api._get_http = AsyncMock(return_value=http)  # noqa: SLF001
+
+    await api.async_power_on_with_timer("home-1", "node-gate")
+
+    http.power_on_with_timer.assert_awaited_once_with("home-1", "node-gate")
+    await api.async_close()

--- a/tests/unit/test_production.py
+++ b/tests/unit/test_production.py
@@ -1,0 +1,15 @@
+"""Unit tests for solar production parsers."""
+
+from __future__ import annotations
+
+from enki.lib.production import parse_production_value
+
+
+def test_parse_production_value_numeric() -> None:
+    assert parse_production_value(250) == 250.0
+    assert parse_production_value(12.5) == 12.5
+
+
+def test_parse_production_value_string_with_unit() -> None:
+    assert parse_production_value("109 W") == 109.0
+    assert parse_production_value("42.3 kWh") == 42.3

--- a/tests/unit/test_scenario_button.py
+++ b/tests/unit/test_scenario_button.py
@@ -1,0 +1,89 @@
+"""Unit tests for EnkiScenarioButton entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.button import EnkiScenarioButton
+from enki.domain.models import EnkiScenario
+
+
+def _scenario(**kwargs) -> EnkiScenario:
+    defaults = {
+        "home_id": "home-1",
+        "scenario_id": "scenario-1",
+        "label": "Good night",
+        "enabled": True,
+        "status": "IDLE",
+    }
+    defaults.update(kwargs)
+    return EnkiScenario(**defaults)
+
+
+def _coordinator(*, scenarios: list[EnkiScenario], last_update_success: bool = True) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.last_update_success = last_update_success
+    coordinator.api.scenarios = scenarios
+    coordinator.api.async_activate_scenario = AsyncMock()
+    return coordinator
+
+
+def test_scenario_button_available_when_enabled() -> None:
+    scenario = _scenario()
+    entity = EnkiScenarioButton(_coordinator(scenarios=[scenario]), "home-1", "scenario-1")
+
+    assert entity.available is True
+
+
+def test_scenario_button_unavailable_when_disabled() -> None:
+    scenario = _scenario(enabled=False)
+    entity = EnkiScenarioButton(_coordinator(scenarios=[scenario]), "home-1", "scenario-1")
+
+    assert entity.available is False
+
+
+def test_scenario_button_unavailable_when_missing_from_poll() -> None:
+    entity = EnkiScenarioButton(_coordinator(scenarios=[]), "home-1", "scenario-1")
+
+    assert entity.available is False
+
+
+def test_scenario_button_unavailable_when_coordinator_failed() -> None:
+    scenario = _scenario()
+    entity = EnkiScenarioButton(
+        _coordinator(scenarios=[scenario], last_update_success=False),
+        "home-1",
+        "scenario-1",
+    )
+
+    assert entity.available is False
+
+
+def test_refresh_from_scenario_updates_label() -> None:
+    entity = EnkiScenarioButton(_coordinator(scenarios=[_scenario()]), "home-1", "scenario-1")
+    entity._attr_name = "Old label"
+
+    entity.refresh_from_scenario(_scenario(label="Away mode"))
+
+    assert entity._attr_name == "Away mode"
+
+
+def test_coordinator_update_applies_latest_label() -> None:
+    coordinator = _coordinator(scenarios=[_scenario(label="Morning")])
+    entity = EnkiScenarioButton(coordinator, "home-1", "scenario-1")
+    entity._attr_name = "Stale"
+
+    entity._handle_coordinator_update()
+
+    assert entity._attr_name == "Morning"
+
+
+@pytest.mark.asyncio
+async def test_scenario_button_press_activates_cloud_scenario() -> None:
+    coordinator = _coordinator(scenarios=[_scenario()])
+    entity = EnkiScenarioButton(coordinator, "home-1", "scenario-1")
+
+    await entity.async_press()
+
+    coordinator.api.async_activate_scenario.assert_awaited_once_with("home-1", "scenario-1")

--- a/tests/unit/test_telemetry_enrichment.py
+++ b/tests/unit/test_telemetry_enrichment.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from enki.domain.capabilities import EnkiCapabilityProfile
 from enki.domain.profile import (
     build_discovery_record,
     format_github_issue_body,
     profile_to_export_dict,
 )
 from enki.domain.telemetry_coverage import discovery_record_needs_telemetry
-from enki.domain.telemetry_enrichment import enrich_telemetry_export
+from enki.domain.telemetry_enrichment import enrich_telemetry_export, ha_platforms_for_profile
 
 
 def _noirot_record():
@@ -112,3 +113,20 @@ def test_github_issue_body_is_english_and_includes_api_errors() -> None:
     assert "API read errors (last poll)" in body
     assert "HTTP 500" in body
     assert "Profil appareil" not in body
+
+
+def test_ha_platforms_include_button_for_shutter_presets() -> None:
+    profile = EnkiCapabilityProfile(
+        device_type="access_and_motorizations",
+        capabilities=frozenset(
+            [
+                "change_shutter_position",
+                "check_shutter_position",
+                "execute_preset",
+            ]
+        ),
+        possible_values={"execute_preset": {"values": ["MORNING"]}},
+        bff_device_type="access_and_motorizations",
+    )
+
+    assert ha_platforms_for_profile(profile) == ["button", "cover"]

--- a/tests/unit/test_telemetry_enrichment.py
+++ b/tests/unit/test_telemetry_enrichment.py
@@ -130,3 +130,14 @@ def test_ha_platforms_include_button_for_shutter_presets() -> None:
     )
 
     assert ha_platforms_for_profile(profile) == ["button", "cover"]
+
+
+def test_ha_platforms_include_button_for_impulse_relay() -> None:
+    profile = EnkiCapabilityProfile(
+        device_type="access_and_motorizations",
+        capabilities=frozenset(["power_on_with_timer"]),
+        possible_values={},
+        bff_device_type="access_and_motorizations",
+    )
+
+    assert ha_platforms_for_profile(profile) == ["button"]


### PR DESCRIPTION
## Summary

- Add `Co-authored-by` trailers on migration / CyrilP-related commits (history rewrite)
- Include `CONTRIBUTORS.md` crediting the original [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) contributors

**Co-authored contributors** (human, excluding dependabot):

- CyrilP
- McGiverGim (Míguel Ángel Mulero Martínez)
- katnion
- bbird81
- kitenoob

## Commits touched

Messages matching `migration` or `CyrilP`, including:

- `feat(migration): migrate legacy CyrilP config entries`
- `docs: add MIGRATION.md for CyrilP upgrade path`
- PR #62 merge + follow-up `fix(migration)` / `test(migration)`

## Merge note

This branch **rewrites git history** (new SHAs) to append commit trailers. A normal merge may not be ideal.

**Recommended:** after approval, fast-forward or force-push this branch to `main` (temporarily allow force-push on the protected branch), then delete the branch.

`CONTRIBUTORS.md` is already on `main` (`26f8b51`) — merging may dedupe to one file; content is the same.

## Test plan

- [x] `git log` on branch shows `Co-authored-by` on migration commits
- [ ] After merge/push: GitHub commit pages show co-author avatars on listed commits