### PR TITLE
test(migration): Co-authored-by on unit test commit only

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,11 @@ def _patch_aiohttp_client_response_for_aioresponses() -> None:
 
 _patch_aiohttp_client_response_for_aioresponses()
 
+_voluptuous = MagicMock()
+_voluptuous.Schema = MagicMock(side_effect=lambda schema: schema)
+_voluptuous.Required = MagicMock(side_effect=lambda key, **kwargs: key)
+sys.modules.setdefault("voluptuous", _voluptuous)
+
 _HA_STUBS = [
     "homeassistant",
     "homeassistant.config_entries",

--- a/tests/unit/test_config_flow_migration.py
+++ b/tests/unit/test_config_flow_migration.py
@@ -7,11 +7,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from enki import async_migrate_entry as init_async_migrate_entry
 from enki.config_flow import EnkiConfigFlow
 from enki.const import CONF_SCAN_INTERVAL
 from enki.migration import async_migrate_entry, is_legacy_config_entry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 
 @dataclass
@@ -156,8 +156,6 @@ async def test_legacy_v1_entry_renames_solar_entity_unique_id() -> None:
         "sensor.enki_solar_power",
         new_unique_id="enki-node1-power-production",
     )
-
-
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Credits the original [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component) contributors on the config-flow migration test harness.

**One commit on top of `main`:**
- `Co-authored-by` trailers (CyrilP, McGiverGim, katnion, bbird81, kitenoob)
- CI fix: `voluptuous` stub in `conftest.py` + import sort in test file

Replaces the messy multi-commit branch (merge commit + duplicate history) that blocked GitHub rebase.

## Merge

Use **Merge pull request** (merge commit or squash). Rebase should work now if you update the branch.

## Test plan

- [x] `pytest tests/unit` — 229 passed
- [x] `ruff check .` + `ruff format --check .`