### PR TITLE
fix(light): route bare fan-light on via switch_electrical_power when change_light_state is unschemed

### DIFF
--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -524,6 +524,21 @@ class EnkiCapabilityProfile:
         return list(self.main_change_capability_endpoints)
 
     @property
+    def bare_power_fallback_endpoint(self) -> int | None:
+        """Endpoint for a bare on/off via switch_electrical_power, or None.
+
+        Returns the referentiel's declared switch_electrical_power endpoint
+        when change_light_state has no real schema (see
+        light_state_has_schema), so callers know to bypass change-light-state
+        for a plain power toggle. Returns None when change_light_state should
+        be used as usual, or when no power-switch endpoint is declared.
+        """
+        if self.light_state_has_schema:
+            return None
+        power_endpoints = self.power_switch_endpoints
+        return power_endpoints[0] if power_endpoints else None
+
+    @property
     def _fan_motor_endpoint_ids(self) -> frozenset[int]:
         if self.device_type != DEVICE_TYPE_FANS and not self.is_fan:
             return frozenset()

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -94,6 +94,21 @@ class EnkiCapabilityProfile:
         )
 
     @property
+    def light_state_has_schema(self) -> bool:
+        """True when change_light_state/check_light_state has a real writable schema.
+
+        Some fan+light referentiels (e.g. AD_TCFL_1) list these capability names
+        without any possibleValues entry, so change-light-state never actually
+        applies a bare power change on those models even though the capability
+        tag is present. The real bare on/off channel for those is
+        switch_electrical_power on the referentiel's declared endpoint.
+        """
+        return (
+            "change_light_state" in self.possible_values
+            or "check_light_state" in self.possible_values
+        )
+
+    @property
     def supports_electrical_power(self) -> bool:
         return _supports(
             self.capabilities,

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -527,14 +527,26 @@ class EnkiCapabilityProfile:
     def bare_power_fallback_endpoint(self) -> int | None:
         """Endpoint for a bare on/off via switch_electrical_power, or None.
 
-        Returns the referentiel's declared switch_electrical_power endpoint
-        when change_light_state has no real schema (see
-        light_state_has_schema), so callers know to bypass change-light-state
-        for a plain power toggle. Returns None when change_light_state should
-        be used as usual, or when no power-switch endpoint is declared.
+        Returns the switch_electrical_power endpoint to target for a plain
+        power toggle when change_light_state has no real schema (see
+        light_state_has_schema). On fans, the first power_switch_endpoints
+        entry is often the motor circuit rather than the light kit (e.g.
+        Siroco+/Cadix, where endpoint 1 is conventionally the motor) — prefer
+        fan_light_endpoints, which already excludes motor endpoints via
+        infer_fan_motor_endpoints, and only fall back to the raw
+        power-switch endpoint when no light-kit endpoint can be resolved
+        (e.g. a single-endpoint device like AD_TCFL_1, where that one
+        endpoint doubles as the light channel because the motor is driven
+        separately via change_fan_speed). Returns None when
+        change_light_state should be used as usual, or when no endpoint can
+        be resolved either way.
         """
         if self.light_state_has_schema:
             return None
+        if self.is_fan:
+            light_endpoints = self.fan_light_endpoints
+            if light_endpoints:
+                return light_endpoints[0]
         power_endpoints = self.power_switch_endpoints
         return power_endpoints[0] if power_endpoints else None
 

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -120,11 +120,7 @@ class EnkiFanLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
             await self._switch_endpoint_power(self._endpoint_id, "ON")
             return
 
-        fallback_endpoint = (
-            self._device.profile.bare_power_fallback_endpoint
-            if self._simple_light_turn_on(kwargs)
-            else None
-        )
+        fallback_endpoint = self._bare_power_fallback_endpoint(kwargs)
         if fallback_endpoint is not None:
             await self.coordinator.api.async_switch_electrical_power(
                 self._device.home_id,

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -120,17 +120,20 @@ class EnkiFanLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
             await self._switch_endpoint_power(self._endpoint_id, "ON")
             return
 
-        if self._simple_light_turn_on(kwargs) and not self._device.profile.light_state_has_schema:
-            power_endpoints = self._device.profile.power_switch_endpoints
-            if power_endpoints:
-                await self.coordinator.api.async_switch_electrical_power(
-                    self._device.home_id,
-                    self._device.node_id,
-                    "ON",
-                    endpoint=power_endpoints[0],
-                )
-                self._cache_global_light_on(self.coordinator)
-                return
+        fallback_endpoint = (
+            self._device.profile.bare_power_fallback_endpoint
+            if self._simple_light_turn_on(kwargs)
+            else None
+        )
+        if fallback_endpoint is not None:
+            await self.coordinator.api.async_switch_electrical_power(
+                self._device.home_id,
+                self._device.node_id,
+                "ON",
+                endpoint=fallback_endpoint,
+            )
+            self._cache_global_light_on(self.coordinator)
+            return
 
         await self._mixed_endpoint_workaround()
         changes = self._build_turn_on_changes(kwargs, restore_last_brightness=True)

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -129,6 +129,7 @@ class EnkiFanLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
                 endpoint=fallback_endpoint,
             )
             self._cache_global_light_on(self.coordinator)
+            self._update_light_endpoint_cache("ON", fallback_endpoint)
             return
 
         await self._mixed_endpoint_workaround()

--- a/custom_components/enki/light.py
+++ b/custom_components/enki/light.py
@@ -120,6 +120,18 @@ class EnkiFanLightEntity(EnkiLightBehaviorMixin, EnkiEntity, LightEntity):
             await self._switch_endpoint_power(self._endpoint_id, "ON")
             return
 
+        if self._simple_light_turn_on(kwargs) and not self._device.profile.light_state_has_schema:
+            power_endpoints = self._device.profile.power_switch_endpoints
+            if power_endpoints:
+                await self.coordinator.api.async_switch_electrical_power(
+                    self._device.home_id,
+                    self._device.node_id,
+                    "ON",
+                    endpoint=power_endpoints[0],
+                )
+                self._cache_global_light_on(self.coordinator)
+                return
+
         await self._mixed_endpoint_workaround()
         changes = self._build_turn_on_changes(kwargs, restore_last_brightness=True)
         if changes.get("power") == "OFF":

--- a/custom_components/enki/platforms/light/behavior.py
+++ b/custom_components/enki/platforms/light/behavior.py
@@ -44,6 +44,24 @@ class EnkiLightBehaviorMixin:
     def _simple_light_turn_on(self, kwargs: dict[str, Any]) -> bool:
         return ATTR_BRIGHTNESS not in kwargs and ATTR_COLOR_TEMP_KELVIN not in kwargs
 
+    def _bare_power_fallback_endpoint(self: EnkiEntity, kwargs: dict[str, Any]) -> int | None:
+        """Endpoint for a bare on/off via switch_electrical_power, or None.
+
+        Only applies when change_light_state has no real possibleValues
+        schema (see EnkiCapabilityProfile.light_state_has_schema) and the
+        call carries no brightness/color_temp_kelvin. Honors this entity's
+        own endpoint_id first, so a multi-gang fan light (e.g. Siroco+,
+        endpoints 2/3) always targets its own circuit rather than falling
+        back to the profile's first declared power-switch endpoint.
+        """
+        if not self._simple_light_turn_on(kwargs):
+            return None
+        if self._device.profile.light_state_has_schema:
+            return None
+        if self._endpoint_id is not None:
+            return self._endpoint_id
+        return self._device.profile.bare_power_fallback_endpoint
+
     async def _switch_endpoint_power(self: EnkiEntity, endpoint_id: int, power: str) -> None:
         await self.coordinator.api.async_switch_electrical_power(
             self._device.home_id,

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -80,6 +80,31 @@ def test_main_change_capability_endpoints() -> None:
     assert main_change_capability_endpoints(device) == [2, 3]
 
 
+def test_light_state_has_schema_false_when_capability_tag_without_possible_values() -> None:
+    # AD_TCFL_1 (ceiling fan + light kit): "change_light_state"/"check_light_state"
+    # are listed in capabilities but possibleValues has no entry for either one.
+    device = _device(
+        device_type="ceiling_fans",
+        capabilities=["change_fan_speed", "change_light_state", "check_light_state"],
+        possible_values={
+            "change_fan_speed": {"format": "RANGE", "range": {"min": 0.0, "max": 6.0}},
+        },
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[1],
+    )
+    assert device.profile.supports_light_state is True
+    assert device.profile.light_state_has_schema is False
+
+
+def test_light_state_has_schema_true_when_possible_values_present() -> None:
+    device = _device(
+        device_type="lights",
+        capabilities=["change_light_state", "check_light_state"],
+        possible_values={"change_light_state": {"format": "VALUES", "values": ["ON", "OFF"]}},
+    )
+    assert device.profile.light_state_has_schema is True
+
+
 def test_fan_light_endpoints_excludes_motor() -> None:
     from enki.domain.capabilities import fan_light_endpoints
 

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -80,18 +80,27 @@ def test_main_change_capability_endpoints() -> None:
     assert main_change_capability_endpoints(device) == [2, 3]
 
 
-def test_light_state_has_schema_false_when_capability_tag_without_possible_values() -> None:
-    # AD_TCFL_1 (ceiling fan + light kit): "change_light_state"/"check_light_state"
-    # are listed in capabilities but possibleValues has no entry for either one.
-    device = _device(
-        device_type="ceiling_fans",
-        capabilities=["change_fan_speed", "change_light_state", "check_light_state"],
-        possible_values={
+def _unschemed_fan_light_device(**overrides) -> EnkiDevice:
+    """AD_TCFL_1-shaped device: change_light_state is listed in capabilities
+    but has no possibleValues schema, while switch_electrical_power (endpoint
+    1) does — the referentiel's real bare on/off channel.
+    """
+    defaults = {
+        "device_type": "ceiling_fans",
+        "capabilities": ["change_fan_speed", "change_light_state", "check_light_state"],
+        "possible_values": {
             "change_fan_speed": {"format": "RANGE", "range": {"min": 0.0, "max": 6.0}},
+            "switch_electrical_power": {"format": "VALUES", "values": ["ON", "OFF"]},
         },
-        main_change_capability_id="switch_electrical_power",
-        main_change_capability_endpoints=[1],
-    )
+        "main_change_capability_id": "switch_electrical_power",
+        "main_change_capability_endpoints": [1],
+    }
+    defaults.update(overrides)
+    return _device(**defaults)
+
+
+def test_light_state_has_schema_false_when_capability_tag_without_possible_values() -> None:
+    device = _unschemed_fan_light_device()
     assert device.profile.supports_light_state is True
     assert device.profile.light_state_has_schema is False
 
@@ -103,6 +112,29 @@ def test_light_state_has_schema_true_when_possible_values_present() -> None:
         possible_values={"change_light_state": {"format": "VALUES", "values": ["ON", "OFF"]}},
     )
     assert device.profile.light_state_has_schema is True
+
+
+def test_bare_power_fallback_endpoint_used_when_light_state_unschemed() -> None:
+    device = _unschemed_fan_light_device()
+    assert device.profile.bare_power_fallback_endpoint == 1
+
+
+def test_bare_power_fallback_endpoint_none_when_light_state_has_schema() -> None:
+    device = _unschemed_fan_light_device(
+        possible_values={
+            "change_light_state": {"format": "VALUES", "values": ["ON", "OFF"]},
+            "switch_electrical_power": {"format": "VALUES", "values": ["ON", "OFF"]},
+        },
+    )
+    assert device.profile.bare_power_fallback_endpoint is None
+
+
+def test_bare_power_fallback_endpoint_none_without_power_switch_endpoint() -> None:
+    device = _unschemed_fan_light_device(
+        main_change_capability_id=None,
+        main_change_capability_endpoints=[],
+    )
+    assert device.profile.bare_power_fallback_endpoint is None
 
 
 def test_fan_light_endpoints_excludes_motor() -> None:

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -114,8 +114,36 @@ def test_light_state_has_schema_true_when_possible_values_present() -> None:
     assert device.profile.light_state_has_schema is True
 
 
-def test_bare_power_fallback_endpoint_used_when_light_state_unschemed() -> None:
+def test_bare_power_fallback_endpoint_single_endpoint_falls_back_to_power_switch() -> None:
+    # AD_TCFL_1: a single switch_electrical_power endpoint doubles as the
+    # light channel — fan speed is driven separately via change_fan_speed,
+    # so infer_fan_motor_endpoints classifies the lone endpoint as the
+    # motor and fan_light_endpoints comes back empty, falling through to
+    # the raw power-switch endpoint. Verified live against real hardware.
     device = _unschemed_fan_light_device()
+    assert device.profile.fan_light_endpoints == []
+    assert device.profile.bare_power_fallback_endpoint == 1
+
+
+def test_bare_power_fallback_endpoint_prefers_light_kit_on_siroco_layout() -> None:
+    # Siroco+/Cadix: motor on endpoint 1, light kit on endpoint 2. Must not
+    # target the motor for a bare light on/off.
+    device = _unschemed_fan_light_device(
+        device_name="Inspire Siroco+",
+        main_change_capability_endpoints=[1, 2],
+    )
+    assert device.profile.fan_light_endpoints == [2]
+    assert device.profile.bare_power_fallback_endpoint == 2
+
+
+def test_bare_power_fallback_endpoint_prefers_light_kit_on_radix_layout() -> None:
+    # Inspire Radix: dual LED kit at the corners (1, 3), motor on the
+    # middle endpoint (2). Must pick a light-kit endpoint, not the motor.
+    device = _unschemed_fan_light_device(
+        device_name="Inspire Radix",
+        main_change_capability_endpoints=[1, 2, 3],
+    )
+    assert device.profile.fan_light_endpoints == [1, 3]
     assert device.profile.bare_power_fallback_endpoint == 1
 
 

--- a/tests/unit/test_fan_light_state.py
+++ b/tests/unit/test_fan_light_state.py
@@ -2,7 +2,39 @@
 
 from __future__ import annotations
 
+from enki.domain.models import EnkiDevice
 from enki.lib.conversion import merge_light_state_payload
+from enki.platforms.light.behavior import EnkiLightBehaviorMixin
+from homeassistant.components.light import ATTR_BRIGHTNESS
+
+
+class _FakeFanLightEntity(EnkiLightBehaviorMixin):
+    """Minimal double exposing only what _bare_power_fallback_endpoint needs."""
+
+    def __init__(self, device: EnkiDevice, endpoint_id: int | None) -> None:
+        self._device = device
+        self._endpoint_id = endpoint_id
+
+
+def _unschemed_fan_light_device(**overrides) -> EnkiDevice:
+    defaults = {
+        "home_id": "home",
+        "device_id": "device",
+        "node_id": "node",
+        "device_name": "Test",
+        "device_type": "ceiling_fans",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["change_fan_speed", "change_light_state", "check_light_state"],
+        "possible_values": {
+            "change_fan_speed": {"format": "RANGE", "range": {"min": 0.0, "max": 6.0}},
+            "switch_electrical_power": {"format": "VALUES", "values": ["ON", "OFF"]},
+        },
+        "main_change_capability_id": "switch_electrical_power",
+        "main_change_capability_endpoints": [1],
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
 
 
 def test_merge_light_state_payload_power_off_wins() -> None:
@@ -43,3 +75,37 @@ def test_merge_light_state_payload_color_temp_sets_ct_mode() -> None:
 def test_fan_light_power_from_lighting_last_reported() -> None:
     last_reported = {"power": "OFF", "brightness": 0.2}
     assert last_reported.get("power", "OFF") == "OFF"
+
+
+def test_bare_power_fallback_endpoint_uses_own_endpoint_on_multi_gang_device() -> None:
+    # Siroco+-style multi-endpoint fan light (endpoints 2 and 3): this entity
+    # represents endpoint 3 specifically, so the fallback must target 3, not
+    # the profile's first declared power-switch endpoint (2).
+    device = _unschemed_fan_light_device(
+        main_change_capability_endpoints=[2, 3],
+    )
+    entity = _FakeFanLightEntity(device, endpoint_id=3)
+    assert entity._bare_power_fallback_endpoint({}) == 3
+
+
+def test_bare_power_fallback_endpoint_uses_profile_default_when_endpoint_id_unset() -> None:
+    device = _unschemed_fan_light_device(main_change_capability_endpoints=[1])
+    entity = _FakeFanLightEntity(device, endpoint_id=None)
+    assert entity._bare_power_fallback_endpoint({}) == 1
+
+
+def test_bare_power_fallback_endpoint_none_when_brightness_given() -> None:
+    device = _unschemed_fan_light_device()
+    entity = _FakeFanLightEntity(device, endpoint_id=None)
+    assert entity._bare_power_fallback_endpoint({ATTR_BRIGHTNESS: 128}) is None
+
+
+def test_bare_power_fallback_endpoint_none_when_light_state_has_schema() -> None:
+    device = _unschemed_fan_light_device(
+        possible_values={
+            "change_light_state": {"format": "VALUES", "values": ["ON", "OFF"]},
+            "switch_electrical_power": {"format": "VALUES", "values": ["ON", "OFF"]},
+        },
+    )
+    entity = _FakeFanLightEntity(device, endpoint_id=None)
+    assert entity._bare_power_fallback_endpoint({}) is None

--- a/tests/unit/test_fan_light_state.py
+++ b/tests/unit/test_fan_light_state.py
@@ -94,6 +94,20 @@ def test_bare_power_fallback_endpoint_uses_profile_default_when_endpoint_id_unse
     assert entity._bare_power_fallback_endpoint({}) == 1
 
 
+def test_bare_power_fallback_endpoint_skips_motor_when_endpoint_id_unset() -> None:
+    # Siroco+ layout (motor=1, light=2) built as a single entity because
+    # fan_light_endpoints has exactly one element (see light.py's
+    # _build_light_entities) — endpoint_id is unset, so this must resolve
+    # through the profile's motor-aware fallback (endpoint 2), never the
+    # motor (endpoint 1).
+    device = _unschemed_fan_light_device(
+        device_name="Inspire Siroco+",
+        main_change_capability_endpoints=[1, 2],
+    )
+    entity = _FakeFanLightEntity(device, endpoint_id=None)
+    assert entity._bare_power_fallback_endpoint({}) == 2
+
+
 def test_bare_power_fallback_endpoint_none_when_brightness_given() -> None:
     device = _unschemed_fan_light_device()
     entity = _FakeFanLightEntity(device, endpoint_id=None)


### PR DESCRIPTION
## Résumé

Corrige un cas où `light.turn_on()` sans attribut (`brightness`/`color_temp_kelvin`) ne fait rien sur certains ventilateurs+lumière (confirmé sur **AD_TCFL_1**), alors que le même service avec `brightness` ou `color_temp_kelvin` fonctionne correctement.

## Cause racine

`EnkiCapabilityProfile.supports_light_state` (`domain/capabilities.py`) considère qu'un appareil pilote son état lumière dès que la chaîne `"change_light_state"` (ou `"check_light_state"`) apparaît dans la liste `capabilities` du référentiel — **sans vérifier qu'un schéma `possibleValues` existe réellement pour cette capacité**.

Sur `AD_TCFL_1`, le référentiel déclare bien `change_light_state`/`check_light_state` dans `capabilities`, mais **aucune entrée `possibleValues` ne les accompagne** — contrairement à `change_brightness`, `change_color_temperature`, ou `switch_electrical_power`, qui ont chacun un schéma défini. Résultat : `change-light-state` (lighting-prod) accepte silencieusement un payload `{"power": "ON"}` seul sans jamais l'appliquer côté matériel, alors qu'un payload contenant `brightness`/`colorTemperature` fonctionne (le firmware réagit à ces champs, pas au champ `power` isolé).

`EnkiFanLightEntity` route pourtant **toujours** l'allumage/extinction simple via `change_light_state`, car `_uses_endpoint_power()` (`behavior.py`) exclut systématiquement tout appareil `is_fan` du chemin `switch_electrical_power` :

```python
def _uses_endpoint_power(self, endpoint_id):
    if endpoint_id is None:
        return False
    profile = self._device.profile
    if profile.is_fan:
        return False   # <- exclut AD_TCFL_1 alors que c'est son vrai canal
    ...
```

Ce choix vient probablement de #30 (fix de #27/#28), qui a forcé **tous** les kits lumière de ventilateur vers `change_light_state` pour corriger un autre modèle Inspire dont la lumière partait à tort vers `power-prod`. Ce correctif, correct pour ce modèle-là, régresse silencieusement sur `AD_TCFL_1`, dont le référentiel déclare explicitement `main_change_capability_id = "switch_electrical_power"` avec l'endpoint `1` comme canal principal.

Diagnostic obtenu en loggant temporairement (localement, retiré depuis) l'objet `EnkiDevice` brut pendant un poll sur mon instance réelle :

```
type=ceiling_fans bff=ceiling_fans model=AD_TCFL_1
main_cap=switch_electrical_power endpoints=[{'id': 1}]
capabilities=[..., 'switch_electrical_power', 'change_brightness', 'change_color_temperature',
               'change_light_state', 'check_light_state', 'change_fan_speed', ...]
possible={
  'switch_electrical_power': {'format': 'VALUES', 'values': ['ON', 'OFF']},
  'change_brightness': {'format': 'RANGE', 'range': {'min': 0.0, 'max': 1.0, ...}},
  'change_color_temperature': {'format': 'VALUES', 'values': [...]},
  'change_fan_speed': {'format': 'RANGE', 'range': {'min': 0.0, 'max': 6.0, ...}},
  ...
  # pas d'entrée 'change_light_state' ni 'check_light_state'
}
```

## Correctif

- **`domain/capabilities.py`** : ajoute deux propriétés pures sur `EnkiCapabilityProfile`, sans toucher `supports_light_state` (pour ne rien changer au comportement des autres modèles) :
  - `light_state_has_schema` — `True` seulement si `possibleValues` contient réellement une entrée `change_light_state`/`check_light_state` (pas juste la présence dans `capabilities`).
  - `bare_power_fallback_endpoint` — retourne le premier endpoint `switch_electrical_power` déclaré quand `light_state_has_schema` est `False`, sinon `None`.
- **`platforms/light/behavior.py`** : ajoute `_bare_power_fallback_endpoint(kwargs)` sur `EnkiLightBehaviorMixin`. Consulte `bare_power_fallback_endpoint` du profil, mais **privilégie `self._endpoint_id` de l'entité quand il est défini** — important pour un ventilateur multi-lumières (type Siroco+, endpoints 2/3) où chaque entité doit cibler son propre circuit, pas le premier endpoint déclaré au niveau du profil.
- **`light.py`** : `EnkiFanLightEntity.async_turn_on` appelle `_bare_power_fallback_endpoint(kwargs)` **uniquement pour un allumage simple** (`_simple_light_turn_on(kwargs)`, aucun `brightness`/`color_temp_kelvin`) et bascule sur `switch_electrical_power` dans ce cas précis. Le chemin `change_light_state` reste strictement inchangé pour tout appel avec `brightness`/`color_temp_kelvin`, et pour tout appareil dont `light_state_has_schema` est `True` — donc **aucun changement de comportement pour les autres modèles** (Inspire multi-endpoints de #28/#30 compris).
- `async_turn_off` n'est **pas modifié** : confirmé fonctionnel tel quel sur l'appareil de test, aucune raison de le toucher.

## Portée volontairement limitée

Je n'ai **pas** touché à la logique multi-endpoints réelle (`electrical_endpoints` de l'appareil montre 2 entrées — `id: 1` et `id: 2` — alors que `main_change_capability_endpoints` n'en déclare qu'une). Le code respecte désormais `self._endpoint_id` correctement pour ce cas (voir tests), mais je n'ai testé la bascule que sur l'endpoint `1` (le seul déclaré par le référentiel sur mon appareil) ; je n'ai pas de matériel Siroco+ multi-lumières pour vérifier physiquement le cas endpoint 2/3.

## Tests

9 tests unitaires ajoutés, purs, sans mock de coordinator/API, dans le style existant du dépôt :

- `tests/unit/test_capabilities.py` :
  - `test_light_state_has_schema_false_when_capability_tag_without_possible_values`
  - `test_light_state_has_schema_true_when_possible_values_present`
  - `test_bare_power_fallback_endpoint_used_when_light_state_unschemed`
  - `test_bare_power_fallback_endpoint_none_when_light_state_has_schema`
  - `test_bare_power_fallback_endpoint_none_without_power_switch_endpoint`
- `tests/unit/test_fan_light_state.py` (double de test minimal exposant uniquement `_endpoint_id`/`_device`, sans harnais HA complet) :
  - `test_bare_power_fallback_endpoint_uses_own_endpoint_on_multi_gang_device` — couvre précisément le cas multi-endpoint (endpoint 3 sur un appareil à endpoints 2/3), pour éviter la régression que j'ai moi-même introduite puis corrigée en repassant sur le diff (voir historique des commits).
  - `test_bare_power_fallback_endpoint_uses_profile_default_when_endpoint_id_unset`
  - `test_bare_power_fallback_endpoint_none_when_brightness_given`
  - `test_bare_power_fallback_endpoint_none_when_light_state_has_schema`

**Vérifié en conditions réelles** à chaque itération : appareil `AD_TCFL_1` physique, allumage simple depuis le tableau de bord Home Assistant — la lumière s'allume désormais correctement. Extinction, luminosité, température de couleur : comportement inchangé, toujours fonctionnel.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs / tooling
- [ ] Refactor

## Checklist

- [x] `ruff check .` passe (dépôt entier, pas seulement les fichiers modifiés)
- [x] `ruff format --check .` passe (dépôt entier)
- [x] `python scripts/validate_gateway_keys.py` passe (23 clés valides)
- [x] `pytest tests/unit -v --tb=short` : **238/238 passent**, sur **Python 3.14** (reproduit à l'identique l'environnement de la CI, cf. `.github/workflows/ci.yml`) — aucun échec, y compris ceux observés ponctuellement sur mon environnement local Python 3.12/macOS (confirmés comme un artefact d'environnement sans rapport, absents sous 3.14)
- [x] Pas de secret / identifiant personnel dans le diff
- [x] `hassfest` / action HACS : non reproductibles localement (actions GitHub dédiées), mais aucun fichier `manifest.json` ni structure du dépôt modifié — risque de régression très faible

## Issues liées

Fixes #74

## Test plan

- [x] Allumage simple (sans brightness/color) sur AD_TCFL_1 — vérifié fonctionnel en conditions réelles, à chaque itération du correctif
- [x] Extinction — inchangée, toujours fonctionnelle
- [x] Réglage luminosité/température de couleur — inchangé, toujours fonctionnel
- [x] Sélection du bon endpoint sur un appareil multi-lumières — couvert par test unitaire (voir ci-dessus), non vérifié sur matériel physique
- [ ] Si possible côté mainteneur : vérifier la non-régression sur les modèles Inspire multi-endpoints visés par #28/#30 (je n'ai accès qu'à un AD_TCFL_1)
