### PR TITLE
docs: mark dry-contact gate receiver as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisi
 - **Sensors** (Lexman, Sedea, …) — `binary_sensor`, `sensor`
 - **Siren** (Lexman) — `switch`
 - **Heating** (Noirot radiator, Equation pilot wire) — `climate`, `select` (stable since **v1.6.8**)
+- **Gate / garage dry contact** (Lexman 83424576, Nodon SIN-4-1-20) — `button` impulse (stable since **v1.6.17**, [#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56))
 
 ### Beta
 
 - **Covers** (Evology, Nodon, …) — `cover`
-- **Gate / garage dry contact** (Lexman 83424576, Nodon SIN-4-1-20) — `button` impulse ([#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56))
 - **Water leak** (Lexman) — `binary_sensor`, `sensor` (on-site leak test pending — [#36](https://github.com/cyrilcolinet/enki-integration-hass/issues/36))
 - **Scenarios** (Enki cloud) — `button`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -101,7 +101,7 @@ Commands:
 
 Gateway key: `ENKI_ACCESS_MOTORIZATION_API_KEY` in `const.py` (filled from APK 2.25.1). Legacy path `api-enki-access-and-motorizations-prod` is obsolete. See [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md) for validation with mitmproxy.
 
-### Dry-contact gate / garage receiver (Lexman 83424576, Nodon SIN-4-1-20) — beta
+### Dry-contact gate / garage receiver (Lexman 83424576, Nodon SIN-4-1-20)
 
 **Referentiel capability:** `power_on_with_timer` only (Mpulse mode — timed impulse, no state read).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,8 +21,8 @@ Short version: [README](../README.md) · detailed view below.
 | ✅ Supported | Equation ON/OFF relay | ON/OFF (like Edisio outlets) |
 | ✅ Supported | Equation pilot wire | `select` (comfort / eco / frost / off); stable since **v1.6.8** (`thermostat-prod`) |
 | ✅ Supported | Noirot radiator | `climate` + window / presence detection; stable since **v1.6.8** (`thermostat-prod` + `presence-detector-prod`) |
+| ✅ Supported | Lexman / Nodon dry-contact gate receiver | `button` “Trigger” via `power_on_with_timer` (`api-enki-power-prod`); Mpulse mode; stable since **v1.6.17** ([#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56)) |
 | 🔬 Beta | Roller shutters (Evology, Nodon, …) | `cover` “Shutter (beta)” if active in the app; `ENKI_ACCESS_MOTORIZATION_API_KEY` (APK 2.25.1); limited real-world testing |
-| 🔬 Beta | Lexman / Nodon dry-contact gate receiver | `button` “Trigger” via `power_on_with_timer` (`api-enki-power-prod`); Mpulse mode — field test [#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56) |
 | 🔬 Beta | Lexman water leak detector | leak `binary_sensor` + battery `sensor`; reads OK remotely — on-site wet test pending ([#36](https://github.com/cyrilcolinet/enki-integration-hass/issues/36)) |
 | 🔜 Soon | ACOVA ARLAN radiators | manufacturer allowlist OK, no test hardware |
 | 🔬 Beta | Enki scenarios (“Open living room”, …) | `button` (v1.6.0+) |

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -156,7 +156,7 @@ Contributor network feedback: [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md).
 3. Test open / close / position vs the Enki mobile app.
 4. Report results (model, HA version, integration version, `enki` log excerpt if it fails).
 
-## Dry-contact gate / garage receiver — beta (Lexman, Nodon)
+## Dry-contact gate / garage receiver (Lexman, Nodon)
 
 **HA entity:** `button` “Trigger” / “Déclencher”
 
@@ -166,16 +166,9 @@ Contributor network feedback: [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md).
 | Capability | `power_on_with_timer` only (no position/opening — **not** a `cover`) |
 | Enki app mode | **Mpulse** — contact closes for a few seconds then reopens (timed impulse) |
 
-**API:** `POST api-enki-power-prod/v1/power/{nodeId}/power-on-with-timer` — no body. Same gateway key as outlets (`ENKI_POWER_API_KEY`). Detail: [API.md](API.md#dry-contact-gate--garage-receiver-lexman-83424576-nodon-sin-4-1-20--beta).
+**API:** `POST api-enki-power-prod/v1/power/{nodeId}/power-on-with-timer` — no body. Same gateway key as outlets (`ENKI_POWER_API_KEY`). Detail: [API.md](API.md#dry-contact-gate--garage-receiver-lexman-83424576-nodon-sin-4-1-20).
 
-**Since v1.6.17.** Field feedback: [#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56).
-
-### For testers (gate / dry contact)
-
-1. Update the Enki integration (**v1.6.17+**) via HACS, then restart Home Assistant.
-2. Open the gate receiver device — look for a **Trigger** button entity.
-3. Press it and confirm the gate (or water heater relay) behaves like a single tap in the Enki app.
-4. Report model, integration version, and any error in `enki` logs.
+**Stable since v1.6.17** — field-confirmed ([#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56)). Related On/Off water-heater SKU (83424574): [#87](https://github.com/cyrilcolinet/enki-integration-hass/issues/87).
 
 ## Cross-cutting features
 
@@ -201,7 +194,8 @@ Reads are best-effort (404 skipped) and driven by referentiel capabilities, not 
 | Status | Topic |
 |--------|--------|
 | ✅ Stable | Heating (Noirot, pilot wire, Equation relay) since v1.6.8 |
-| 🔬 Beta | Covers, dry-contact gate receiver, Lexman water leak (on-site test), scenarios — feedback welcome |
+| ✅ Stable | Dry-contact gate / garage receiver (Lexman 83424576) since v1.6.17 |
+| 🔬 Beta | Covers, Lexman water leak (on-site test), scenarios — feedback welcome |
 | Soon | ACOVA ARLAN radiators (same heating API if capabilities match) |
 | Not planned | Enki alarm (no API identified) |
 | Out of scope | Enki pairing and device setup, Leroy Merlin account management → [Enki support](https://support.enki-home.com/) (configure devices in the app before HA) |


### PR DESCRIPTION
## Summary
- Promote Lexman/Nodon dry-contact gate (83424576, `power_on_with_timer`) from beta to stable after field confirmation on #56
- Update README, ROADMAP, SUPPORTED_DEVICES, API
- Leave covers and Lexman water leak (#36) in beta

## Test plan
- [ ] Docs render correctly on GitHub
- [ ] Anchor to API dry-contact section still works