### PR TITLE
feat(boiler): support Lexman On/Off water-heater via BFF fallback (#87)

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -9,7 +9,7 @@ from typing import Any
 import aiohttp
 
 from ..const import DEVICE_TYPE_LIGHTS, LOGGER
-from ..domain.capabilities import EnkiCapabilityProfile
+from ..domain.capabilities import EnkiCapabilityProfile, merge_capabilities_with_bff
 from ..domain.models import EnkiDevice, EnkiDiscoveryRecord, EnkiScenario
 from ..domain.profile import (
     build_discovery_record,
@@ -262,7 +262,14 @@ class EnkiAPI:
         node_info = await http.get_node(home_id, node_id)
         device_info = await self._get_referentiel_device(http, device_id)
         device_type = device_info.get("type") or bff_type
-        capabilities = device_info.get("capabilities", [])
+        main_change_capability_id = metadata.get("mainChangeCapabilityId")
+        if not isinstance(main_change_capability_id, str):
+            main_change_capability_id = None
+        capabilities = merge_capabilities_with_bff(
+            device_info.get("capabilities", []),
+            main_change_capability_id=main_change_capability_id,
+            endpoints=main_change_endpoints,
+        )
         possible_values = device_info.get("possibleValues", {})
         power_production = parse_bff_power(item.get("description"))
 
@@ -281,7 +288,7 @@ class EnkiAPI:
             capabilities=capabilities,
             possible_values=possible_values,
             bff_device_type=bff_type,
-            main_change_capability_id=metadata.get("mainChangeCapabilityId"),
+            main_change_capability_id=main_change_capability_id,
             main_change_capability_endpoints=main_change_endpoints,
             power_production=power_production,
             referentiel_i18n=str(device_info.get("i18n") or ""),
@@ -317,6 +324,7 @@ class EnkiAPI:
             firmware_version=str(preliminary_firmware) if preliminary_firmware else None,
             supported_by_integration=supported,
             referentiel_device_id=device_id,
+            main_change_capability_id=main_change_capability_id,
         )
         self._register_node_profile(node_id, record)
 
@@ -349,6 +357,7 @@ class EnkiAPI:
                 firmware_version=str(last_reported["firmware_version"]),
                 supported_by_integration=supported,
                 referentiel_device_id=device_id,
+                main_change_capability_id=main_change_capability_id,
             )
 
         self._register_poll_state(node_id, {**node_info, **last_reported})
@@ -374,7 +383,7 @@ class EnkiAPI:
                 possible_values=possible_values,
                 last_reported_value={**node_info, **last_reported},
                 bff_device_type=bff_type,
-                main_change_capability_id=metadata.get("mainChangeCapabilityId"),
+                main_change_capability_id=main_change_capability_id,
                 main_change_capability_endpoints=main_change_endpoints,
                 power_production=power_production,
                 referentiel_i18n=str(device_info.get("i18n") or ""),

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -34,6 +34,57 @@ def possible_values_dict(possible_values: dict[str, Any] | None) -> dict[str, An
     return {}
 
 
+def supplemental_capabilities_from_bff(
+    main_change_capability_id: str | None,
+    endpoints: list[Any] | tuple[Any, ...] | None = None,
+) -> list[str]:
+    """Capabilities implied by BFF dashboard metadata when the referentiel is thin.
+
+    Some On/Off relays (Lexman water-heater SKU, #87) are reclassified as ``boiler``
+    with an empty referentiel capability list. The BFF tile still exposes
+    ``mainChangeCapabilityId`` and/or endpoint ``lastReportedValue`` of ON/OFF.
+    """
+    found: list[str] = []
+    if isinstance(main_change_capability_id, str):
+        capability = main_change_capability_id.strip()
+        if capability:
+            found.append(capability)
+
+    for entry in endpoints or ():
+        if not isinstance(entry, dict):
+            continue
+        raw = entry.get("lastReportedValue")
+        power: str | None = None
+        if isinstance(raw, str) and raw in {"ON", "OFF"}:
+            power = raw
+        elif isinstance(raw, dict):
+            value = raw.get("power")
+            if isinstance(value, str) and value in {"ON", "OFF"}:
+                power = value
+        if power is not None:
+            found.extend(["switch_electrical_power", "check_electrical_power"])
+            break
+
+    return list(dict.fromkeys(found))
+
+
+def merge_capabilities_with_bff(
+    capabilities: list[str] | dict[str, Any] | None,
+    *,
+    main_change_capability_id: str | None = None,
+    endpoints: list[Any] | tuple[Any, ...] | None = None,
+) -> list[str]:
+    """Union referentiel capabilities with BFF-inferred ones (stable order)."""
+    merged = list(capabilities_set(capabilities))
+    for capability in supplemental_capabilities_from_bff(
+        main_change_capability_id,
+        endpoints,
+    ):
+        if capability not in merged:
+            merged.append(capability)
+    return merged
+
+
 def _supports(capabilities: set[str], possible_values: dict[str, Any], *names: str) -> bool:
     """True when any capability name appears in capabilities or possibleValues."""
     return any(name in capabilities or name in possible_values for name in names)
@@ -68,9 +119,14 @@ class EnkiCapabilityProfile:
             endpoint_id = endpoint_id_from_entry(entry)
             if endpoint_id is not None:
                 endpoints.append(endpoint_id)
+        capabilities = merge_capabilities_with_bff(
+            device.capabilities,
+            main_change_capability_id=device.main_change_capability_id,
+            endpoints=list(endpoint_entries),
+        )
         return cls(
             device_type=device.device_type,
-            capabilities=frozenset(capabilities_set(device.capabilities)),
+            capabilities=frozenset(capabilities),
             possible_values=possible_values_dict(device.possible_values),
             bff_device_type=device.bff_device_type,
             main_change_capability_id=device.main_change_capability_id,

--- a/custom_components/enki/domain/models.py
+++ b/custom_components/enki/domain/models.py
@@ -64,6 +64,7 @@ class EnkiDiscoveryRecord:
     firmware_version: str | None
     supported_by_integration: bool
     referentiel_device_id: str | None = None
+    main_change_capability_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/enki/domain/profile.py
+++ b/custom_components/enki/domain/profile.py
@@ -157,6 +157,7 @@ def build_discovery_record(
     firmware_version: str | None,
     supported_by_integration: bool,
     referentiel_device_id: str | None = None,
+    main_change_capability_id: str | None = None,
 ) -> EnkiDiscoveryRecord:
     return EnkiDiscoveryRecord(
         device_type=device_type,
@@ -168,6 +169,7 @@ def build_discovery_record(
         firmware_version=firmware_version,
         supported_by_integration=supported_by_integration,
         referentiel_device_id=referentiel_device_id,
+        main_change_capability_id=main_change_capability_id,
     )
 
 
@@ -177,7 +179,7 @@ def profile_to_export_dict(
     integration_version: str,
     ha_version: str,
 ) -> dict[str, Any]:
-    return {
+    export: dict[str, Any] = {
         "device_type": record.device_type,
         "bff_device_type": record.bff_device_type,
         "manufacturer": record.manufacturer,
@@ -190,6 +192,9 @@ def profile_to_export_dict(
         "integration_version": integration_version,
         "ha_version": ha_version,
     }
+    if record.main_change_capability_id:
+        export["main_change_capability_id"] = record.main_change_capability_id
+    return export
 
 
 def profile_fingerprint(export_dict: dict[str, Any]) -> str:
@@ -203,6 +208,7 @@ def profile_fingerprint(export_dict: dict[str, Any]) -> str:
         "supported_by_integration": export_dict.get("supported_by_integration"),
         "capabilities": export_dict.get("capabilities"),
         "possible_values": export_dict.get("possible_values"),
+        "main_change_capability_id": export_dict.get("main_change_capability_id"),
     }
     payload = json.dumps(stable, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
@@ -242,6 +248,9 @@ def format_github_issue_body(export_dict: dict[str, Any], fingerprint: str) -> s
 
     if referentiel_device_id := export_dict.get("referentiel_device_id"):
         body += f"- **Referentiel device ID:** `{referentiel_device_id}`\n"
+
+    if main_change := export_dict.get("main_change_capability_id"):
+        body += f"- **BFF main capability:** `{main_change}`\n"
 
     if platforms := export_dict.get("ha_platforms"):
         platform_line = ", ".join(f"`{platform}`" for platform in platforms)

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -140,6 +140,7 @@ def profile_from_record(record: EnkiDiscoveryRecord) -> EnkiCapabilityProfile:
         capabilities=frozenset(record.capabilities or []),
         possible_values=record.possible_values or {},
         bff_device_type=record.bff_device_type or "",
+        main_change_capability_id=record.main_change_capability_id,
     )
 
 

--- a/custom_components/enki/lib/enki_scope.py
+++ b/custom_components/enki/lib/enki_scope.py
@@ -26,6 +26,9 @@ _ENKI_ECOSYSTEM_MANUFACTURERS = frozenset(
 _ENKI_NATIVE_DEVICE_TYPES = frozenset(
     {
         "access_and_motorizations",
+        # Lexman/Nodon On/Off water-heater relay may appear as boiler with null manufacturer
+        # when the app remaps the node from the device name (#87).
+        "boiler",
         "ceiling_fans",
         "inverters",
     }

--- a/custom_components/enki/lib/telemetry_labels.py
+++ b/custom_components/enki/lib/telemetry_labels.py
@@ -14,6 +14,7 @@ _REASON_GITHUB_LABELS: dict[str, str] = {
 
 _DEVICE_FAMILY_GITHUB_LABELS: dict[str, str] = {
     "access_and_motorizations": "motorization",
+    "boiler": "control",
     "ceiling_fans": "climate",
     "heaters_and_pilot_wires": "climate",
     "inverters": "energy",
@@ -76,6 +77,7 @@ TELEMETRY_GITHUB_ORPHAN_LABELS: tuple[str, ...] = (
 
 _DEVICE_TYPE_LABELS: dict[str, str] = {
     "access_and_motorizations": "motorization",
+    "boiler": "boiler / water heater relay",
     "ceiling_fans": "ceiling fan",
     "heaters_and_pilot_wires": "heating",
     "inverters": "inverter",

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -168,7 +168,18 @@ Contributor network feedback: [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md).
 
 **API:** `POST api-enki-power-prod/v1/power/{nodeId}/power-on-with-timer` — no body. Same gateway key as outlets (`ENKI_POWER_API_KEY`). Detail: [API.md](API.md#dry-contact-gate--garage-receiver-lexman-83424576-nodon-sin-4-1-20).
 
-**Stable since v1.6.17** — field-confirmed ([#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56)). Related On/Off water-heater SKU (83424574): [#87](https://github.com/cyrilcolinet/enki-integration-hass/issues/87).
+**Stable since v1.6.17** — field-confirmed ([#56](https://github.com/cyrilcolinet/enki-integration-hass/issues/56)).
+
+### Lexman On/Off water-heater relay (83424574)
+
+Same Nodon SIN-4-1-20 family as the gate module, but Enki may expose it as referentiel type **`boiler`** (especially when the app name suggests a water heater) with an **empty** capability list and no manufacturer.
+
+| Signal | HA surface |
+|--------|------------|
+| BFF `mainChangeCapabilityId` = `switch_electrical_power`, or endpoint `lastReportedValue` ON/OFF | `switch` (outlet) via `api-enki-power-prod` |
+| BFF / referentiel `power_on_with_timer` only | `button` “Trigger” (same as gate) |
+
+Diagnostics now export `main_change_capability_id` so empty-referentiel boilers stay actionable ([#87](https://github.com/cyrilcolinet/enki-integration-hass/issues/87)). If both signals are missing, the dedicated `api-enki-equation-water-heater-prod` path is still unwired.
 
 ## Cross-cutting features
 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -36,6 +36,7 @@ Diagnostics and GitHub prefill now include extra **English** context when availa
 |-------|---------|
 | `ha_platforms` | HA platforms that would be created (`climate`, `select`, …) |
 | `uncovered_capabilities` | Referentiel capabilities not implemented yet |
+| `main_change_capability_id` | BFF dashboard primary capability (useful when the referentiel list is empty, e.g. `boiler`) |
 | `api_read_errors` | Cloud read failures from the **last poll** (`heating/check_pilot_wire_state → HTTP 500`) — no node/home ids |
 | `telemetry_reason` | Why a notification was suggested |
 

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -221,3 +221,41 @@ def test_impulse_relay_supported_not_cover() -> None:
     assert profile.is_impulse_relay is True
     assert profile.is_cover is False
     assert device_is_supported(device) is True
+
+
+def test_boiler_empty_referentiel_uses_bff_switch_capability() -> None:
+    """Lexman On/Off water-heater (#87): boiler type, empty referentiel, BFF ON/OFF."""
+    device = _device(
+        device_type="boiler",
+        bff_device_type="boiler",
+        capabilities=[],
+        main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[{"id": 1, "lastReportedValue": "ON"}],
+    )
+    profile = device.profile
+    assert profile.supports_electrical_power is True
+    assert profile.is_outlet is True
+    assert device_is_supported(device) is True
+
+
+def test_boiler_infers_power_from_bff_endpoint_state_alone() -> None:
+    device = _device(
+        device_type="boiler",
+        bff_device_type="boiler",
+        capabilities=[],
+        main_change_capability_id=None,
+        main_change_capability_endpoints=[{"id": 1, "lastReportedValue": {"power": "OFF"}}],
+    )
+    assert device.profile.is_outlet is True
+    assert device_is_supported(device) is True
+
+
+def test_boiler_empty_without_bff_signal_stays_unsupported() -> None:
+    device = _device(
+        device_type="boiler",
+        bff_device_type="boiler",
+        capabilities=[],
+        main_change_capability_id=None,
+        main_change_capability_endpoints=[],
+    )
+    assert device_is_supported(device) is False

--- a/tests/unit/test_device_profile.py
+++ b/tests/unit/test_device_profile.py
@@ -39,6 +39,23 @@ def test_profile_to_export_dict_excludes_sensitive_keys() -> None:
     assert "homeId" not in export["possible_values"]
 
 
+def test_profile_export_includes_bff_main_capability() -> None:
+    record = build_discovery_record(
+        device_type="boiler",
+        bff_device_type="boiler",
+        capabilities=["switch_electrical_power"],
+        possible_values={},
+        manufacturer=None,
+        model=None,
+        firmware_version=None,
+        supported_by_integration=True,
+        referentiel_device_id="6226fd906ceb9ce2aafcf715",
+        main_change_capability_id="switch_electrical_power",
+    )
+    export = profile_to_export_dict(record, integration_version="1.6.21", ha_version="2026.7.4")
+    assert export["main_change_capability_id"] == "switch_electrical_power"
+
+
 def test_profile_fingerprint_stable_across_versions() -> None:
     record = _sample_record()
     first = profile_to_export_dict(record, integration_version="1.0.0", ha_version="2024.1")

--- a/tests/unit/test_enki_scope.py
+++ b/tests/unit/test_enki_scope.py
@@ -24,3 +24,4 @@ def test_native_enki_device_types_without_manufacturer() -> None:
     assert device_in_enki_scope(manufacturer=None, device_type="ceiling_fans") is True
     assert device_in_enki_scope(manufacturer=None, device_type="inverters") is True
     assert device_in_enki_scope(manufacturer=None, device_type="access_and_motorizations") is True
+    assert device_in_enki_scope(manufacturer=None, device_type="boiler") is True

--- a/tests/unit/test_telemetry_coverage.py
+++ b/tests/unit/test_telemetry_coverage.py
@@ -6,6 +6,7 @@ from enki.domain.profile import build_discovery_record
 from enki.domain.telemetry_coverage import (
     api_read_errors_need_telemetry,
     capability_is_covered,
+    discovery_record_eligible_for_telemetry,
     discovery_record_needs_telemetry,
     profile_from_record,
 )
@@ -66,6 +67,23 @@ def test_unsupported_device_still_needs_telemetry() -> None:
         firmware_version=None,
         supported_by_integration=False,
     )
+    assert discovery_record_needs_telemetry(record) is True
+
+
+def test_empty_boiler_profile_eligible_without_manufacturer() -> None:
+    """#87 diagnostics: boiler + null manufacturer must stay in telemetry scope."""
+    record = build_discovery_record(
+        device_type="boiler",
+        bff_device_type="boiler",
+        capabilities=[],
+        possible_values={},
+        manufacturer=None,
+        model=None,
+        firmware_version=None,
+        supported_by_integration=False,
+        referentiel_device_id="6226fd906ceb9ce2aafcf715",
+    )
+    assert discovery_record_eligible_for_telemetry(record) is True
     assert discovery_record_needs_telemetry(record) is True
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Uses the diagnostics dump from [#87](https://github.com/cyrilcolinet/enki-integration-hass/issues/87) (`config_entry-enki-…json`).

The Lexman On/Off water-heater relay (83424574) appears as referentiel type `boiler` with **empty capabilities**, null manufacturer, and no firmware — previously out of Enki scope and impossible to map. The sibling gate module (`power_on_with_timer`) is already supported.

This PR:
- Treats `boiler` as a native Enki device type (manufacturer may be missing)
- Merges BFF `mainChangeCapabilityId` and ON/OFF endpoint `lastReportedValue` into the capability profile when the referentiel list is empty → creates a `switch` via `api-enki-power-prod`
- Exports `main_change_capability_id` in diagnostics / telemetry for the empty-referentiel case

If BFF exposes neither `switch_electrical_power` nor ON/OFF endpoint state, the dedicated `api-enki-equation-water-heater-prod` path remains unwired (needs APK/mitm).

## Type

- [x] Feature
- [x] Docs / tooling

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest tests/unit` passes (264)
- [x] FR/EN translations updated if the UI changed (N/A)
- [x] No secrets or personal identifiers in the diff

## Related issues

Fixes #87 (when BFF exposes ON/OFF / `switch_electrical_power`; otherwise unblocks the next diagnostics round)

## Test plan

- [x] Unit: empty boiler + BFF `switch_electrical_power` → `is_outlet`
- [x] Unit: empty boiler + endpoint `lastReportedValue` ON/OFF → supported
- [x] Unit: empty boiler with no BFF signal stays unsupported
- [x] Unit: `boiler` in scope without manufacturer; telemetry eligible
- [ ] Field: @nodfrog — update to this PR / next release, restart HA, confirm a `switch` appears for the water heater; if not, re-attach diagnostics (should now include `main_change_capability_id`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9cc7-37b5-723b-acfd-fd7554b0c5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9cc7-37b5-723b-acfd-fd7554b0c5e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

