### PR TITLE
feat(diagnostics): expose control hint and telemetry exclusion

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -317,6 +317,7 @@ class EnkiAPI:
             firmware_version=str(preliminary_firmware) if preliminary_firmware else None,
             supported_by_integration=supported,
             referentiel_device_id=device_id,
+            main_change_capability_id=metadata.get("mainChangeCapabilityId"),
         )
         self._register_node_profile(node_id, record)
 

--- a/custom_components/enki/domain/models.py
+++ b/custom_components/enki/domain/models.py
@@ -64,6 +64,8 @@ class EnkiDiscoveryRecord:
     firmware_version: str | None
     supported_by_integration: bool
     referentiel_device_id: str | None = None
+    # BFF tile control hint: the only clue left when the referentiel returns no capabilities.
+    main_change_capability_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/enki/domain/profile.py
+++ b/custom_components/enki/domain/profile.py
@@ -157,6 +157,7 @@ def build_discovery_record(
     firmware_version: str | None,
     supported_by_integration: bool,
     referentiel_device_id: str | None = None,
+    main_change_capability_id: str | None = None,
 ) -> EnkiDiscoveryRecord:
     return EnkiDiscoveryRecord(
         device_type=device_type,
@@ -168,6 +169,7 @@ def build_discovery_record(
         firmware_version=firmware_version,
         supported_by_integration=supported_by_integration,
         referentiel_device_id=referentiel_device_id,
+        main_change_capability_id=main_change_capability_id,
     )
 
 
@@ -184,6 +186,7 @@ def profile_to_export_dict(
         "model": record.model,
         "firmware_version": record.firmware_version,
         "referentiel_device_id": record.referentiel_device_id,
+        "main_change_capability_id": record.main_change_capability_id,
         "supported_by_integration": record.supported_by_integration,
         "capabilities": sorted(record.capabilities or []),
         "possible_values": record.possible_values,
@@ -242,6 +245,9 @@ def format_github_issue_body(export_dict: dict[str, Any], fingerprint: str) -> s
 
     if referentiel_device_id := export_dict.get("referentiel_device_id"):
         body += f"- **Referentiel device ID:** `{referentiel_device_id}`\n"
+
+    if main_change := export_dict.get("main_change_capability_id"):
+        body += f"- **Main change capability:** `{main_change}`\n"
 
     if platforms := export_dict.get("ha_platforms"):
         platform_line = ", ".join(f"`{platform}`" for platform in platforms)

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -159,21 +159,33 @@ def _normalize_type(value: str | None) -> str:
     return value.strip().lower().replace(" ", "_")
 
 
-def discovery_record_eligible_for_telemetry(record: EnkiDiscoveryRecord) -> bool:
-    """Return False for out-of-scope or hub profiles that should not spam GitHub."""
+def discovery_record_telemetry_exclusion(record: EnkiDiscoveryRecord) -> str | None:
+    """Why this profile never reaches telemetry, or None when it is eligible.
+
+    Surfaced in diagnostics: without it an out-of-scope device looks identical to
+    a supported one that simply had nothing to report.
+    """
     if not device_in_enki_scope(
         manufacturer=record.manufacturer,
         device_type=record.device_type,
     ):
-        return False
+        return "out_of_enki_scope"
 
     device_type = _normalize_type(record.device_type)
     bff_type = _normalize_type(record.bff_device_type)
     if device_type in _GATEWAY_DEVICE_TYPES or bff_type in _GATEWAY_DEVICE_TYPES:
-        return False
+        return "gateway"
 
     caps = record.capabilities or []
-    return not (caps and any(cap in _GATEWAY_CAPABILITY_MARKERS for cap in caps))
+    if caps and any(cap in _GATEWAY_CAPABILITY_MARKERS for cap in caps):
+        return "gateway"
+
+    return None
+
+
+def discovery_record_eligible_for_telemetry(record: EnkiDiscoveryRecord) -> bool:
+    """Return False for out-of-scope or hub profiles that should not spam GitHub."""
+    return discovery_record_telemetry_exclusion(record) is None
 
 
 def _poll_state_has_key(poll_state: dict[str, Any], state_key: str) -> bool:

--- a/custom_components/enki/domain/telemetry_enrichment.py
+++ b/custom_components/enki/domain/telemetry_enrichment.py
@@ -11,6 +11,7 @@ from .telemetry_coverage import (
     api_read_errors_need_telemetry,
     capability_is_covered,
     discovery_record_eligible_for_telemetry,
+    discovery_record_telemetry_exclusion,
     profile_from_record,
 )
 
@@ -113,5 +114,8 @@ def enrich_telemetry_export(
     )
     if reason:
         enriched["telemetry_reason"] = reason
+
+    if exclusion := discovery_record_telemetry_exclusion(record):
+        enriched["telemetry_excluded"] = exclusion
 
     return enriched

--- a/tests/unit/test_diagnostics_blind_spot.py
+++ b/tests/unit/test_diagnostics_blind_spot.py
@@ -1,0 +1,134 @@
+"""Diagnostics must explain profiles that telemetry silently drops (see issue #87)."""
+
+from __future__ import annotations
+
+from enki.domain.profile import (
+    build_discovery_record,
+    format_github_issue_body,
+    profile_fingerprint,
+    profile_to_export_dict,
+)
+from enki.domain.telemetry_coverage import (
+    discovery_record_eligible_for_telemetry,
+    discovery_record_telemetry_exclusion,
+)
+from enki.domain.telemetry_enrichment import enrich_telemetry_export
+
+
+def _boiler_record():
+    """Water heater relay as Enki reports it: no manufacturer, no capabilities."""
+    return build_discovery_record(
+        device_type="boiler",
+        bff_device_type="boiler",
+        capabilities=[],
+        possible_values={},
+        manufacturer=None,
+        model=None,
+        firmware_version=None,
+        supported_by_integration=False,
+        referentiel_device_id="6226fd906ceb9ce2aafcf715",
+        main_change_capability_id="switch_electrical_power",
+    )
+
+
+def _export(record) -> dict:
+    return profile_to_export_dict(
+        record,
+        integration_version="1.6.21",
+        ha_version="2026.7.4",
+    )
+
+
+def test_whenProfileIsOutOfEnkiScope_thenExclusionIsReported() -> None:
+    # Given
+    record = _boiler_record()
+
+    # When
+    exclusion = discovery_record_telemetry_exclusion(record)
+
+    # Then
+    assert exclusion == "out_of_enki_scope"
+    assert discovery_record_eligible_for_telemetry(record) is False
+
+
+def test_whenGatewayProfile_thenExclusionSaysGateway() -> None:
+    # Given
+    record = build_discovery_record(
+        device_type="gateways",
+        bff_device_type="gateways",
+        capabilities=["gateway_reboot"],
+        possible_values={},
+        manufacturer="Enki",
+        model="EnkiConnectGW001",
+        firmware_version="2.0.0",
+        supported_by_integration=False,
+    )
+
+    # When / Then
+    assert discovery_record_telemetry_exclusion(record) == "gateway"
+
+
+def test_whenSupportedProfile_thenNoExclusion() -> None:
+    # Given
+    record = build_discovery_record(
+        device_type="access_and_motorizations",
+        bff_device_type="access_and_motorizations",
+        capabilities=["power_on_with_timer"],
+        possible_values={},
+        manufacturer="Lexman",
+        model=None,
+        firmware_version="2.0.0",
+        supported_by_integration=True,
+    )
+
+    # When / Then
+    assert discovery_record_telemetry_exclusion(record) is None
+    assert "telemetry_excluded" not in enrich_telemetry_export(_export(record), record)
+
+
+def test_whenDroppedByScope_thenDiagnosticsCarryTheReason() -> None:
+    # Given
+    record = _boiler_record()
+
+    # When
+    enriched = enrich_telemetry_export(_export(record), record)
+
+    # Then
+    assert enriched["telemetry_excluded"] == "out_of_enki_scope"
+    assert "telemetry_reason" not in enriched
+
+
+def test_whenReferentielHasNoCapabilities_thenMainChangeCapabilityIsExported() -> None:
+    # Given
+    record = _boiler_record()
+
+    # When
+    export = _export(record)
+
+    # Then
+    assert export["capabilities"] == []
+    assert export["main_change_capability_id"] == "switch_electrical_power"
+    assert "Main change capability" in format_github_issue_body(export, "f" * 64)
+
+
+def test_whenMainChangeCapabilityChanges_thenFingerprintStaysStable() -> None:
+    # Given
+    without = _export(
+        build_discovery_record(
+            device_type="boiler",
+            bff_device_type="boiler",
+            capabilities=[],
+            possible_values={},
+            manufacturer=None,
+            model=None,
+            firmware_version=None,
+            supported_by_integration=False,
+            referentiel_device_id="6226fd906ceb9ce2aafcf715",
+        )
+    )
+
+    # When
+    with_hint = _export(_boiler_record())
+
+    # Then — adding the hint must not re-notify users about already reported devices.
+    assert profile_fingerprint(without) == profile_fingerprint(with_hint)


### PR DESCRIPTION
## Why

The diagnostics dump on #87 surfaced a blind spot. A profile rejected by `device_in_enki_scope()` gets no `telemetry_reason`, no notification and no GitHub prefill — so in the export it is indistinguishable from a healthy device with nothing to report.

Concretely, that user's water heater relay shows up as `device_type: boiler` with `manufacturer: null` and an empty `capabilities` list. It was silently dropped, and would never have surfaced without a manual dump.

## What changes

- `telemetry_excluded` added to the diagnostics export: `out_of_enki_scope` or `gateway`. Telemetry eligibility itself is unchanged — third-party Zigbee still must not spam GitHub, we just say why it was skipped.
- `discovery_record_telemetry_exclusion()` becomes the single source of truth; `discovery_record_eligible_for_telemetry()` is now a thin wrapper over it.
- `main_change_capability_id` (BFF `mainChangeCapabilityId`) carried on `EnkiDiscoveryRecord` and exported. It was already parsed into `EnkiDevice` but never reached diagnostics. When the referentiel returns zero capabilities it is the only remaining clue to how the app drives the device.
- Added to the prefilled GitHub issue body as **Main change capability**.

`profile_fingerprint()` is untouched, so users already notified about a device are not notified again.

## Test plan
- [x] `ruff check` / `ruff format`
- [x] `pytest` — 265 passed, 1 skipped
- [x] Replayed the real #87 dump through the new code: `boiler` now reports `out_of_enki_scope`, the gateway reports `gateway`, the six supported profiles are unaffected
- [x] Fingerprint stability covered by a dedicated test

Refs #87