### PR TITLE
fix(diagnostics): keep control hints on the discovery record

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import replace
 from typing import Any
 
 import aiohttp
@@ -318,6 +319,8 @@ class EnkiAPI:
             supported_by_integration=supported,
             referentiel_device_id=device_id,
             main_change_capability_id=metadata.get("mainChangeCapabilityId"),
+            main_change_capability_endpoints=main_change_endpoints,
+            referentiel_i18n=skeleton.referentiel_i18n,
         )
         self._register_node_profile(node_id, record)
 
@@ -340,16 +343,11 @@ class EnkiAPI:
                 )
 
         if last_reported.get("firmware_version"):
-            record = build_discovery_record(
-                device_type=device_type,
-                bff_device_type=bff_type,
-                capabilities=capabilities,
-                possible_values=possible_values,
-                manufacturer=manufacturer_str,
-                model=model,
+            # Patch in place: rebuilding the record here silently dropped every
+            # field the builder gained since.
+            record = replace(
+                record,
                 firmware_version=str(last_reported["firmware_version"]),
-                supported_by_integration=supported,
-                referentiel_device_id=device_id,
             )
 
         self._register_poll_state(node_id, {**node_info, **last_reported})

--- a/custom_components/enki/domain/models.py
+++ b/custom_components/enki/domain/models.py
@@ -64,8 +64,11 @@ class EnkiDiscoveryRecord:
     firmware_version: str | None
     supported_by_integration: bool
     referentiel_device_id: str | None = None
-    # BFF tile control hint: the only clue left when the referentiel returns no capabilities.
+    # BFF tile control hints: the only clues left when the referentiel returns no capabilities.
+    # The capability says what to send, the endpoints say where, the i18n key names the product.
     main_change_capability_id: str | None = None
+    main_change_capability_endpoints: list[int] = field(default_factory=list)
+    referentiel_i18n: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/enki/domain/profile.py
+++ b/custom_components/enki/domain/profile.py
@@ -8,6 +8,7 @@ from typing import Any
 from urllib.parse import quote
 
 from ..const import TELEMETRY_GITHUB_REPO
+from ..lib.fan_endpoints import endpoint_id_from_entry
 from ..lib.telemetry_labels import (
     format_telemetry_issue_title,
     resolve_display_value,
@@ -158,7 +159,14 @@ def build_discovery_record(
     supported_by_integration: bool,
     referentiel_device_id: str | None = None,
     main_change_capability_id: str | None = None,
+    main_change_capability_endpoints: list[int | dict[str, Any]] | None = None,
+    referentiel_i18n: str | None = None,
 ) -> EnkiDiscoveryRecord:
+    endpoint_ids = {
+        endpoint_id
+        for entry in main_change_capability_endpoints or []
+        if (endpoint_id := endpoint_id_from_entry(entry)) is not None
+    }
     return EnkiDiscoveryRecord(
         device_type=device_type,
         bff_device_type=bff_device_type,
@@ -170,6 +178,8 @@ def build_discovery_record(
         supported_by_integration=supported_by_integration,
         referentiel_device_id=referentiel_device_id,
         main_change_capability_id=main_change_capability_id,
+        main_change_capability_endpoints=sorted(endpoint_ids),
+        referentiel_i18n=referentiel_i18n or None,
     )
 
 
@@ -187,6 +197,8 @@ def profile_to_export_dict(
         "firmware_version": record.firmware_version,
         "referentiel_device_id": record.referentiel_device_id,
         "main_change_capability_id": record.main_change_capability_id,
+        "main_change_capability_endpoints": list(record.main_change_capability_endpoints),
+        "referentiel_i18n": record.referentiel_i18n,
         "supported_by_integration": record.supported_by_integration,
         "capabilities": sorted(record.capabilities or []),
         "possible_values": record.possible_values,
@@ -248,6 +260,13 @@ def format_github_issue_body(export_dict: dict[str, Any], fingerprint: str) -> s
 
     if main_change := export_dict.get("main_change_capability_id"):
         body += f"- **Main change capability:** `{main_change}`\n"
+
+    if endpoints := export_dict.get("main_change_capability_endpoints"):
+        endpoint_line = ", ".join(f"`{endpoint}`" for endpoint in endpoints)
+        body += f"- **Main change endpoints:** {endpoint_line}\n"
+
+    if i18n := export_dict.get("referentiel_i18n"):
+        body += f"- **Referentiel i18n key:** `{i18n}`\n"
 
     if platforms := export_dict.get("ha_platforms"):
         platform_line = ", ".join(f"`{platform}`" for platform in platforms)

--- a/tests/unit/test_diagnostics_blind_spot.py
+++ b/tests/unit/test_diagnostics_blind_spot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from enki.domain.profile import (
     build_discovery_record,
     format_github_issue_body,
@@ -28,6 +30,8 @@ def _boiler_record():
         supported_by_integration=False,
         referentiel_device_id="6226fd906ceb9ce2aafcf715",
         main_change_capability_id="switch_electrical_power",
+        main_change_capability_endpoints=[{"id": 1}, {"id": 1}, 3],
+        referentiel_i18n="boiler.connected_receiver_on_off",
     )
 
 
@@ -98,20 +102,63 @@ def test_whenDroppedByScope_thenDiagnosticsCarryTheReason() -> None:
     assert "telemetry_reason" not in enriched
 
 
-def test_whenReferentielHasNoCapabilities_thenMainChangeCapabilityIsExported() -> None:
+def test_whenReferentielHasNoCapabilities_thenControlHintsAreExported() -> None:
     # Given
     record = _boiler_record()
 
     # When
     export = _export(record)
+    body = format_github_issue_body(export, "f" * 64)
 
-    # Then
+    # Then — capability says what to send, endpoints where, i18n names the product.
     assert export["capabilities"] == []
     assert export["main_change_capability_id"] == "switch_electrical_power"
-    assert "Main change capability" in format_github_issue_body(export, "f" * 64)
+    assert export["main_change_capability_endpoints"] == [1, 3]
+    assert export["referentiel_i18n"] == "boiler.connected_receiver_on_off"
+    assert "Main change capability" in body
+    assert "Main change endpoints" in body
+    assert "Referentiel i18n key" in body
 
 
-def test_whenMainChangeCapabilityChanges_thenFingerprintStaysStable() -> None:
+def test_whenEndpointEntriesAreMissingOrMalformed_thenExportStaysEmpty() -> None:
+    # Given
+    record = build_discovery_record(
+        device_type="boiler",
+        bff_device_type="boiler",
+        capabilities=[],
+        possible_values={},
+        manufacturer=None,
+        model=None,
+        firmware_version=None,
+        supported_by_integration=False,
+        main_change_capability_endpoints=[{"label": "no id"}, None],
+        referentiel_i18n="",
+    )
+
+    # When
+    export = _export(record)
+
+    # Then
+    assert export["main_change_capability_endpoints"] == []
+    assert export["referentiel_i18n"] is None
+
+
+def test_whenFirmwareIsPatchedLate_thenControlHintsSurvive() -> None:
+    # Given — discovery patches firmware once metadata reads land.
+    record = _boiler_record()
+
+    # When
+    patched = replace(record, firmware_version="2.0.0")
+
+    # Then — a rebuild here used to drop every field the builder gained since.
+    assert patched.firmware_version == "2.0.0"
+    assert patched.main_change_capability_id == "switch_electrical_power"
+    assert patched.main_change_capability_endpoints == [1, 3]
+    assert patched.referentiel_i18n == "boiler.connected_receiver_on_off"
+    assert patched.referentiel_device_id == "6226fd906ceb9ce2aafcf715"
+
+
+def test_whenControlHintsAreAdded_thenFingerprintStaysStable() -> None:
     # Given
     without = _export(
         build_discovery_record(


### PR DESCRIPTION
Follow-up to #92, from reviewing what discovery reads but still throws away.

## Two missing fields

`main_change_capability_id` says *what* to send. It does not say *where*, and it does not identify the product. Two fields already parsed into `EnkiDevice` never reached `EnkiDiscoveryRecord`:

- **`main_change_capability_endpoints`** — `EnkiCapabilityProfile` already uses these for `power_endpoints` and fan routing. Targeting the wrong endpoint is the exact bug class we hit on the Radix light/motor split, so the capability without the endpoint is half the information. Exported as sorted, de-duplicated integer ids via `endpoint_id_from_entry()`.
- **`referentiel_i18n`** — on the #87 profile, `manufacturer`, `model` and `capabilities` are all null and `_referentiel_model()` finds no `modelNumber` / `commercialReference` / `reference`. The referentiel i18n key is the last remaining product identifier. It comes from the Enki catalogue, not from the user-set tile label (`title.label`, which we never export), so it stays non-PII.

## A drift bug this uncovered

`_discover_dashboard_item()` rebuilt the record from scratch when metadata reads returned a firmware version:

```python
if last_reported.get("firmware_version"):
    record = build_discovery_record(...)  # only the original arguments
```

That rebuild never passed `main_change_capability_id`, so the hint **shipped in 1.7.0 was wiped for every device whose firmware read succeeds** — that is, most active devices. Replaced with `dataclasses.replace(record, firmware_version=...)`, which cannot drift when the builder gains a field. Covered by a regression test.

## Test plan
- [x] `ruff check` / `ruff format`
- [x] `pytest` — 267 passed, 1 skipped
- [x] Malformed endpoint entries (no `id`, `None`) degrade to an empty list rather than leaking raw dicts
- [x] Fingerprint still stable — no re-notification for already reported devices
- [x] Rendered the #87 boiler export end to end: capability, endpoints, i18n key and `telemetry_excluded: out_of_enki_scope` all present

Refs #87