### PR TITLE
fix(api): publish the discovery snapshot atomically

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -67,6 +67,9 @@ class EnkiAPI:
         self._node_fingerprints: dict[str, str] = {}
         self._profile_read_errors: dict[str, dict[str, str]] = {}
         self._profile_poll_state: dict[str, dict[str, Any]] = {}
+        self._pending_fingerprints: dict[str, str] = {}
+        self._pending_read_errors: dict[str, dict[str, str]] = {}
+        self._pending_poll_state: dict[str, dict[str, Any]] = {}
 
     async def async_close(self) -> None:
         """Close the underlying HTTP session."""
@@ -112,15 +115,26 @@ class EnkiAPI:
         """Discover all nodes across every home on the account."""
         http = await self._get_http()
         homes = await http.get_homes()
+
+        # Discovery writes into the pending snapshot and only publishes it once
+        # every home succeeded. Clearing upfront exposed readers (diagnostics,
+        # telemetry) to a half-built snapshot mid-poll, and left them empty for
+        # good whenever a poll raised after the reset.
+        self._pending_fingerprints = {}
+        self._pending_read_errors = {}
+        self._pending_poll_state = {}
+
         devices: list[EnkiDevice] = []
-        self._discovery_records = []
-        self._node_fingerprints.clear()
-        self._profile_read_errors.clear()
-        self._profile_poll_state.clear()
+        records: list[EnkiDiscoveryRecord] = []
         for home_id in homes:
-            home_devices, records = await self._discover_home(http, home_id)
+            home_devices, home_records = await self._discover_home(http, home_id)
             devices.extend(home_devices)
-            self._discovery_records.extend(records)
+            records.extend(home_records)
+
+        self._discovery_records = records
+        self._node_fingerprints = self._pending_fingerprints
+        self._profile_read_errors = self._pending_read_errors
+        self._profile_poll_state = self._pending_poll_state
         return devices
 
     @property
@@ -137,15 +151,15 @@ class EnkiAPI:
 
     def _register_node_profile(self, node_id: str, record: EnkiDiscoveryRecord) -> None:
         export = profile_to_export_dict(record, integration_version="", ha_version="")
-        self._node_fingerprints[node_id] = profile_fingerprint(export)
+        self._pending_fingerprints[node_id] = profile_fingerprint(export)
 
     def _register_poll_state(self, node_id: str, state: dict[str, Any]) -> None:
-        fingerprint = self._node_fingerprints.get(node_id)
+        fingerprint = self._pending_fingerprints.get(node_id)
         if not fingerprint:
             return
         sanitized = sanitize_poll_state(state)
         if sanitized:
-            self._profile_poll_state[fingerprint] = sanitized
+            self._pending_poll_state[fingerprint] = sanitized
 
     def _note_read_error(
         self,
@@ -155,13 +169,13 @@ class EnkiAPI:
         capability: str,
         err: Exception,
     ) -> None:
-        fingerprint = self._node_fingerprints.get(node_id)
+        fingerprint = self._pending_fingerprints.get(node_id)
         if not fingerprint:
             return
         status = getattr(err, "status", None)
         label = f"HTTP {status}" if status else err.__class__.__name__
         key = f"{service}/{capability}"
-        self._profile_read_errors.setdefault(fingerprint, {})[key] = label
+        self._pending_read_errors.setdefault(fingerprint, {})[key] = label
 
     @property
     def scenarios(self) -> tuple[EnkiScenario, ...]:

--- a/tests/unit/test_discovery_snapshot.py
+++ b/tests/unit/test_discovery_snapshot.py
@@ -1,0 +1,93 @@
+"""Discovery must publish its snapshot atomically (see issue #87).
+
+A poll re-runs full discovery every 30 s. Readers hitting that window, or a poll
+raising midway, used to see an empty discovery_records while the coordinator kept
+serving its cached devices — diagnostics then reported devices but zero profiles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from enki.api.client import EnkiAPI
+from enki.domain.profile import build_discovery_record
+
+
+def _record(device_type: str = "boiler"):
+    return build_discovery_record(
+        device_type=device_type,
+        bff_device_type=device_type,
+        capabilities=[],
+        possible_values={},
+        manufacturer=None,
+        model=None,
+        firmware_version=None,
+        supported_by_integration=False,
+    )
+
+
+def _api_with_one_home() -> EnkiAPI:
+    api = EnkiAPI("user", "pass")
+    http = AsyncMock()
+    http.get_homes = AsyncMock(return_value=["home-1"])
+    api._get_http = AsyncMock(return_value=http)  # noqa: SLF001
+    return api
+
+
+@pytest.mark.asyncio
+async def test_whenDiscoveryRaises_thenPreviousSnapshotSurvives() -> None:
+    # Given a completed discovery
+    api = _api_with_one_home()
+    with patch.object(EnkiAPI, "_discover_home", AsyncMock(return_value=(["dev"], [_record()]))):
+        await api.async_get_devices()
+    assert len(api.discovery_records) == 1
+
+    # When the next poll blows up midway
+    with (
+        patch.object(EnkiAPI, "_discover_home", AsyncMock(side_effect=RuntimeError("boom"))),
+        pytest.raises(RuntimeError),
+    ):
+        await api.async_get_devices()
+
+    # Then diagnostics still have something to show
+    assert len(api.discovery_records) == 1
+
+
+@pytest.mark.asyncio
+async def test_whenReadDuringDiscovery_thenSnapshotIsNeverEmpty() -> None:
+    # Given a completed discovery and a slow poll in flight
+    api = _api_with_one_home()
+    with patch.object(EnkiAPI, "_discover_home", AsyncMock(return_value=(["dev"], [_record()]))):
+        await api.async_get_devices()
+
+    async def slow_discover(*_args, **_kwargs):
+        await asyncio.sleep(0)
+        return ["dev"], [_record("lights")]
+
+    # When diagnostics read while the poll is running
+    with patch.object(EnkiAPI, "_discover_home", slow_discover):
+        task = asyncio.create_task(api.async_get_devices())
+        await asyncio.sleep(0)
+        mid_poll = api.discovery_records
+        await task
+
+    # Then the reader saw the previous snapshot, not a half-built one
+    assert len(mid_poll) == 1
+    assert [record.device_type for record in api.discovery_records] == ["lights"]
+
+
+@pytest.mark.asyncio
+async def test_whenDiscoverySucceeds_thenStaleProfilesAreDropped() -> None:
+    # Given
+    api = _api_with_one_home()
+    with patch.object(EnkiAPI, "_discover_home", AsyncMock(return_value=(["dev"], [_record()]))):
+        await api.async_get_devices()
+
+    # When a later poll returns fewer profiles
+    with patch.object(EnkiAPI, "_discover_home", AsyncMock(return_value=([], []))):
+        await api.async_get_devices()
+
+    # Then the published snapshot replaces the old one rather than accumulating
+    assert api.discovery_records == []


### PR DESCRIPTION
## Symptom

The v1.7.1 diagnostics dump on #87 reports `device_count: 6` and `discovery_profiles: []`. Those cannot both be true — every discovered node appends a record.

## Cause

`async_get_devices()` cleared the shared snapshot **before** rebuilding it:

```python
self._discovery_records = []
self._node_fingerprints.clear()
...
for home_id in homes:                      # dozens of HTTP calls
    ...
    self._discovery_records.extend(records)
```

Polls re-run full discovery every 30 s (`DEFAULT_SCAN_INTERVAL`), so the empty window is wide. Two ways to land in it:

- **Concurrent read** — downloading diagnostics mid-poll returns a half-built or empty list.
- **A raising poll** — the coordinator only catches `EnkiAuthError` / `EnkiConnectionError`. Anything else propagates, `coordinator.data` keeps the last good devices, and the records stay empty **permanently**. Devices without profiles, exactly the dump we got.

## Fix

Discovery fills a pending snapshot and publishes it only once every home succeeded, so readers always see the last complete one. Applies to `_discovery_records` and to the three fingerprint / read-error / poll-state maps, which had the same clear-then-refill shape.

## Test plan
- [x] `ruff check` / `ruff format`
- [x] `pytest` — 270 passed, 1 skipped
- [x] Two regression tests fail on `main` and pass here: a poll raising midway, and a read during an in-flight poll
- [x] A later poll returning fewer profiles still replaces the snapshot instead of accumulating

Refs #87