### PR TITLE
feat(cover): support RTS roller shutters without position

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -774,6 +774,21 @@ class EnkiAPI:
             max(0, min(100, position)),
         )
 
+    async def async_switch_roller_shutter(
+        self,
+        home_id: str,
+        node_id: str,
+        opening: str,
+    ) -> None:
+        """Open or close an RTS shutter, which has no position to aim for."""
+        http = await self._get_http()
+        await http.motorization_post(
+            home_id,
+            node_id,
+            "switch-roller-shutter",
+            opening.upper(),
+        )
+
     async def async_stop_shutter(self, home_id: str, node_id: str) -> None:
         """Stop an in-progress shutter movement."""
         http = await self._get_http()

--- a/custom_components/enki/cover.py
+++ b/custom_components/enki/cover.py
@@ -47,6 +47,14 @@ class EnkiCoverEntity(EnkiEntity, CoverEntity):
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-cover"
         self._supports_position = device.profile.supports_shutter_position
         self._supports_stop = device.profile.supports_shutter_stop
+        self._supports_switch = device.profile.supports_roller_shutter_switch
+        # One-way RTS radio: nothing ever reports back, so the state HA shows is
+        # only what we last sent.
+        self._attr_assumed_state = self._supports_switch and not (
+            self._supports_position
+            or device.profile.supports_shutter_opening
+            or device.profile.supports_roller_shutter_state
+        )
 
     @property
     def supported_features(self) -> CoverEntityFeature:
@@ -82,10 +90,10 @@ class EnkiCoverEntity(EnkiEntity, CoverEntity):
         return roller_shutter_state_is_closing(self._device.reported.roller_shutter_state)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
-        await self._set_position(100)
+        await self._move("OPEN")
 
     async def async_close_cover(self, **kwargs: Any) -> None:
-        await self._set_position(0)
+        await self._move("CLOSED")
 
     async def async_set_cover_position(self, position: int, **kwargs: Any) -> None:
         await self._set_position(position)
@@ -95,6 +103,21 @@ class EnkiCoverEntity(EnkiEntity, CoverEntity):
         node_id = self._device.node_id
         await self.coordinator.api.async_stop_shutter(home_id, node_id)
         self.coordinator.update_cached_value(node_id, "roller_shutter_state", "STOPPED")
+
+    async def _move(self, opening: str) -> None:
+        if self._supports_switch and not self._supports_position:
+            await self._switch(opening)
+            return
+        await self._set_position(100 if opening == "OPEN" else 0)
+
+    async def _switch(self, opening: str) -> None:
+        node_id = self._device.node_id
+        await self.coordinator.api.async_switch_roller_shutter(
+            self._device.home_id,
+            node_id,
+            opening,
+        )
+        self.coordinator.update_cached_value(node_id, "shutter_opening", opening)
 
     async def _set_position(self, position: int) -> None:
         clamped = max(0, min(100, position))

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -184,6 +184,11 @@ class EnkiCapabilityProfile:
         )
 
     @property
+    def supports_roller_shutter_switch(self) -> bool:
+        """RTS-style motorizations: OPEN/CLOSED commands, no position at all."""
+        return "switch_roller_shutter" in self.capabilities
+
+    @property
     def supports_shutter_stop(self) -> bool:
         return "stop_change_shutter_position" in self.capabilities
 
@@ -418,7 +423,11 @@ class EnkiCapabilityProfile:
     def is_cover(self) -> bool:
         """Roller shutters and similar motorizations (beta)."""
         if self.device_type in {DEVICE_TYPE_ACCESS_MOTORIZATION, "access_and_motorizations"}:
-            return self.supports_shutter_position or self.supports_shutter_opening
+            return (
+                self.supports_shutter_position
+                or self.supports_shutter_opening
+                or self.supports_roller_shutter_switch
+            )
         return self.supports_shutter_position
 
     @property

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -42,6 +42,7 @@ _CAPABILITY_PROBES: dict[str, str] = {
     "change_light_state": "supports_light_state",
     "change_shutter_position": "supports_shutter_position",
     "stop_change_shutter_position": "supports_shutter_stop",
+    "switch_roller_shutter": "supports_roller_shutter_switch",
     "check_roller_shutter_state": "supports_roller_shutter_state",
     "change_roller_shutter_mode": "supports_roller_shutter_mode",
     "check_roller_shutter_mode": "supports_roller_shutter_mode",

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,6 +98,12 @@ Commands:
 - `POST …/stop-change-shutter-position` — stop mid-travel (no body)
 - `POST …/change-roller-shutter-mode` — body `{"value": "NORMAL"|"INVERTED"}`
 - `POST …/execute-preset` — body `{"value": "<preset>"}` when referentiel lists presets
+- `POST …/switch-roller-shutter` — body `{"value": "OPEN"|"CLOSED"}` for RTS motorizations
+
+RTS models (Somfy, `tr_device_rts_roller_shutter_motorization_label`) expose only
+`switch_roller_shutter` and `stop_change_shutter_position`: one-way radio, so no
+position and no `check-*` feedback. The cover entity reports `assumed_state`.
+Path segment unconfirmed against real hardware — see #96.
 
 Gateway key: `ENKI_ACCESS_MOTORIZATION_API_KEY` in `const.py` (filled from APK 2.25.1). Legacy path `api-enki-access-and-motorizations-prod` is obsolete. See [BETA_VOLETS_KEY.md](BETA_VOLETS_KEY.md) for validation with mitmproxy.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,8 +117,14 @@ _ha_const.UnitOfEnergy.KILO_WATT_HOUR = "kWh"
 class _HaEntity:
     """Minimal HA Entity stand-in for unit tests."""
 
+    _attr_assumed_state = False
+
     def async_write_ha_state(self) -> None:
         return None
+
+    @property
+    def assumed_state(self) -> bool:
+        return self._attr_assumed_state
 
 
 class _CoordinatorEntity(_HaEntity):

--- a/tests/unit/test_cover_entities.py
+++ b/tests/unit/test_cover_entities.py
@@ -46,6 +46,7 @@ def _coordinator_for_device(device: EnkiDevice) -> MagicMock:
     )
     coordinator.update_cached_value = MagicMock()
     coordinator.api.async_set_shutter_position = AsyncMock()
+    coordinator.api.async_switch_roller_shutter = AsyncMock()
     coordinator.api.async_stop_shutter = AsyncMock()
     coordinator.api.async_execute_shutter_preset = AsyncMock()
     coordinator.api.async_power_on_with_timer = AsyncMock()
@@ -135,6 +136,99 @@ async def test_cover_stop_calls_api_and_caches_state() -> None:
         "roller_shutter_state",
         "STOPPED",
     )
+
+
+def _rts_device(**kwargs) -> EnkiDevice:
+    """Somfy RTS motorization from issue #96: open/close only, no feedback."""
+    return _cover_device(
+        capabilities=["switch_roller_shutter", "stop_change_shutter_position"],
+        possible_values={"switch_roller_shutter": {"values": ["OPEN", "CLOSED"]}},
+        last_reported_value={},
+        **kwargs,
+    )
+
+
+def test_rts_cover_is_discovered_and_exposes_open_close_stop() -> None:
+    device = _rts_device()
+    entity = EnkiCoverEntity(_coordinator_for_device(device), device)
+
+    assert device.profile.is_cover is True
+    features = entity.supported_features
+    assert features & CoverEntityFeature.OPEN
+    assert features & CoverEntityFeature.CLOSE
+    assert features & CoverEntityFeature.STOP
+    assert not (features & CoverEntityFeature.SET_POSITION)
+
+
+def test_rts_cover_has_no_position_and_assumes_its_state() -> None:
+    device = _rts_device()
+    entity = EnkiCoverEntity(_coordinator_for_device(device), device)
+
+    assert entity.current_cover_position is None
+    assert entity.is_closed is None
+    assert entity.assumed_state is True
+
+
+def test_cover_with_feedback_does_not_assume_its_state() -> None:
+    device = _cover_device()
+    entity = EnkiCoverEntity(_coordinator_for_device(device), device)
+
+    assert entity.assumed_state is False
+
+
+@pytest.mark.asyncio
+async def test_rts_cover_open_switches_instead_of_setting_position() -> None:
+    device = _rts_device()
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiCoverEntity(coordinator, device)
+
+    await entity.async_open_cover()
+
+    coordinator.api.async_switch_roller_shutter.assert_awaited_once_with(
+        "home-1",
+        "node-1",
+        "OPEN",
+    )
+    coordinator.api.async_set_shutter_position.assert_not_awaited()
+    coordinator.update_cached_value.assert_called_once_with("node-1", "shutter_opening", "OPEN")
+
+
+@pytest.mark.asyncio
+async def test_rts_cover_close_switches_and_reports_closed() -> None:
+    device = _rts_device()
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiCoverEntity(coordinator, device)
+
+    await entity.async_close_cover()
+
+    coordinator.api.async_switch_roller_shutter.assert_awaited_once_with(
+        "home-1",
+        "node-1",
+        "CLOSED",
+    )
+    device.last_reported_value["shutter_opening"] = "CLOSED"
+    assert entity.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_positional_cover_keeps_using_position_api() -> None:
+    # Given a shutter that also happens to expose the RTS switch
+    device = _cover_device(
+        capabilities=[
+            "change_shutter_position",
+            "check_shutter_position",
+            "switch_roller_shutter",
+        ],
+    )
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiCoverEntity(coordinator, device)
+
+    # When
+    await entity.async_open_cover()
+
+    # Then position stays authoritative
+    coordinator.api.async_set_shutter_position.assert_awaited_once_with("home-1", "node-1", 100)
+    coordinator.api.async_switch_roller_shutter.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #96.

## Context

A Somfy RTS motorization reported via telemetry (`tr_device_rts_roller_shutter_motorization_label`) exposes exactly two capabilities:

- `switch_roller_shutter` — values `OPEN` / `CLOSED`
- `stop_change_shutter_position`

No position, no `check_*`. RTS is one-way radio: the device never reports back.

`is_cover` required `supports_shutter_position` or `supports_shutter_opening`, so the device was dropped as unsupported.

## Changes

- New probe `supports_roller_shutter_switch`, accepted by `is_cover` for motorization types only.
- `async_switch_roller_shutter()` posting `switch-roller-shutter` with `OPEN` / `CLOSED`.
- Open/close divert to that call **only** when position is absent, so every already-supported shutter keeps the exact path it had.
- The entity sets `assumed_state` when nothing reports back, and caches what it sent into the existing `shutter_opening` field, which `is_closed` already reads.
- `switch_roller_shutter` added to the telemetry coverage map so it stops being flagged uncovered.
- `docs/API.md` documents the endpoint and flags it unverified.

STOP already worked — `stop_change_shutter_position` was covered.

## Caveat

The path segment follows the convention every other shutter command uses (`change-shutter-position`, `stop-change-shutter-position`), but I have no RTS hardware to confirm it. Needs a field check by the reporter.

## Test plan
- [x] `ruff check` / `ruff format`
- [x] `pytest` — 276 passed, 1 skipped
- [x] The exact #96 profile now yields `is_cover=True`, `is_supported=True`, no uncovered capabilities
- [x] RTS cover exposes OPEN/CLOSE/STOP without SET_POSITION, no position, `assumed_state=True`
- [x] Regression: a shutter exposing both position and the switch still uses the position API, and a normal shutter keeps `assumed_state=False`