### PR TITLE
feat(switch): expose water-heater on/off relay as a switch

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -430,7 +430,7 @@ class EnkiAPI:
                     err=err,
                 )
 
-        if profile.supports_electrical_power:
+        if profile.supports_electrical_power or profile.is_boiler_switch:
             try:
                 power_details = await http.get_electrical_power(home_id, node_id)
                 state["electrical_power"] = power_details.get("lastReportedValue")

--- a/custom_components/enki/const.py
+++ b/custom_components/enki/const.py
@@ -53,6 +53,7 @@ DEVICE_TYPE_FANS = "ceiling_fans"
 DEVICE_TYPE_INVERTERS = "inverters"
 DEVICE_TYPE_ACCESS_MOTORIZATION = "access_and_motorizations"
 DEVICE_TYPE_SENSORS = "sensors"
+DEVICE_TYPE_BOILER = "boiler"
 
 REFERENTIEL_VERSION = "2.23.0"
 

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ..const import (
     DEVICE_TYPE_ACCESS_MOTORIZATION,
+    DEVICE_TYPE_BOILER,
     DEVICE_TYPE_FANS,
     DEVICE_TYPE_INVERTERS,
     DEVICE_TYPE_LIGHTS,
@@ -436,6 +437,27 @@ class EnkiCapabilityProfile:
         return self.supports_power_on_with_timer
 
     @property
+    def is_boiler_switch(self) -> bool:
+        """Plain on/off relay re-typed as a water heater (Enki `boiler` module).
+
+        When a Nodon/Lexman relay is assigned to a water heater, the app re-types
+        it to the `boiler` profile and the referentiel serves an empty catalogue
+        entry — no capabilities, no mainChangeCapability. The boiler-system
+        micro-service only reads status and manages node linking (APK ic1/dd1);
+        the actual on/off still goes through the generic power API on the node.
+        So drive it as a bare on/off switch via switch_electrical_power.
+
+        Scoped narrowly (empty capabilities, no mainChangeCapability) so a real
+        piloted water heater that declares its own capabilities is never caught
+        here and mis-driven.
+        """
+        return (
+            self.device_type == DEVICE_TYPE_BOILER
+            and not self.capabilities
+            and self.main_change_capability_id is None
+        )
+
+    @property
     def is_environment_sensor(self) -> bool:
         """Temperature, humidity, illuminance, or battery level sensors (not thermostats)."""
         if self.supports_thermostat:
@@ -504,6 +526,7 @@ class EnkiCapabilityProfile:
             or self.is_pilot_wire
             or self.supports_vibration_sensibility
             or self.is_impulse_relay
+            or self.is_boiler_switch
         )
 
     @property

--- a/custom_components/enki/lib/enki_scope.py
+++ b/custom_components/enki/lib/enki_scope.py
@@ -23,9 +23,14 @@ _ENKI_ECOSYSTEM_MANUFACTURERS = frozenset(
 )
 
 # Referentiel types reserved for the Enki catalogue (manufacturer sometimes missing from API).
+# `boiler` is the Enki "chauffe-eau piloté" module: the app re-types a plain Enki relay to
+# this profile when it is wired to a water heater, and the referentiel then serves it with an
+# empty manufacturer. It is native Enki (dedicated api-enki-boiler-system-prod service), not
+# third-party Zigbee — see EnkiCapabilityProfile.is_boiler_switch.
 _ENKI_NATIVE_DEVICE_TYPES = frozenset(
     {
         "access_and_motorizations",
+        "boiler",
         "ceiling_fans",
         "inverters",
     }

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -72,6 +72,9 @@
       "fan_light": {
         "name": "Light"
       },
+      "fan_light_numbered": {
+        "name": "Light {number}"
+      },
       "light": {
         "name": "Light"
       }
@@ -133,6 +136,9 @@
     "switch": {
       "outlet": {
         "name": "Outlet"
+      },
+      "boiler": {
+        "name": "Water heater"
       },
       "vibration_detection": {
         "name": "Vibration detection"

--- a/custom_components/enki/switch.py
+++ b/custom_components/enki/switch.py
@@ -81,8 +81,18 @@ def _build_switch_entities(
 ) -> list[SwitchEntity]:
     entities: list[SwitchEntity] = []
     entities.extend(_build_outlet_switches(coordinator, device))
+    entities.extend(_build_boiler_switches(coordinator, device))
     entities.extend(_build_config_switches(coordinator, device))
     return entities
+
+
+def _build_boiler_switches(
+    coordinator: EnkiCoordinator,
+    device: EnkiDevice,
+) -> list[EnkiBoilerSwitch]:
+    if not device.profile.is_boiler_switch:
+        return []
+    return [EnkiBoilerSwitch(coordinator, device)]
 
 
 def _build_outlet_switches(
@@ -190,6 +200,25 @@ class EnkiOutletSwitch(EnkiEntity, SwitchEntity):
             return
         self.coordinator.update_cached_value(node_id, "electrical_power", power)
         self.coordinator.update_cached_value(node_id, "power", power)
+
+
+class EnkiBoilerSwitch(EnkiOutletSwitch):
+    """On/off relay wired to a water heater (Enki `boiler` module).
+
+    Same power API as an outlet (switch_electrical_power on the whole node), but
+    surfaced as a plain switch rather than an OUTLET so it reads as a water-heater
+    control. See EnkiCapabilityProfile.is_boiler_switch.
+    """
+
+    _attr_translation_key = "boiler"
+    _attr_device_class = SwitchDeviceClass.SWITCH
+
+    def __init__(
+        self,
+        coordinator: EnkiCoordinator,
+        device: EnkiDevice,
+    ) -> None:
+        super().__init__(coordinator, device, endpoint_id=None, suffix="boiler")
 
 
 class EnkiConfigSwitch(EnkiEntity, SwitchEntity):

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -72,6 +72,9 @@
       "fan_light": {
         "name": "Light"
       },
+      "fan_light_numbered": {
+        "name": "Light {number}"
+      },
       "light": {
         "name": "Light"
       }
@@ -139,6 +142,9 @@
     "switch": {
       "outlet": {
         "name": "Outlet"
+      },
+      "boiler": {
+        "name": "Water heater"
       },
       "vibration_detection": {
         "name": "Vibration detection"

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -72,6 +72,9 @@
       "fan_light": {
         "name": "Lumière"
       },
+      "fan_light_numbered": {
+        "name": "Lumière {number}"
+      },
       "light": {
         "name": "Lumière"
       }
@@ -139,6 +142,9 @@
     "switch": {
       "outlet": {
         "name": "Prise"
+      },
+      "boiler": {
+        "name": "Chauffe-eau"
       },
       "vibration_detection": {
         "name": "Détection vibration"

--- a/tests/unit/test_boiler_switch.py
+++ b/tests/unit/test_boiler_switch.py
@@ -1,0 +1,106 @@
+"""Unit tests for the water-heater on/off relay exposed as a switch (#87)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.domain.models import EnkiDevice
+from enki.switch import EnkiBoilerSwitch, _build_switch_entities
+from homeassistant.components.switch import SwitchDeviceClass
+
+
+def _boiler_device(**kwargs) -> EnkiDevice:
+    """The re-skinned relay: type `boiler`, empty referentiel, no control hints."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-boiler",
+        "device_name": "Chauffe-eau",
+        "device_type": "boiler",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [],
+        "main_change_capability_id": None,
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _coordinator_for_device(device: EnkiDevice) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.data = [device]
+    coordinator.get_device_by_node = lambda node_id: next(
+        (entry for entry in coordinator.data if entry.node_id == node_id),
+        None,
+    )
+    coordinator.update_cached_value = MagicMock()
+    coordinator.update_endpoint_power = MagicMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    return coordinator
+
+
+def test_boiler_device_builds_a_single_switch() -> None:
+    device = _boiler_device()
+    entities = _build_switch_entities(_coordinator_for_device(device), device)
+
+    assert len(entities) == 1
+    entity = entities[0]
+    assert isinstance(entity, EnkiBoilerSwitch)
+    assert entity._attr_device_class == SwitchDeviceClass.SWITCH  # noqa: SLF001
+    assert entity._attr_translation_key == "boiler"  # noqa: SLF001
+    assert entity._attr_unique_id == "enki-node-boiler-boiler"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_boiler_switch_turn_on_calls_power_api_without_endpoint() -> None:
+    device = _boiler_device()
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiBoilerSwitch(coordinator, device)
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1",
+        "node-boiler",
+        "ON",
+        endpoint=None,
+    )
+    # No endpoint → cache the node-level power, not an endpoint slot.
+    coordinator.update_endpoint_power.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_boiler_switch_turn_off_calls_power_api() -> None:
+    device = _boiler_device()
+    coordinator = _coordinator_for_device(device)
+    entity = EnkiBoilerSwitch(coordinator, device)
+
+    await entity.async_turn_off()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1",
+        "node-boiler",
+        "OFF",
+        endpoint=None,
+    )
+
+
+def test_boiler_switch_reflects_reported_power() -> None:
+    on = EnkiBoilerSwitch(
+        _coordinator_for_device(_boiler_device(last_reported_value={"power": "ON"})),
+        _boiler_device(last_reported_value={"power": "ON"}),
+    )
+    off = EnkiBoilerSwitch(
+        _coordinator_for_device(_boiler_device(last_reported_value={"power": "OFF"})),
+        _boiler_device(last_reported_value={"power": "OFF"}),
+    )
+    unknown = EnkiBoilerSwitch(
+        _coordinator_for_device(_boiler_device()),
+        _boiler_device(),
+    )
+
+    assert on.is_on is True
+    assert off.is_on is False
+    assert unknown.is_on is None

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -72,6 +72,30 @@ def test_device_uses_power_api_only() -> None:
     assert device_is_supported(device) is True
 
 
+def test_boiler_relay_without_capabilities_is_a_switch() -> None:
+    # The re-skinned water-heater relay (#87): type `boiler`, empty referentiel.
+    device = _device(
+        device_type="boiler",
+        capabilities=[],
+        main_change_capability_id=None,
+    )
+    assert device.profile.is_boiler_switch is True
+    assert device_is_supported(device) is True
+    # Not a light, not an outlet — a plain switch driven via the power API.
+    assert is_light_controllable(device) is False
+    assert device.profile.is_outlet is False
+
+
+def test_real_piloted_boiler_with_capabilities_is_not_a_bare_switch() -> None:
+    # A genuine piloted water heater declares its own capabilities: leave it alone.
+    device = _device(
+        device_type="boiler",
+        capabilities=["change_thermostat_target_temperature"],
+        main_change_capability_id="change_thermostat_target_temperature",
+    )
+    assert device.profile.is_boiler_switch is False
+
+
 def test_main_change_capability_endpoints() -> None:
     device = _device(
         main_change_capability_id="switch_electrical_power",

--- a/tests/unit/test_diagnostics_blind_spot.py
+++ b/tests/unit/test_diagnostics_blind_spot.py
@@ -35,6 +35,20 @@ def _boiler_record():
     )
 
 
+def _third_party_record():
+    """A genuine non-Enki Zigbee device paired on the box (belongs in ZHA/Z2M)."""
+    return build_discovery_record(
+        device_type="smart_plug",
+        bff_device_type="smart_plug",
+        capabilities=["switch_electrical_power"],
+        possible_values={},
+        manufacturer="Tuya",
+        model="TS011F",
+        firmware_version="1.0.0",
+        supported_by_integration=False,
+    )
+
+
 def _export(record) -> dict:
     return profile_to_export_dict(
         record,
@@ -45,7 +59,7 @@ def _export(record) -> dict:
 
 def test_whenProfileIsOutOfEnkiScope_thenExclusionIsReported() -> None:
     # Given
-    record = _boiler_record()
+    record = _third_party_record()
 
     # When
     exclusion = discovery_record_telemetry_exclusion(record)
@@ -92,7 +106,7 @@ def test_whenSupportedProfile_thenNoExclusion() -> None:
 
 def test_whenDroppedByScope_thenDiagnosticsCarryTheReason() -> None:
     # Given
-    record = _boiler_record()
+    record = _third_party_record()
 
     # When
     enriched = enrich_telemetry_export(_export(record), record)
@@ -100,6 +114,25 @@ def test_whenDroppedByScope_thenDiagnosticsCarryTheReason() -> None:
     # Then
     assert enriched["telemetry_excluded"] == "out_of_enki_scope"
     assert "telemetry_reason" not in enriched
+
+
+def test_whenBoilerRelayHasNoManufacturer_thenItStaysInEnkiScope() -> None:
+    # Given — the re-skinned water-heater relay: type `boiler`, no manufacturer (#87).
+    record = build_discovery_record(
+        device_type="boiler",
+        bff_device_type="boiler",
+        capabilities=[],
+        possible_values={},
+        manufacturer=None,
+        model=None,
+        firmware_version=None,
+        supported_by_integration=True,
+        referentiel_device_id="6226fd906ceb9ce2aafcf715",
+    )
+
+    # When / Then — no longer silently dropped as third-party Zigbee.
+    assert discovery_record_telemetry_exclusion(record) is None
+    assert discovery_record_eligible_for_telemetry(record) is True
 
 
 def test_whenReferentielHasNoCapabilities_thenControlHintsAreExported() -> None:


### PR DESCRIPTION
## Context

Fixes the "Unsupported device — Relay" report in #87.

A plain Nodon/Lexman on/off module (Lexman `83424574`, same SIN-4-1-20 hardware as the gate module in #56) wired to a water heater is re-typed by the Enki app to a `boiler` profile. The referentiel then serves it **empty** — no manufacturer, no capabilities, no `mainChangeCapability`:

```json
{ "device_type": "boiler", "manufacturer": null, "capabilities": [],
  "main_change_capability_id": null, "telemetry_excluded": "out_of_enki_scope" }
```

Two things blocked it:

1. **Silently dropped.** The scope filter treated the empty profile as third-party Zigbee (`out_of_enki_scope`), so it never surfaced.
2. **Nothing to map.** With no capabilities, no platform claimed it.

Digging into the APK, the `boiler-system` micro-service (`ic1`/`dd1`) only **reads status and manages node linking (link/unlink, min-time)** — it has **no on/off command**. The real toggle goes through the standard power API on the node, exactly like any relay.

## Change

- Treat `boiler` as a **native Enki type** so it stays in scope (dedicated `api-enki-boiler-system-prod` service — not third-party).
- Classify a capability-less `boiler` profile (empty capabilities **and** no `mainChangeCapability`) as `is_boiler_switch` → a plain on/off **switch** driven via `switch_electrical_power` (no endpoint), reusing the existing outlet-switch machinery.
- Read its initial power state during discovery.
- Entity name: **Water heater** / **Chauffe-eau**.

The classification rule is intentionally narrow so a *real* piloted water heater that declares its own capabilities is never caught here and mis-driven.

## Tests

- `tests/unit/test_boiler_switch.py` — entity build, on/off routing (no endpoint), state read-back.
- `tests/unit/test_capabilities.py` — `is_boiler_switch` positive/negative.
- `tests/unit/test_diagnostics_blind_spot.py` — boiler now stays in scope; out-of-scope coverage moved to a genuine third-party device.

Full unit suite green, ruff clean.

## ⚠️ Needs live confirmation

Because the re-skinned `boiler` referentiel is empty, the control channel is **inferred** (same relay hardware as the gate module, same power service) — strong, but unproven without hardware. Before merge, the reporter should confirm: does toggling the *Water heater* switch actually turn the heater on/off, and does its state stay in sync with the Enki app?

Refs #87.