### PR TITLE
fix(coordinator): hold optimistic writes against stale cloud polls

### DIFF
--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import timedelta
@@ -21,6 +22,50 @@ from .migration import resolve_scan_interval
 from .notifications import EnkiNotifier, notify_for_connection_error
 from .telemetry import EnkiTelemetryReporter
 
+# How long an optimistic value stays authoritative against the cloud. The Enki
+# cloud can take ~30 s to reflect a command, so a poll inside that window still
+# returns the pre-command state; holding a bit past that keeps HA from reverting
+# an optimistic change before the cloud catches up (issue #111).
+_OPTIMISTIC_HOLD_SECONDS = 45.0
+
+
+def _override_current(device: EnkiDevice, path: tuple) -> Any:
+    """Read the value a stored override targets from live device state."""
+    reported = device.last_reported_value
+    kind = path[0]
+    if kind == "top":
+        return reported.get(path[1])
+    if kind == "nested":
+        parent = reported.get(path[1])
+        return parent.get(path[2]) if isinstance(parent, dict) else None
+    if kind == "endpoint":
+        for endpoint in reported.get("electrical_endpoints") or []:
+            if isinstance(endpoint, dict) and endpoint.get("id") == path[1]:
+                value = endpoint.get("lastReportedValue")
+                return value.get("power") if isinstance(value, dict) else value
+    return None
+
+
+def _override_apply(device: EnkiDevice, path: tuple, value: Any) -> None:
+    """Re-apply a held optimistic value onto freshly polled device state."""
+    reported = device.last_reported_value
+    kind = path[0]
+    if kind == "top":
+        reported[path[1]] = value
+    elif kind == "nested":
+        parent = reported.setdefault(path[1], {})
+        if isinstance(parent, dict):
+            parent[path[2]] = value
+    elif kind == "endpoint":
+        for endpoint in reported.get("electrical_endpoints") or []:
+            if isinstance(endpoint, dict) and endpoint.get("id") == path[1]:
+                current = endpoint.get("lastReportedValue")
+                if isinstance(current, dict):
+                    current["power"] = value
+                else:
+                    endpoint["lastReportedValue"] = value
+                break
+
 
 class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
     """Poll Enki cloud and expose device snapshots to platforms."""
@@ -30,6 +75,9 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         self.config_entry = config_entry
         self._suspend_notify = False
+        # node_id -> {path: (optimistic value, monotonic expiry)}. Holds optimistic
+        # writes authoritative until the cloud reflects them or they expire (#111).
+        self._overrides: dict[str, dict[tuple, tuple[Any, float]]] = {}
         self.api = EnkiAPI(
             config_entry.data[CONF_USERNAME],
             config_entry.data[CONF_PASSWORD],
@@ -72,7 +120,7 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
                     err,
                     exc_info=LOGGER.isEnabledFor(logging.DEBUG),
                 )
-            return devices
+            return self._apply_optimistic_overrides(devices)
 
     async def _async_sync_maintenance_notification(self) -> None:
         """Re-check Enki maintenance flag each poll; dismiss when it clears."""
@@ -130,12 +178,19 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
             if not previous:
                 self._notify()
 
+    def _record_override(self, node_id: str, path: tuple, value: Any) -> None:
+        self._overrides.setdefault(node_id, {})[path] = (
+            value,
+            time.monotonic() + _OPTIMISTIC_HOLD_SECONDS,
+        )
+
     def update_cached_value(self, node_id: str, key: str, value: Any) -> None:
         """Optimistically patch cached state after a successful command."""
         device = self.get_device_by_node(node_id)
         if device is None or self.data is None:
             return
         device.last_reported_value[key] = value
+        self._record_override(node_id, ("top", key), value)
         self._notify()
 
     def update_cached_nested(self, node_id: str, parent_key: str, key: str, value: Any) -> None:
@@ -146,6 +201,7 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         parent = device.last_reported_value.setdefault(parent_key, {})
         if isinstance(parent, dict):
             parent[key] = value
+        self._record_override(node_id, ("nested", parent_key, key), value)
         self._notify()
 
     def update_endpoint_power(self, node_id: str, endpoint_id: int, power: str) -> None:
@@ -159,4 +215,31 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
                 if isinstance(endpoint, dict) and endpoint.get("id") == endpoint_id:
                     endpoint["lastReportedValue"] = power
                     break
+        self._record_override(node_id, ("endpoint", endpoint_id), power)
         self._notify()
+
+    def _apply_optimistic_overrides(self, devices: list[EnkiDevice]) -> list[EnkiDevice]:
+        """Re-apply still-pending optimistic writes over freshly polled state.
+
+        The Enki cloud is eventually consistent: a poll within the propagation
+        window returns the pre-command value and would revert an optimistic
+        change (issue #111). For each held override, drop it once the cloud
+        agrees (or it expires) and otherwise re-apply it so the poll can't
+        stomp it.
+        """
+        now = time.monotonic()
+        for node_id in list(self._overrides):
+            paths = self._overrides[node_id]
+            device = next((item for item in devices if item.node_id == node_id), None)
+            if device is None:
+                del self._overrides[node_id]
+                continue
+            for path in list(paths):
+                value, expires_at = paths[path]
+                if now >= expires_at or _override_current(device, path) == value:
+                    del paths[path]
+                    continue
+                _override_apply(device, path, value)
+            if not paths:
+                del self._overrides[node_id]
+        return devices

--- a/tests/unit/test_fan_multi_light.py
+++ b/tests/unit/test_fan_multi_light.py
@@ -157,6 +157,7 @@ def _bare_coordinator() -> EnkiCoordinator:
     """A coordinator instance without HA wiring, for cache-notify tests."""
     coordinator = object.__new__(EnkiCoordinator)
     coordinator._suspend_notify = False
+    coordinator._overrides = {}
     coordinator.data = [_cadix()]
     return coordinator
 

--- a/tests/unit/test_optimistic_guard.py
+++ b/tests/unit/test_optimistic_guard.py
@@ -74,9 +74,7 @@ def test_expired_override_lets_the_cloud_win() -> None:
 
 
 def test_endpoint_power_override_held_against_stale_poll() -> None:
-    coordinator = _coordinator(
-        _device(electrical_endpoints=[{"id": 3, "lastReportedValue": "ON"}])
-    )
+    coordinator = _coordinator(_device(electrical_endpoints=[{"id": 3, "lastReportedValue": "ON"}]))
     coordinator.update_endpoint_power("node", 3, "OFF")
 
     fresh = _device(electrical_endpoints=[{"id": 3, "lastReportedValue": "ON"}])

--- a/tests/unit/test_optimistic_guard.py
+++ b/tests/unit/test_optimistic_guard.py
@@ -1,0 +1,85 @@
+"""Optimistic-write guard: a stale cloud poll must not revert optimistic state.
+
+The Enki cloud is eventually consistent (~30 s), so a poll inside that window
+returns the pre-command value. The coordinator holds optimistic writes
+authoritative until the cloud agrees or they expire (issue #111).
+"""
+
+from __future__ import annotations
+
+import time
+
+from enki.coordinator import EnkiCoordinator
+from enki.domain.models import EnkiDevice
+
+
+def _device(**last_reported) -> EnkiDevice:
+    return EnkiDevice(
+        home_id="home",
+        device_id="dev",
+        node_id="node",
+        device_name="Cadix",
+        device_type="ceiling_fans",
+        is_enabled=True,
+        state="ACTIVE",
+        last_reported_value=dict(last_reported),
+    )
+
+
+def _coordinator(device: EnkiDevice) -> EnkiCoordinator:
+    coordinator = object.__new__(EnkiCoordinator)
+    coordinator._suspend_notify = False
+    coordinator._overrides = {}
+    coordinator.data = [device]
+    coordinator.async_set_updated_data = lambda data: None
+    return coordinator
+
+
+def test_stale_poll_does_not_revert_optimistic_value() -> None:
+    coordinator = _coordinator(_device(light_power="OFF"))
+    coordinator.update_cached_value("node", "light_power", "ON")
+
+    # Cloud hasn't propagated yet: a fresh poll still reports OFF.
+    fresh = _device(light_power="OFF")
+    result = coordinator._apply_optimistic_overrides([fresh])
+
+    assert result[0].last_reported_value["light_power"] == "ON"
+
+
+def test_override_released_once_cloud_agrees() -> None:
+    coordinator = _coordinator(_device(light_power="OFF"))
+    coordinator.update_cached_value("node", "light_power", "ON")
+
+    # Cloud catches up → the override is dropped.
+    coordinator._apply_optimistic_overrides([_device(light_power="ON")])
+    assert coordinator._overrides == {}
+
+    # A later genuine change (e.g. physical off) is now respected, not held.
+    later = _device(light_power="OFF")
+    coordinator._apply_optimistic_overrides([later])
+    assert later.last_reported_value["light_power"] == "OFF"
+
+
+def test_expired_override_lets_the_cloud_win() -> None:
+    coordinator = _coordinator(_device(light_power="OFF"))
+    coordinator.update_cached_value("node", "light_power", "ON")
+    # Force expiry so a genuinely-failed command can't stick forever.
+    coordinator._overrides["node"][("top", "light_power")] = ("ON", time.monotonic() - 1)
+
+    fresh = _device(light_power="OFF")
+    coordinator._apply_optimistic_overrides([fresh])
+
+    assert fresh.last_reported_value["light_power"] == "OFF"
+    assert coordinator._overrides == {}
+
+
+def test_endpoint_power_override_held_against_stale_poll() -> None:
+    coordinator = _coordinator(
+        _device(electrical_endpoints=[{"id": 3, "lastReportedValue": "ON"}])
+    )
+    coordinator.update_endpoint_power("node", 3, "OFF")
+
+    fresh = _device(electrical_endpoints=[{"id": 3, "lastReportedValue": "ON"}])
+    coordinator._apply_optimistic_overrides([fresh])
+
+    assert fresh.last_reported_value["electrical_endpoints"][0]["lastReportedValue"] == "OFF"


### PR DESCRIPTION
Fixes #111.

## Problem

The Enki cloud is eventually consistent — it takes ~30 s to reflect a command. Any poll inside that window (the scheduled poll, or the #109 reconcile poll fired right after a command) returns the **pre-command** state and overwrites the optimistic update. On the Cadix this showed as: toggle a light → correct for <1 s → reverts to the old state → correct again only ~30 s later (Video 1 in the v1.10 feedback).

## Fix — optimistic guard

The coordinator now records every optimistic write (`update_cached_value`, `update_cached_nested`, `update_endpoint_power`) as a pending override with a short hold. On each poll, `_apply_optimistic_overrides` reconciles fresh cloud state against those overrides:

- **Cloud agrees** (polled value matches the optimistic one) → drop the override, trust the cloud from now on.
- **Still stale** → re-apply the optimistic value so the poll can't revert it.
- **Expired** (hold > 45 s, safely past the ~30 s propagation) → drop it, so a command the device actually rejected can't stick forever.

This makes the #109 reconcile safe too: its early, stale poll can no longer stomp the optimistic state.

## Trade-off

For a command the hardware genuinely rejects (e.g. commanding the ambient ring while the fan spins), the optimistic value is now held for up to 45 s before the cloud wins. That edge case is rare; the pervasive revert-on-every-command was the bigger problem. Modelling the ring/fan restriction is tracked separately (#106).

## Tests

`test_optimistic_guard.py` — stale poll held, released once the cloud agrees, expiry lets the cloud win, and per-endpoint power held.

## Related

Foundation for #106 (optimistic fan/light coupling) and helps the desync half of #112.
