### PR TITLE
feat(fan): mirror Cadix fan/light coupling optimistically on start

### DIFF
--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -199,8 +199,35 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
         node_id = self._device.node_id
         await self.coordinator.api.async_set_fan_speed(home_id, node_id, speed)
         self.coordinator.update_cached_value(node_id, "fan_speed", speed)
+        self._apply_cadix_light_coupling(starting=speed > 0)
         # Fan start/stop couples other kits in firmware (Cadix ring/main) — reconcile.
         self.coordinator.request_reconcile()
+
+    def _apply_cadix_light_coupling(self, *, starting: bool) -> None:
+        """Optimistically mirror the Cadix fan/light coupling (issue #106).
+
+        Starting the fan forces the ambient ring OFF (anti-strobe) and, when the
+        ring was lit, turns the main light ON so the room isn't left dark. These
+        firmware side effects otherwise only reach HA at the next cloud poll; the
+        optimistic guard (#111) keeps them from being reverted meanwhile. The
+        fan-stop restore is left to polling for now (it depends on the pre-start
+        state).
+        """
+        if not starting:
+            return
+        profile = self._device.profile
+        labels = f"{profile.device_name} {profile.referentiel_i18n} {profile.referentiel_model}"
+        if "cadix" not in labels.lower():
+            return
+        light_endpoints = profile.fan_light_endpoints
+        if len(light_endpoints) != 2:
+            return
+        main, ambient = light_endpoints[0], light_endpoints[1]
+        node_id = self._device.node_id
+        ring_was_on = self._device.reported.endpoint_power(ambient) == "ON"
+        self.coordinator.update_endpoint_power(node_id, ambient, "OFF")
+        if ring_was_on:
+            self.coordinator.update_endpoint_power(node_id, main, "ON")
 
     async def _set_motor_power(self, power: str) -> None:
         """ON/OFF fans without speed range — per-endpoint or global power API."""

--- a/tests/unit/test_fan_multi_light.py
+++ b/tests/unit/test_fan_multi_light.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from enki.coordinator import EnkiCoordinator
 from enki.domain.models import EnkiDevice
+from enki.fan import EnkiFanEntity
 from enki.light import EnkiFanLightEntity, _build_light_entities
 from homeassistant.components.light import ATTR_BRIGHTNESS
 
@@ -55,8 +56,10 @@ def _coordinator() -> MagicMock:
     coordinator = MagicMock()
     coordinator.api.async_switch_electrical_power = AsyncMock()
     coordinator.api.async_change_light_state = AsyncMock()
+    coordinator.api.async_set_fan_speed = AsyncMock()
     coordinator.update_endpoint_power = MagicMock()
     coordinator.update_cached_value = MagicMock()
+    coordinator.request_reconcile = MagicMock()
     coordinator.batch_updates = MagicMock(return_value=nullcontext())
     return coordinator
 
@@ -205,3 +208,47 @@ async def test_cadix_light_command_requests_reconcile() -> None:
     await light.async_turn_off()
 
     assert coordinator.request_reconcile.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cadix_fan_start_optimistically_couples_ring_off_and_main_on() -> None:
+    # Confirmed firmware coupling (#106): starting the fan forces the ambient
+    # ring OFF and, since it was lit, turns the main light ON to avoid darkness.
+    coordinator = _coordinator()
+    device = _cadix(
+        last_reported_value={
+            "electrical_endpoints": [
+                {"id": 1, "lastReportedValue": "OFF"},  # main off
+                {"id": 2, "lastReportedValue": "ON"},  # motor
+                {"id": 3, "lastReportedValue": "ON"},  # ambient ring on
+            ],
+        },
+    )
+    fan = EnkiFanEntity(coordinator, device)
+
+    await fan.async_turn_on(percentage=50)
+
+    coupled = {(c.args[1], c.args[2]) for c in coordinator.update_endpoint_power.call_args_list}
+    assert (3, "OFF") in coupled  # ring forced off
+    assert (1, "ON") in coupled  # main on to avoid darkness
+
+
+@pytest.mark.asyncio
+async def test_cadix_fan_start_leaves_main_untouched_when_ring_already_off() -> None:
+    coordinator = _coordinator()
+    device = _cadix(
+        last_reported_value={
+            "electrical_endpoints": [
+                {"id": 1, "lastReportedValue": "ON"},
+                {"id": 2, "lastReportedValue": "ON"},
+                {"id": 3, "lastReportedValue": "OFF"},  # ring already off
+            ],
+        },
+    )
+    fan = EnkiFanEntity(coordinator, device)
+
+    await fan.async_turn_on(percentage=50)
+
+    coupled = {(c.args[1], c.args[2]) for c in coordinator.update_endpoint_power.call_args_list}
+    assert (3, "OFF") in coupled  # ring stays off (idempotent)
+    assert not any(ep == 1 for ep, _ in coupled)  # main not forced


### PR DESCRIPTION
Part of #106. **Stacked on #113** (needs the optimistic guard) — base will collapse to `main` once #113 merges.

## What

When the fan is started from HA, the Cadix firmware forces the ambient ring OFF (anti-strobe) and turns the main light ON when the ring was lit (so the room isn't left dark). Those changes previously only reached HA at the next cloud poll (~30 s lag).

This applies them **optimistically** the moment the fan is toggled — protected by the #111 guard, so a stale poll can't revert them.

## Scope / confidence

- **Ring → OFF** on fan start: always applied (the firmware always cuts the ring while the blades spin — deterministic and confirmed).
- **Main → ON** on fan start: only when the ring was currently ON (matches the reporter's observed "avoid darkness" logic; leaves `main` untouched when the ring was already off, so the uncertain both-off case isn't guessed).
- Gated on the Cadix layout (referentiel label + exactly two light kits), so other fans are unaffected.

## Not included (follow-up on #106)

**Fan-stop restore** (ring returns to its pre-start state, main returns to its prior state) needs remembering the pre-fan light state and has only been confirmed in one scenario, so it's left to polling for now. Happy to add it with proper state tracking once we've confirmed a few more start/stop combinations with the reporter.

## Tests

- Ring lit → start couples ring OFF + main ON.
- Ring already off → start keeps ring OFF, leaves main untouched.
