### PR TITLE
feat(fan): restore Cadix pre-fan light state on stop

### DIFF
--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -78,6 +78,9 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         # node_id -> {path: (optimistic value, monotonic expiry)}. Holds optimistic
         # writes authoritative until the cloud reflects them or they expire (#111).
         self._overrides: dict[str, dict[tuple, tuple[Any, float]]] = {}
+        # node_id -> {endpoint: power} captured before a fan start, restored on stop
+        # to mirror the Cadix pre-fan light configuration optimistically (#106).
+        self._fan_light_restore: dict[str, dict[int, str | None]] = {}
         self.api = EnkiAPI(
             config_entry.data[CONF_USERNAME],
             config_entry.data[CONF_PASSWORD],
@@ -177,6 +180,14 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
             self._suspend_notify = previous
             if not previous:
                 self._notify()
+
+    def remember_fan_light_state(self, node_id: str, states: dict[int, str | None]) -> None:
+        """Snapshot light-endpoint power before a fan start (for stop-restore, #106)."""
+        self._fan_light_restore[node_id] = states
+
+    def pop_fan_light_state(self, node_id: str) -> dict[int, str | None] | None:
+        """Return and clear the pre-fan light snapshot, if any."""
+        return self._fan_light_restore.pop(node_id, None)
 
     def _record_override(self, node_id: str, path: tuple, value: Any) -> None:
         self._overrides.setdefault(node_id, {})[path] = (

--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -197,37 +197,59 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
     async def _set_speed(self, speed: int) -> None:
         home_id = self._device.home_id
         node_id = self._device.node_id
+        was_running = (self._device.reported.fan_speed or 0) > 0
         await self.coordinator.api.async_set_fan_speed(home_id, node_id, speed)
         self.coordinator.update_cached_value(node_id, "fan_speed", speed)
-        self._apply_cadix_light_coupling(starting=speed > 0)
+        now_running = speed > 0
+        if now_running and not was_running:
+            self._apply_cadix_light_coupling(starting=True)
+        elif was_running and not now_running:
+            self._apply_cadix_light_coupling(starting=False)
         # Fan start/stop couples other kits in firmware (Cadix ring/main) — reconcile.
         self.coordinator.request_reconcile()
+
+    def _cadix_light_endpoints(self) -> tuple[int, int] | None:
+        """(main, ambient) light endpoints for a Cadix layout, else None."""
+        profile = self._device.profile
+        labels = f"{profile.device_name} {profile.referentiel_i18n} {profile.referentiel_model}"
+        if "cadix" not in labels.lower():
+            return None
+        light_endpoints = profile.fan_light_endpoints
+        if len(light_endpoints) != 2:
+            return None
+        return light_endpoints[0], light_endpoints[1]
 
     def _apply_cadix_light_coupling(self, *, starting: bool) -> None:
         """Optimistically mirror the Cadix fan/light coupling (issue #106).
 
-        Starting the fan forces the ambient ring OFF (anti-strobe) and, when the
-        ring was lit, turns the main light ON so the room isn't left dark. These
-        firmware side effects otherwise only reach HA at the next cloud poll; the
-        optimistic guard (#111) keeps them from being reverted meanwhile. The
-        fan-stop restore is left to polling for now (it depends on the pre-start
-        state).
+        On start: remember the pre-fan light state, force the ambient ring OFF
+        (anti-strobe), and turn the main light ON when the ring was lit so the
+        room isn't left dark. On stop: restore that remembered configuration.
+        These firmware side effects otherwise only reach HA at the next cloud
+        poll; the optimistic guard (#111) keeps them from being reverted.
         """
-        if not starting:
+        endpoints = self._cadix_light_endpoints()
+        if endpoints is None:
             return
-        profile = self._device.profile
-        labels = f"{profile.device_name} {profile.referentiel_i18n} {profile.referentiel_model}"
-        if "cadix" not in labels.lower():
-            return
-        light_endpoints = profile.fan_light_endpoints
-        if len(light_endpoints) != 2:
-            return
-        main, ambient = light_endpoints[0], light_endpoints[1]
+        main, ambient = endpoints
         node_id = self._device.node_id
-        ring_was_on = self._device.reported.endpoint_power(ambient) == "ON"
-        self.coordinator.update_endpoint_power(node_id, ambient, "OFF")
-        if ring_was_on:
-            self.coordinator.update_endpoint_power(node_id, main, "ON")
+        reported = self._device.reported
+        if starting:
+            self.coordinator.remember_fan_light_state(
+                node_id,
+                {main: reported.endpoint_power(main), ambient: reported.endpoint_power(ambient)},
+            )
+            ring_was_on = reported.endpoint_power(ambient) == "ON"
+            self.coordinator.update_endpoint_power(node_id, ambient, "OFF")
+            if ring_was_on:
+                self.coordinator.update_endpoint_power(node_id, main, "ON")
+            return
+        saved = self.coordinator.pop_fan_light_state(node_id)
+        if not saved:
+            return
+        for endpoint, power in saved.items():
+            if power in ("ON", "OFF"):
+                self.coordinator.update_endpoint_power(node_id, endpoint, power)
 
     async def _set_motor_power(self, power: str) -> None:
         """ON/OFF fans without speed range — per-endpoint or global power API."""

--- a/tests/unit/test_fan_multi_light.py
+++ b/tests/unit/test_fan_multi_light.py
@@ -252,3 +252,61 @@ async def test_cadix_fan_start_leaves_main_untouched_when_ring_already_off() -> 
     coupled = {(c.args[1], c.args[2]) for c in coordinator.update_endpoint_power.call_args_list}
     assert (3, "OFF") in coupled  # ring stays off (idempotent)
     assert not any(ep == 1 for ep, _ in coupled)  # main not forced
+
+
+@pytest.mark.asyncio
+async def test_cadix_fan_start_remembers_pre_fan_light_state() -> None:
+    coordinator = _coordinator()
+    coordinator.remember_fan_light_state = MagicMock()
+    device = _cadix(
+        last_reported_value={
+            "electrical_endpoints": [
+                {"id": 1, "lastReportedValue": "OFF"},
+                {"id": 2, "lastReportedValue": "ON"},  # motor
+                {"id": 3, "lastReportedValue": "ON"},
+            ],
+        },
+    )
+    fan = EnkiFanEntity(coordinator, device)
+
+    await fan.async_turn_on(percentage=50)
+
+    coordinator.remember_fan_light_state.assert_called_once_with("node-cadix", {1: "OFF", 3: "ON"})
+
+
+@pytest.mark.asyncio
+async def test_cadix_fan_stop_restores_saved_light_state() -> None:
+    coordinator = _coordinator()
+    coordinator.pop_fan_light_state = MagicMock(return_value={1: "OFF", 3: "ON"})
+    device = _cadix(
+        last_reported_value={
+            "fan_speed": 2,  # already running → turning off is a stop transition
+            "electrical_endpoints": [
+                {"id": 1, "lastReportedValue": "ON"},
+                {"id": 2, "lastReportedValue": "ON"},  # motor
+                {"id": 3, "lastReportedValue": "OFF"},
+            ],
+        },
+    )
+    fan = EnkiFanEntity(coordinator, device)
+
+    await fan.async_turn_off()
+
+    restored = {(c.args[1], c.args[2]) for c in coordinator.update_endpoint_power.call_args_list}
+    assert (1, "OFF") in restored
+    assert (3, "ON") in restored
+
+
+@pytest.mark.asyncio
+async def test_cadix_fan_speed_change_while_running_does_not_recouple() -> None:
+    coordinator = _coordinator()
+    coordinator.remember_fan_light_state = MagicMock()
+    coordinator.pop_fan_light_state = MagicMock()
+    device = _cadix(last_reported_value={"fan_speed": 2})
+    fan = EnkiFanEntity(coordinator, device)
+
+    await fan.async_set_percentage(80)  # running → running, not a start/stop
+
+    coordinator.remember_fan_light_state.assert_not_called()
+    coordinator.pop_fan_light_state.assert_not_called()
+    coordinator.update_endpoint_power.assert_not_called()


### PR DESCRIPTION
Completes the optimistic side of #106.

## What

The Cadix restores its pre-fan light configuration when the fan stops — main and ambient return to whatever they were before it started. That transition previously only reached HA at the next cloud poll (~30 s).

The fan-start coupling now **snapshots** the two light endpoints' power, and **fan-stop restores** it optimistically (guarded by #111 so a stale poll can't revert it).

## Details

- Coupling now fires only on real **off→on / on→off** transitions, so changing speed while the fan runs no longer disturbs the lights.
- Restore covers **power** (main/ambient ON/OFF). Brightness is a shared node value and is left to polling (tracked in #117).

## Confirmed model (from @ShanoLores's four-combination test)

- Main ON before start → preserved. Ambient → OFF.
- Main OFF + Ambient ON → Ambient OFF, Main ON.
- Stop → previous configuration restored.

## Tests

Start snapshots pre-fan state; stop restores it; speed change while running does not re-couple.
