### PR TITLE
feat(binary_sensor): expose dry-contact electric-strike state

### DIFF
--- a/custom_components/enki/api/capability_routing.py
+++ b/custom_components/enki/api/capability_routing.py
@@ -48,6 +48,11 @@ CAPABILITY_READS: tuple[CapabilityRead, ...] = (
         "check_vibration_sensibility_level",
         "vibration_sensibility_level",
     ),
+    CapabilityRead(
+        "power",
+        "check_dry_contact_for_electric_strike_state",
+        "dry_contact_state",
+    ),
     CapabilityRead("siren", "check_siren_global_state", "siren_global_state"),
     CapabilityRead("water_sensor", "check_water_sensor_state", "water_sensor_state"),
     CapabilityRead("thermostat", "check_pilot_wire_state", "pilot_wire_state"),

--- a/custom_components/enki/binary_sensor.py
+++ b/custom_components/enki/binary_sensor.py
@@ -64,6 +64,13 @@ _BINARY_SENSOR_SPECS: tuple[dict[str, str | BinarySensorDeviceClass], ...] = (
         "device_class": BinarySensorDeviceClass.OPENING,
     },
     {
+        "capability": "check_dry_contact_for_electric_strike_state",
+        "state_key": "dry_contact_state",
+        "suffix": "dry_contact",
+        "translation_key": "dry_contact",
+        "device_class": BinarySensorDeviceClass.OPENING,
+    },
+    {
         "capability": "check_water_sensor_state",
         "state_key": "water_sensor_state",
         "suffix": "water_leak",

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -274,6 +274,14 @@ class EnkiCapabilityProfile:
         )
 
     @property
+    def supports_dry_contact_state(self) -> bool:
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "check_dry_contact_for_electric_strike_state",
+        )
+
+    @property
     def supports_vibration_detection_activation(self) -> bool:
         return _supports(
             self.capabilities,
@@ -485,6 +493,7 @@ class EnkiCapabilityProfile:
             or self.supports_water_leak
             or self.supports_window_open_detection
             or self.supports_occupancy
+            or self.supports_dry_contact_state
         )
 
     @property

--- a/custom_components/enki/domain/profile.py
+++ b/custom_components/enki/domain/profile.py
@@ -71,6 +71,7 @@ _POLL_STATE_EXPORT_KEYS = frozenset(
         "motion_detector_state",
         "vibration_detection",
         "contact_sensor_state",
+        "dry_contact_state",
         "vibration_detection_activation",
         "contact_detection_activation",
         "vibration_sensibility_level",

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -55,6 +55,7 @@ _CAPABILITY_PROBES: dict[str, str] = {
     "check_color_temperature": "supports_color_temperature",
     "check_contact_detection_activation": "supports_contact_detection_activation",
     "check_contact_sensor_state": "supports_contact_sensor",
+    "check_dry_contact_for_electric_strike_state": "supports_dry_contact_state",
     "check_current_humidity": "supports_current_humidity",
     "check_current_temperature": "supports_current_temperature",
     "check_illuminance_level": "supports_illuminance_level",

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -129,6 +129,9 @@
       "contact": {
         "name": "Contact"
       },
+      "dry_contact": {
+        "name": "Dry contact"
+      },
       "water_leak": {
         "name": "Water leak"
       },

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -129,6 +129,9 @@
       "contact": {
         "name": "Contact"
       },
+      "dry_contact": {
+        "name": "Dry contact"
+      },
       "water_leak": {
         "name": "Water leak"
       },

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -129,6 +129,9 @@
       "contact": {
         "name": "Contact"
       },
+      "dry_contact": {
+        "name": "Contact sec"
+      },
       "water_leak": {
         "name": "Fuite d'eau"
       },

--- a/tests/unit/test_dry_contact_sensor.py
+++ b/tests/unit/test_dry_contact_sensor.py
@@ -1,0 +1,66 @@
+"""Dry-contact / electric-strike state as a binary sensor (issue #121)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from enki.api.capability_routing import CAPABILITY_READS
+from enki.binary_sensor import _build_binary_sensor_entities
+from enki.domain.models import EnkiDevice
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+_CAPABILITY = "check_dry_contact_for_electric_strike_state"
+
+
+def _module(**overrides) -> EnkiDevice:
+    defaults = {
+        "home_id": "home",
+        "device_id": "dev",
+        "node_id": "node-module",
+        "device_name": "Module Eclairage",
+        "device_type": "modules",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["power_on_with_timer", "check_electrical_power", _CAPABILITY],
+        "last_reported_value": {"dry_contact_state": "OPENED"},
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def test_profile_flags_dry_contact_binary_sensor() -> None:
+    profile = _module().profile
+    assert profile.supports_dry_contact_state is True
+    assert profile.is_binary_sensor is True
+
+
+def test_capability_read_routes_dry_contact_via_power_service() -> None:
+    read = next((r for r in CAPABILITY_READS if r.capability == _CAPABILITY), None)
+    assert read is not None
+    assert read.transport_id == "power"
+    assert read.state_key == "dry_contact_state"
+
+
+def test_builds_dry_contact_binary_sensor() -> None:
+    entities = _build_binary_sensor_entities(MagicMock(), _module())
+    sensor = next(e for e in entities if e._state_key == "dry_contact_state")
+    assert sensor._attr_device_class == BinarySensorDeviceClass.OPENING
+    assert sensor._attr_translation_key == "dry_contact"
+
+
+def test_dry_contact_is_on_maps_open_closed() -> None:
+    sensor = next(
+        e
+        for e in _build_binary_sensor_entities(MagicMock(), _module())
+        if e._state_key == "dry_contact_state"
+    )
+    assert sensor.is_on is True  # OPENED
+
+    closed = next(
+        e
+        for e in _build_binary_sensor_entities(
+            MagicMock(), _module(last_reported_value={"dry_contact_state": "CLOSED"})
+        )
+        if e._state_key == "dry_contact_state"
+    )
+    assert closed.is_on is False


### PR DESCRIPTION
Closes #121.

## What

The Evology dry-contact / electric-strike module left `check_dry_contact_for_electric_strike_state` uncovered. This reads it (via the power micro-service, same as the module's `power_on_with_timer`) and exposes it as an **opening** binary sensor.

## Changes

- `CapabilityRead` for the capability → `dry_contact_state`.
- Binary-sensor spec + `supports_dry_contact_state` (makes the module a binary-sensor device).
- Capability marked covered in telemetry; `dry_contact_state` added to the diagnostics export.
- `dry_contact` translation (en/fr).

## Needs confirmation on hardware

The **service routing** (`power`) and the **state values** are inferred — no live sample of this capability yet. The read is best-effort (a wrong route just logs and skips), and `dry_contact_state` is now in the diagnostics export, so a fresh diagnostic from @BOEKTAELS will confirm the raw value. If it isn't `OPENED`/`CLOSED`, the on/off mapping is a one-line follow-up.

## Tests

Profile flag, capability routing, sensor build, and open/closed mapping.
