### PR TITLE
fix(telemetry): mark check_bulb_state as covered

### DIFF
--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -63,6 +63,7 @@ _CAPABILITY_PROBES: dict[str, str] = {
     "check_electrical_consumption": "supports_electrical_consumption",
     "check_fan_rotation_direction": "supports_fan_rotation",
     "check_fan_speed": "supports_fan_speed",
+    "check_bulb_state": "supports_light_state",
     "check_light_state": "supports_light_state",
     "check_motion_detection": "supports_motion_detection",
     "check_motion_detector_state": "supports_motion_detection",

--- a/tests/unit/test_telemetry_coverage.py
+++ b/tests/unit/test_telemetry_coverage.py
@@ -234,3 +234,27 @@ def test_lexman_shutter_capabilities_are_covered() -> None:
     assert capability_is_covered("check_roller_shutter_state", profile) is True
     assert capability_is_covered("change_roller_shutter_mode", profile) is True
     assert capability_is_covered("execute_preset", profile) is True
+
+
+def test_check_bulb_state_covered_for_cct_bulb() -> None:
+    # Eglo EG-FWCCT8-1 (issue #122): the bulb works as a light, so check_bulb_state
+    # is covered by the light entity and must not be flagged as a capability gap.
+    record = build_discovery_record(
+        device_type="lights",
+        bff_device_type="lights",
+        capabilities=[
+            "switch_electrical_power",
+            "change_light_state",
+            "check_light_state",
+            "change_brightness",
+            "change_color_temperature",
+            "check_bulb_state",
+        ],
+        possible_values={},
+        manufacturer="Eglo",
+        model="EG-FWCCT8-1",
+        firmware_version="2.0.0",
+        supported_by_integration=True,
+    )
+    profile = profile_from_record(record)
+    assert capability_is_covered("check_bulb_state", profile) is True


### PR DESCRIPTION
The Eglo EG-FWCCT8-1 works fully as a light (brightness, color temperature, on/off all report correctly). Its only "uncovered" capability was `check_bulb_state`, which is just the bulb's on/off state — already surfaced by the light entity via `check_light_state`.

Map it to `supports_light_state` so it counts as covered and stops raising a false capability-gap telemetry report for CCT bulbs.
