### PR TITLE
fix(telemetry): mark check_multisensor_state as covered

### DIFF
--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -9,9 +9,12 @@ from ..lib.enki_scope import device_in_enki_scope
 from .capabilities import EnkiCapabilityProfile
 from .models import EnkiDiscoveryRecord
 
-# Device lifecycle / admin / SDK plumbing — not exposed as Home Assistant entities.
+# Device lifecycle / admin / SDK plumbing, plus composite/aggregate states with no
+# separate HA entity — not exposed as Home Assistant entities.
 # Firmware *check* uses check_current_firmware_version + ota_inventory (binary_sensor).
 # SDK inventory / upgrade commands (update_sdk_firmware, …) are not planned as HA actions.
+# check_multisensor_state is a bundled read; its temperature / humidity / motion /
+# illuminance channels are each already exposed as their own entity.
 _TELEMETRY_IGNORED_CAPABILITIES = frozenset(
     {
         "ack_sdk_device_inventory_update",
@@ -19,6 +22,7 @@ _TELEMETRY_IGNORED_CAPABILITIES = frozenset(
         "check_certificate_renewal_confirmation",
         "check_current_firmware_version",
         "check_esdk_certificate_renewal",
+        "check_multisensor_state",
         "check_sdk_firmware_upgrade",
         "execute_generic_ota_command",
         "node_connected",

--- a/tests/unit/test_telemetry_coverage.py
+++ b/tests/unit/test_telemetry_coverage.py
@@ -258,3 +258,28 @@ def test_check_bulb_state_covered_for_cct_bulb() -> None:
     )
     profile = profile_from_record(record)
     assert capability_is_covered("check_bulb_state", profile) is True
+
+
+def test_check_multisensor_state_covered() -> None:
+    # Lexman 4-in-1 multisensor (issue #126): the composite check_multisensor_state
+    # has no dedicated entity — its channels are exposed individually — so it must
+    # not be flagged as a capability gap.
+    record = build_discovery_record(
+        device_type="sensors",
+        bff_device_type="sensors",
+        capabilities=[
+            "check_battery_health",
+            "check_current_humidity",
+            "check_current_temperature",
+            "check_illuminance_level",
+            "check_motion_detection",
+            "check_multisensor_state",
+        ],
+        possible_values={},
+        manufacturer="Lexman",
+        model="ref 651eb5245b3a",
+        firmware_version="2.0.0",
+        supported_by_integration=True,
+    )
+    profile = profile_from_record(record)
+    assert capability_is_covered("check_multisensor_state", profile) is True


### PR DESCRIPTION
Refs #126.

The Lexman 4-in-1 multisensor (`ref 651eb5245b3a`) already works: temperature, humidity, motion and illuminance are each exposed as their own entity, plus battery. Its only "uncovered" capability was `check_multisensor_state` — a bundled/composite read with no separate HA representation.

Mark it as covered so it no longer raises a false capability-gap telemetry report for multisensors.

_(The `luminosity_sensor/check_illuminance_level → HTTP 403` in the report is a separate gateway-key issue, not addressed here.)_
