### PR TITLE
fix(discovery): skip dashboard items missing deviceId

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -232,7 +232,11 @@ class EnkiAPI:
             item: dict[str, Any],
         ) -> tuple[EnkiDevice | None, EnkiDiscoveryRecord | None]:
             async with semaphore:
-                return await self._discover_dashboard_item(http, home_id, item)
+                try:
+                    return await self._discover_dashboard_item(http, home_id, item)
+                except Exception as err:  # noqa: BLE001 — one item must not break discovery
+                    LOGGER.debug("Dashboard item skipped in home %s: %s", home_id, err)
+                    return None, None
 
         results = await asyncio.gather(*(discover_item(item) for item in items))
 
@@ -261,7 +265,7 @@ class EnkiAPI:
         item: dict[str, Any],
     ) -> tuple[EnkiDevice | None, EnkiDiscoveryRecord | None]:
         metadata = item.get("metadata", {})
-        if "nodeId" not in metadata:
+        if "nodeId" not in metadata or "deviceId" not in metadata:
             return None, None
 
         node_id = metadata["nodeId"]

--- a/tests/unit/test_discovery_missing_device_id.py
+++ b/tests/unit/test_discovery_missing_device_id.py
@@ -1,0 +1,37 @@
+"""Discovery must not crash on dashboard items missing deviceId (issue #126 comment)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from enki.api.client import EnkiAPI
+
+
+@pytest.mark.asyncio
+async def test_dashboard_item_without_device_id_is_skipped() -> None:
+    api = EnkiAPI("user", "pass")
+    # metadata has nodeId but no deviceId — used to raise KeyError and break the poll.
+    result = await api._discover_dashboard_item(MagicMock(), "home", {"metadata": {"nodeId": "n1"}})
+    assert result == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_discover_home_isolates_a_failing_item() -> None:
+    api = EnkiAPI("user", "pass")
+    http = MagicMock()
+    http.get_dashboard = AsyncMock(
+        return_value={"sections": [{"items": [{"bad": True}, {"good": True}]}]}
+    )
+
+    async def fake_item(_http, _home, item):
+        if item.get("good"):
+            return "dev", "rec"
+        raise RuntimeError("boom")
+
+    with patch.object(EnkiAPI, "_discover_dashboard_item", AsyncMock(side_effect=fake_item)):
+        devices, records = await api._discover_home(http, "home")
+
+    # The failing item is skipped, the good one still discovered.
+    assert devices == ["dev"]
+    assert records == ["rec"]


### PR DESCRIPTION
Refs #131.

Reported by @graindcafe in a comment on #126 — they had to patch `client.py` for setup to succeed.

`_discover_dashboard_item` read `metadata["deviceId"]` while only guarding `nodeId`. A dashboard item with a `nodeId` but no `deviceId` raised `KeyError`, and since items were gathered without per-item error handling, it aborted the **whole** discovery and blocked setup.

- Guard `deviceId` alongside `nodeId` (skip the item cleanly).
- Isolate per-item failures in `_discover_home`, so one malformed device can never break the poll again.

Tests: item without `deviceId` is skipped; a failing item doesn't stop the others from being discovered.
