### PR TITLE
ci(release): pending-release label, then close issues on release

### DIFF
--- a/.github/workflows/pending-release.yml
+++ b/.github/workflows/pending-release.yml
@@ -1,0 +1,46 @@
+name: Pending release
+
+# When a PR referencing an issue (Refs #N, fixes #N, …) merges to main, mark
+# that issue "pending release". It is closed + labelled "released" later, when
+# the version actually ships (see release-please.yml → close-released-issues).
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  issues: write
+
+jobs:
+  label-referenced-issues:
+    name: label-referenced-issues
+    if: >-
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'release-please--')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const text = `${pr.title}\n${pr.body || ''}`;
+            const re = /\b(?:refs?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|related to|see)\s+#(\d+)/gi;
+            const numbers = new Set([...text.matchAll(re)].map((m) => Number(m[1])));
+            for (const number of numbers) {
+              try {
+                const { data } = await github.rest.issues.get({ ...context.repo, issue_number: number });
+                if (data.pull_request || data.state === 'closed') continue;
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: number,
+                  labels: ['pending release'],
+                });
+                core.info(`#${number} → pending release`);
+              } catch (err) {
+                core.info(`Skip #${number}: ${err.message}`);
+              }
+            }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,3 +56,43 @@ jobs:
             ## Install
 
             HACS → Enki → Update, then restart Home Assistant.
+
+  close-released-issues:
+    name: close-released-issues
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      # Everything merged to main since the last release ships in this tag, so
+      # close every "pending release" issue, swap the label to "released", and
+      # note the version.
+      - uses: actions/github-script@v7
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        with:
+          script: |
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo,
+              state: 'open',
+              labels: 'pending release',
+              per_page: 100,
+            });
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              await github.rest.issues.removeLabel({
+                ...context.repo, issue_number: issue.number, name: 'pending release',
+              }).catch(() => {});
+              await github.rest.issues.addLabels({
+                ...context.repo, issue_number: issue.number, labels: ['released'],
+              });
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number, body: `Released in ${process.env.TAG}. 🎉`,
+              });
+              await github.rest.issues.update({
+                ...context.repo, issue_number: issue.number, state: 'closed', state_reason: 'completed',
+              });
+              core.info(`Closed #${issue.number} (released in ${process.env.TAG})`);
+            }


### PR DESCRIPTION
Automates the issue lifecycle, while keeping `Refs #N` (so nothing closes on merge):

**1. On PR merge to `main`** (`pending-release.yml`) — parses the PR for issue references (`Refs #N`, `fixes #N`, …) and labels each referenced issue **`pending release`**. Skips the release-please PR and already-closed issues.

**2. On release** (`close-released-issues` job in `release-please.yml`, gated on `release_created`) — every open **`pending release`** issue is **closed** (`completed`), the label is swapped to **`released`**, and a `Released in vX.Y.Z 🎉` comment is added.

So: merge → `pending release` (open), version ships → closed + `released`. The issue closes exactly at release time, not at merge.

Notes:
- Both labels already exist (release-please uses them on its own release PR; here they're applied to issues too — consistent meaning).
- Uses `actions/github-script`; PR text is read from `context.payload` (no `${{ }}` injection).
- `.github/` is in release-please `exclude-paths`, so this doesn't bump the version.
