### PR TITLE
feat(scripts): add --raw mode to dump dashboard shape

### DIFF
--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -4,6 +4,7 @@
 Usage:
     python3 scripts/discover_devices.py <email> <password>
     python3 scripts/discover_devices.py <email> <password> --export
+    python3 scripts/discover_devices.py <email> <password> --raw
 """
 
 from __future__ import annotations
@@ -26,6 +27,34 @@ EnkiAPI = client_mod.EnkiAPI
 profile_fingerprint = profile_mod.profile_fingerprint
 profile_to_export_dict = profile_mod.profile_to_export_dict
 enrich_telemetry_export = enrichment_mod.enrich_telemetry_export
+
+
+async def dump_raw(username: str, password: str) -> None:
+    """Print the shape of the homes + dashboard responses (keys/counts only, no ids).
+
+    Helps diagnose empty discovery: shows whether homes are returned and whether
+    the dashboard actually carries device items, without leaking any identifiers.
+    """
+    api = EnkiAPI(username, password)
+    await api.async_connect()
+    http = await api._get_http()
+
+    homes = await http.get_homes()
+    print(f"homes: {len(homes)}")
+    for index, home_id in enumerate(homes):
+        dashboard = await http.get_dashboard(home_id)
+        sections = dashboard.get("sections", []) if isinstance(dashboard, dict) else []
+        print(f"home[{index}]: dashboard_keys={sorted(dashboard)} sections={len(sections)}")
+        for s_index, section in enumerate(sections):
+            items = section.get("items", []) if isinstance(section, dict) else []
+            print(f"  section[{s_index}]: keys={sorted(section)} items={len(items)}")
+            for item in items:
+                metadata = item.get("metadata", {}) if isinstance(item, dict) else {}
+                print(
+                    f"    item: keys={sorted(item)} "
+                    f"metadata_keys={sorted(metadata)} deviceType={metadata.get('deviceType')!r}"
+                )
+    await api.async_close()
 
 
 async def main(username: str, password: str, export_json: bool) -> None:
@@ -70,9 +99,17 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Output a single JSON array (anonymized profiles)",
     )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Dump the homes + dashboard shape (keys/counts only) to debug empty discovery",
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    asyncio.run(main(args.username, args.password, args.export))
+    if args.raw:
+        asyncio.run(dump_raw(args.username, args.password))
+    else:
+        asyncio.run(main(args.username, args.password, args.export))


### PR DESCRIPTION
Refs #130.

Adds `--raw` to `scripts/discover_devices.py`: it dumps the shape of the `homes` and `dashboard` API responses — section/item counts, item keys, `metadata` keys and `deviceType` — **without any identifiers** (keys and counts only).

This is to diagnose "no devices discovered" reports (#130): discovery walks `dashboard.sections[].items[]`, so if that comes back empty (or Enki changed the structure), we get zero devices even though the account has devices. `--raw` shows exactly where the emptiness is.

```
python3 scripts/discover_devices.py '<email>' '<password>' --raw
```
