### PR TITLE
ci(release): mark issues released without closing them

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,8 +57,8 @@ jobs:
 
             HACS → Enki → Update, then restart Home Assistant.
 
-  close-released-issues:
-    name: close-released-issues
+  mark-released-issues:
+    name: mark-released-issues
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
@@ -67,8 +67,8 @@ jobs:
       issues: write
     steps:
       # Everything merged to main since the last release ships in this tag, so
-      # close every "pending release" issue, swap the label to "released", and
-      # note the version.
+      # swap "pending release" → "released" and note the version. Issues stay
+      # OPEN on purpose — closing them is left to the maintainer.
       - uses: actions/github-script@v9
         env:
           TAG: ${{ needs.release-please.outputs.tag_name }}
@@ -91,8 +91,5 @@ jobs:
               await github.rest.issues.createComment({
                 ...context.repo, issue_number: issue.number, body: `Released in ${process.env.TAG}. 🎉`,
               });
-              await github.rest.issues.update({
-                ...context.repo, issue_number: issue.number, state: 'closed', state_reason: 'completed',
-              });
-              core.info(`Closed #${issue.number} (released in ${process.env.TAG})`);
+              core.info(`#${issue.number} → released (${process.env.TAG})`);
             }


### PR DESCRIPTION
Adjusts the release automation (from #133): on release, `pending release` issues are now **marked `released` + commented with the tag, but left OPEN**. Closing them is the maintainer's call, not automatic.

- Renamed the job `close-released-issues` → `mark-released-issues`.
- Dropped the `state: closed` update; kept the label swap (`pending release` → `released`) and the `Released in vX.Y.Z` comment.
