### PR TITLE
fix(issue-template): quote description with colon in bug.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -36,7 +36,7 @@ body:
   - type: textarea
     attributes:
       label: Debug logs
-      description: Enable logger `enki: debug` in configuration.yaml
+      description: "Enable logger `enki: debug` in configuration.yaml"
       render: text
     validations:
       required: true


### PR DESCRIPTION
## Problem

The **Bug report** template never showed up in the new-issue chooser (`blank_issues_enabled: false`, only Feature request / Device profile / Blank appeared). GitHub was silently rejecting `bug.yml`:

> YAML syntax error: mapping values are not allowed in this context at line 39 column 39

## Cause

The Debug logs `description` was unquoted:

```yaml
description: Enable logger `enki: debug` in configuration.yaml
```

The `: ` inside `enki: debug` is parsed by YAML as a mapping separator, which is invalid there — so the whole form failed to parse and GitHub dropped it from the chooser.

## Fix

Quote the value:

```yaml
description: "Enable logger `enki: debug` in configuration.yaml"
```

All four templates now parse cleanly (verified with `yaml.safe_load`), so **Bug report** reappears in the chooser.

Surfaced via #143, where the reporter opened a one-line bare issue because the Bug report form wasn't offered.

Refs #143