### PR TITLE
ci(codeql): add code scanning workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: CodeQL config
+
+# Broader security query pack than the default suite.
+queries:
+  - uses: security-extended
+
+# Analyze the integration and its tooling; tests are excluded.
+paths:
+  - custom_components/enki
+  - scripts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 5 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"


### PR DESCRIPTION
## What

Adds GitHub **code scanning** via CodeQL, configured entirely in YAML:

- `.github/workflows/codeql.yml` — analyzes Python on push/PR to `main`, weekly (Mon 05:30 UTC), and on demand (`workflow_dispatch`).
- `.github/codeql/codeql-config.yml` — `security-extended` query pack, scoped to `custom_components/enki` and `scripts` (tests excluded).

`build-mode: none` since Python is interpreted (no compile step). Job permissions follow the repo convention: top-level `permissions: {}`, `security-events: write` only where needed.

## Result

Once merged and the workflow runs on `main`, findings appear under **Security → Code scanning**, and new alerts are annotated inline on PRs.

## Note for the maintainer

If **Default setup** for code scanning is currently enabled in *Settings → Security → Code scanning*, GitHub won't run this advanced workflow alongside it — pick one. This PR is the *advanced* (config-as-code) path; if default setup is on, switch it off after merge so this workflow drives scanning.