### PR TITLE
feat(diagnostics): anonymized request/response report on API failures

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -66,9 +66,11 @@ class EnkiAPI:
         self._scenarios: tuple[EnkiScenario, ...] = ()
         self._node_fingerprints: dict[str, str] = {}
         self._profile_read_errors: dict[str, dict[str, str]] = {}
+        self._profile_read_reports: dict[str, dict[str, dict[str, Any]]] = {}
         self._profile_poll_state: dict[str, dict[str, Any]] = {}
         self._pending_fingerprints: dict[str, str] = {}
         self._pending_read_errors: dict[str, dict[str, str]] = {}
+        self._pending_read_reports: dict[str, dict[str, dict[str, Any]]] = {}
         self._pending_poll_state: dict[str, dict[str, Any]] = {}
 
     async def async_close(self) -> None:
@@ -122,6 +124,7 @@ class EnkiAPI:
         # good whenever a poll raised after the reset.
         self._pending_fingerprints = {}
         self._pending_read_errors = {}
+        self._pending_read_reports = {}
         self._pending_poll_state = {}
 
         devices: list[EnkiDevice] = []
@@ -134,6 +137,7 @@ class EnkiAPI:
         self._discovery_records = records
         self._node_fingerprints = self._pending_fingerprints
         self._profile_read_errors = self._pending_read_errors
+        self._profile_read_reports = self._pending_read_reports
         self._profile_poll_state = self._pending_poll_state
         return devices
 
@@ -144,6 +148,10 @@ class EnkiAPI:
     def read_errors_for_fingerprint(self, fingerprint: str) -> dict[str, str]:
         """Anonymized API read failures from the last poll (no node or home ids)."""
         return dict(self._profile_read_errors.get(fingerprint, {}))
+
+    def read_reports_for_fingerprint(self, fingerprint: str) -> dict[str, dict[str, Any]]:
+        """Anonymized full request/response reports for the last poll's read failures."""
+        return dict(self._profile_read_reports.get(fingerprint, {}))
 
     def poll_state_for_fingerprint(self, fingerprint: str) -> dict[str, Any]:
         """Anonymized state values merged from the last poll (no node or home ids)."""
@@ -176,6 +184,9 @@ class EnkiAPI:
         label = f"HTTP {status}" if status else err.__class__.__name__
         key = f"{service}/{capability}"
         self._pending_read_errors.setdefault(fingerprint, {})[key] = label
+        report = getattr(err, "report", None)
+        if report:
+            self._pending_read_reports.setdefault(fingerprint, {})[key] = report
 
     @property
     def scenarios(self) -> tuple[EnkiScenario, ...]:

--- a/custom_components/enki/api/transport.py
+++ b/custom_components/enki/api/transport.py
@@ -22,6 +22,23 @@ from .auth import EnkiAuthSession
 from .gateway_keys import GatewayKeyStore
 from .gateway_registry import OPTIONAL_KEY_TRANSPORT_IDS, WIRED_PATH_PREFIXES
 
+_ERROR_BODY_MAX = 200
+
+
+def _http_error_message(method: str, path: str, status: int, body: str) -> str:
+    """Build an error message that carries the response body's reason, if any.
+
+    Enki's gateway returns the actual cause (e.g. a validation message) in the
+    body; surfacing a trimmed snippet turns an opaque "HTTP 400" into something
+    actionable in the Home Assistant logbook. The snippet stays in the exception
+    message only — read-error telemetry keeps just the status code.
+    """
+    message = f"{method} {path} failed: HTTP {status}"
+    detail = " ".join(body.split())
+    if detail:
+        message = f"{message}: {detail[:_ERROR_BODY_MAX]}"
+    return message
+
 
 class EnkiHttpClient:
     """Authenticated requests against Enki cloud micro-services.
@@ -120,7 +137,7 @@ class EnkiHttpClient:
                 raise EnkiApiNotFoundError(f"GET {path} not found", status=404)
             if response.status != 200:
                 raise EnkiConnectionError(
-                    f"GET {path} failed: HTTP {response.status}",
+                    _http_error_message("GET", path, response.status, await response.text()),
                     status=response.status,
                     service=service,
                 )
@@ -164,7 +181,7 @@ class EnkiHttpClient:
                 raise EnkiApiNotFoundError(f"POST {path} not found", status=404)
             if not is_command_success_status(response.status):
                 raise EnkiConnectionError(
-                    f"POST {path} failed: HTTP {response.status}",
+                    _http_error_message("POST", path, response.status, await response.text()),
                     status=response.status,
                     service=service,
                 )

--- a/custom_components/enki/api/transport.py
+++ b/custom_components/enki/api/transport.py
@@ -18,6 +18,7 @@ from ..lib.command_override import (
     override_end_time_iso,
 )
 from ..lib.conversion import is_command_success_status
+from ..lib.request_report import build_request_report
 from .auth import EnkiAuthSession
 from .gateway_keys import GatewayKeyStore
 from .gateway_registry import OPTIONAL_KEY_TRANSPORT_IDS, WIRED_PATH_PREFIXES
@@ -136,10 +137,19 @@ class EnkiHttpClient:
             if response.status == 404:
                 raise EnkiApiNotFoundError(f"GET {path} not found", status=404)
             if response.status != 200:
+                body = await response.text()
                 raise EnkiConnectionError(
-                    _http_error_message("GET", path, response.status, await response.text()),
+                    _http_error_message("GET", path, response.status, body),
                     status=response.status,
                     service=service,
+                    report=build_request_report(
+                        "GET",
+                        path,
+                        self._headers(service, home_id),
+                        params,
+                        response.status,
+                        body,
+                    ),
                 )
             # Some Enki GET endpoints occasionally answer 200 with an empty or
             # non-JSON body; response.json() would raise on those, so read text
@@ -180,10 +190,19 @@ class EnkiHttpClient:
             if response.status == 404 and not_found_ok:
                 raise EnkiApiNotFoundError(f"POST {path} not found", status=404)
             if not is_command_success_status(response.status):
+                body = await response.text()
                 raise EnkiConnectionError(
-                    _http_error_message("POST", path, response.status, await response.text()),
+                    _http_error_message("POST", path, response.status, body),
                     status=response.status,
                     service=service,
+                    report=build_request_report(
+                        "POST",
+                        path,
+                        self._headers(service, home_id),
+                        json,
+                        response.status,
+                        body,
+                    ),
                 )
 
     async def get_homes(self) -> list[str]:

--- a/custom_components/enki/diagnostics.py
+++ b/custom_components/enki/diagnostics.py
@@ -39,6 +39,7 @@ async def async_get_config_entry_diagnostics(
                 export,
                 record,
                 api_read_errors=coordinator.api.read_errors_for_fingerprint(fingerprint) or None,
+                api_read_reports=coordinator.api.read_reports_for_fingerprint(fingerprint) or None,
                 last_poll_state=coordinator.api.poll_state_for_fingerprint(fingerprint) or None,
             )
         )

--- a/custom_components/enki/domain/telemetry_enrichment.py
+++ b/custom_components/enki/domain/telemetry_enrichment.py
@@ -122,6 +122,7 @@ def enrich_telemetry_export(
     record: EnkiDiscoveryRecord,
     *,
     api_read_errors: dict[str, str] | None = None,
+    api_read_reports: dict[str, dict[str, Any]] | None = None,
     last_poll_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Add non-fingerprint fields for diagnostics and GitHub prefill."""
@@ -141,6 +142,9 @@ def enrich_telemetry_export(
 
     if api_read_errors:
         enriched["api_read_errors"] = dict(sorted(api_read_errors.items()))
+
+    if api_read_reports:
+        enriched["api_read_reports"] = dict(sorted(api_read_reports.items()))
 
     reason = telemetry_notification_reason(
         record,

--- a/custom_components/enki/exceptions.py
+++ b/custom_components/enki/exceptions.py
@@ -18,10 +18,12 @@ class EnkiConnectionError(EnkiError):
         *,
         status: int | None = None,
         service: str | None = None,
+        report: dict[str, object] | None = None,
     ) -> None:
         super().__init__(message)
         self.status = status
         self.service = service
+        self.report = report
 
 
 class EnkiApiNotFoundError(EnkiConnectionError):

--- a/custom_components/enki/lib/request_report.py
+++ b/custom_components/enki/lib/request_report.py
@@ -1,0 +1,89 @@
+"""Anonymized request/response report for failed Enki API calls.
+
+Attached to :class:`EnkiConnectionError` and surfaced in Home Assistant
+diagnostics so a failing call (method, path, headers, payload, response body)
+can be shared without a round-trip. Everything that could identify the user is
+stripped: secret headers are blanked, id-like path/body segments and long or
+sensitively-keyed values are redacted. Only the shape and the gateway's own
+error message survive.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+_REDACTED = "***"
+_SECRET_HEADERS = frozenset({"authorization", "x-gateway-apikey", "homeid"})
+_ID_SEGMENT = re.compile(r"[0-9a-f]{16,}", re.IGNORECASE)
+_SENSITIVE_KEY = re.compile(
+    r"(id|url|uri|token|serial|mac|host|uuid|key|secret|email|phone|address|ssid|name)",
+    re.IGNORECASE,
+)
+_URL = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
+_MAX_STR = 60
+_MAX_TEXT_BODY = 500
+
+
+def mask_ids(text: str) -> str:
+    """Replace long hex id segments (node/home/device ids) with a placeholder."""
+    return _ID_SEGMENT.sub("{id}", text)
+
+
+def redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Blank secret header values (auth token, gateway key, homeId), keep the rest."""
+    return {
+        key: (_REDACTED if key.lower() in _SECRET_HEADERS else value)
+        for key, value in headers.items()
+    }
+
+
+def anonymize(node: Any, key_hint: str = "") -> Any:
+    """Recursively strip identifying values, keeping structure, enums and numbers."""
+    if isinstance(node, dict):
+        return {key: anonymize(value, key) for key, value in node.items()}
+    if isinstance(node, list):
+        return [anonymize(item, key_hint) for item in node]
+    if isinstance(node, str):
+        if _URL.match(node):
+            return "<url>"
+        if _SENSITIVE_KEY.search(key_hint):
+            return _REDACTED
+        if len(node) > _MAX_STR:
+            return f"<redacted:{len(node)}>"
+        return node
+    return node
+
+
+def _anonymize_body(body: str) -> Any | None:
+    text = body.strip()
+    if not text:
+        return None
+    try:
+        return anonymize(json.loads(text))
+    except json.JSONDecodeError:
+        return mask_ids(text[:_MAX_TEXT_BODY])
+
+
+def build_request_report(
+    method: str,
+    path: str,
+    headers: dict[str, str],
+    payload: Any,
+    status: int,
+    body: str,
+) -> dict[str, Any]:
+    """Assemble an anonymized report of a failed request for diagnostics."""
+    report: dict[str, Any] = {
+        "method": method,
+        "path": mask_ids(path),
+        "status": status,
+        "request_headers": redact_headers(headers),
+    }
+    if payload is not None:
+        report["request_payload"] = anonymize(payload)
+    response_body = _anonymize_body(body)
+    if response_body is not None:
+        report["response_body"] = response_body
+    return report

--- a/scripts/discover_devices.py
+++ b/scripts/discover_devices.py
@@ -75,6 +75,7 @@ async def main(username: str, password: str, export_json: bool) -> None:
                 profile_export,
                 record,
                 api_read_errors=api.read_errors_for_fingerprint(fingerprint) or None,
+                api_read_reports=api.read_reports_for_fingerprint(fingerprint) or None,
                 last_poll_state=api.poll_state_for_fingerprint(fingerprint) or None,
             )
         )

--- a/tests/unit/test_api_transport.py
+++ b/tests/unit/test_api_transport.py
@@ -7,6 +7,7 @@ import pytest
 from aioresponses import aioresponses
 from enki.api.transport import EnkiHttpClient
 from enki.const import ENKI_BASE_URL
+from enki.exceptions import EnkiConnectionError
 
 
 class _FakeAuth:
@@ -45,3 +46,19 @@ async def test_get_json_parses_a_normal_json_body() -> None:
     assert await _get_json(status=200, body='{"lastReportedValue": "ON"}') == {
         "lastReportedValue": "ON"
     }
+
+
+@pytest.mark.asyncio
+async def test_get_json_error_includes_response_body_reason() -> None:
+    with pytest.raises(EnkiConnectionError) as exc:
+        await _get_json(status=400, body='{"message": "invalid nodeId"}')
+    assert exc.value.status == 400
+    assert "HTTP 400" in str(exc.value)
+    assert "invalid nodeId" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_json_error_without_body_keeps_status_only() -> None:
+    with pytest.raises(EnkiConnectionError) as exc:
+        await _get_json(status=500, body="")
+    assert str(exc.value).endswith("HTTP 500")

--- a/tests/unit/test_api_transport.py
+++ b/tests/unit/test_api_transport.py
@@ -62,3 +62,15 @@ async def test_get_json_error_without_body_keeps_status_only() -> None:
     with pytest.raises(EnkiConnectionError) as exc:
         await _get_json(status=500, body="")
     assert str(exc.value).endswith("HTTP 500")
+
+
+@pytest.mark.asyncio
+async def test_get_json_error_attaches_anonymized_report() -> None:
+    with pytest.raises(EnkiConnectionError) as exc:
+        await _get_json(status=400, body='{"message": "invalid nodeId"}')
+    report = exc.value.report
+    assert report is not None
+    assert report["method"] == "GET"
+    assert report["status"] == 400
+    assert report["request_headers"]["Authorization"] == "***"
+    assert report["response_body"] == {"message": "invalid nodeId"}

--- a/tests/unit/test_request_report.py
+++ b/tests/unit/test_request_report.py
@@ -1,0 +1,72 @@
+"""Unit tests for the anonymized request/response failure report."""
+
+from __future__ import annotations
+
+from enki.lib.request_report import build_request_report
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "User-Agent": "Enki/1.0 (iPhone)",
+        "Accept": "application/json",
+        "Authorization": "Bearer secret-token-value",
+        "X-Gateway-APIKey": "abcdef0123456789abcdef0123456789",
+        "homeId": "66dd9883202f215627708142",
+        "X-Correlation-Id": "iOS_ABC123",
+    }
+
+
+def test_report_redacts_secret_headers_and_masks_path_ids() -> None:
+    report = build_request_report(
+        "GET",
+        "/api-enki-lighting-prod/v1/lighting/66dd9883202f215627708142/check-light-state",
+        _headers(),
+        None,
+        400,
+        '{"message": "invalid request"}',
+    )
+    assert report["method"] == "GET"
+    assert report["status"] == 400
+    # id in the path is masked
+    assert "66dd9883202f215627708142" not in report["path"]
+    assert "{id}" in report["path"]
+    # secret headers blanked, safe ones kept
+    headers = report["request_headers"]
+    assert headers["Authorization"] == "***"
+    assert headers["X-Gateway-APIKey"] == "***"
+    assert headers["homeId"] == "***"
+    assert headers["Accept"] == "application/json"
+    # the gateway's own reason survives
+    assert report["response_body"] == {"message": "invalid request"}
+
+
+def test_report_anonymizes_response_body_ids_but_keeps_enums() -> None:
+    report = build_request_report(
+        "POST",
+        "/api-enki-lighting-prod/v1/lighting/66dd9883202f215627708142/change-light-state",
+        _headers(),
+        {"power": "ON", "brightness": 50, "colorTemperature": "T3000K"},
+        500,
+        '{"nodeId": "66dd9883202f215627708142", "state": "ERROR"}',
+    )
+    # request payload enums/numbers preserved
+    assert report["request_payload"] == {
+        "power": "ON",
+        "brightness": 50,
+        "colorTemperature": "T3000K",
+    }
+    # response body: id-keyed value redacted, enum kept
+    assert report["response_body"]["nodeId"] == "***"
+    assert report["response_body"]["state"] == "ERROR"
+
+
+def test_report_keeps_non_json_body_truncated_and_id_masked() -> None:
+    report = build_request_report(
+        "GET",
+        "/api-enki-power-prod/v1/power/66dd9883202f215627708142/check-electrical-power",
+        _headers(),
+        None,
+        502,
+        "Bad gateway for 66dd9883202f215627708142",
+    )
+    assert report["response_body"] == "Bad gateway for {id}"

--- a/tests/unit/test_telemetry_enrichment.py
+++ b/tests/unit/test_telemetry_enrichment.py
@@ -162,6 +162,26 @@ def test_enrich_export_adds_capability_routing_for_uncovered() -> None:
     assert routing["services"][0]["service"] == "api-enki-lexman-camera-meari-prod"
 
 
+def test_enrich_export_includes_api_read_reports_when_provided() -> None:
+    record = _noirot_record()
+    export = profile_to_export_dict(record, integration_version="1.14.0", ha_version="2026.8")
+    reports = {
+        "lighting/check-light-state": {
+            "method": "GET",
+            "path": "/api-enki-lighting-prod/v1/lighting/{id}/check-light-state",
+            "status": 400,
+            "response_body": {"message": "invalid request"},
+        }
+    }
+    enriched = enrich_telemetry_export(
+        export,
+        record,
+        api_read_errors={"lighting/check-light-state": "HTTP 400"},
+        api_read_reports=reports,
+    )
+    assert enriched["api_read_reports"]["lighting/check-light-state"]["status"] == 400
+
+
 def test_ha_platforms_include_button_for_shutter_presets() -> None:
     profile = EnkiCapabilityProfile(
         device_type="access_and_motorizations",


### PR DESCRIPTION
## What

When an Enki API read fails, diagnostics now carry a full **anonymized request report** — not just `HTTP 400`. Two layers:

1. **Error message** — a trimmed snippet of the response body is appended to the exception, so the Home Assistant logbook shows the gateway's actual reason inline (`… failed: HTTP 400: {"message": "…"}`).
2. **Diagnostics report** — each failed poll read is captured under `api_read_reports[service/capability]` with `method`, `path`, `request_headers`, `request_payload`, `status`, and `response_body`.

Example (downloadable diagnostics):

```json
"api_read_reports": {
  "lighting/check-light-state": {
    "method": "GET",
    "path": "/api-enki-lighting-prod/v1/lighting/{id}/check-light-state",
    "status": 400,
    "request_headers": { "Authorization": "***", "X-Gateway-APIKey": "***", "homeId": "***", "Accept": "application/json" },
    "response_body": { "message": "…" }
  }
}
```

## Privacy

Everything identifying is stripped before it can be shared: secret headers (`Authorization`, `X-Gateway-APIKey`, `homeId`) are blanked, id-like path/body segments become `{id}`, and long or sensitively-keyed values are redacted — only shape and the gateway's own error text survive. Auto-telemetry is unchanged (status labels only); the full report goes to **diagnostics** and the `discover_devices.py` script.

## Why

Every light command is a read-modify-write: it first `GET check-light-state` to echo the full `lastReportedValue` on the POST. On some devices that read returns 400, aborting the command — and the status code alone doesn't say why. This puts the reason in the diagnostics the user already downloads.

Helps diagnose #143 (Lexman CCT v2 light: `check-light-state` → 400, `check-electrical-power` → 500), where headers/path already match the app's exact contract, so the response body is the missing piece.

## Test plan

- New `test_request_report.py` (redaction, id masking, enum preservation, non-JSON body) + transport `.report` attach test + enrichment passthrough test.
- Full suite green (327 passed, 1 skipped); `ruff check` + `ruff format --check` clean.