### PR TITLE
fix(light): tolerate a failed check-light-state read on commands

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -908,6 +908,32 @@ class EnkiAPI:
             {"power": "ON" if on else "OFF"},
         )
 
+    async def _current_light_base(
+        self,
+        http: EnkiHttpClient,
+        home_id: str,
+        node_id: str,
+    ) -> dict[str, Any]:
+        """Last reported light state to merge a change onto, tolerant of a read failure.
+
+        change-light-state is a read-modify-write: it echoes the full
+        lastReportedValue back on every POST. Some devices (e.g. the Lexman
+        connected light CCT v2, #143) reject check-light-state with a business
+        error, which must not block the command — fall back to an empty base so
+        the write still carries the requested fields instead of raising.
+        """
+        try:
+            current = await http.get_light_state(home_id, node_id)
+        except EnkiConnectionError as err:
+            LOGGER.debug(
+                "check-light-state unavailable for node %s; sending partial payload: %s",
+                node_id,
+                err,
+            )
+            return {}
+        base = current.get("lastReportedValue", {})
+        return base if isinstance(base, dict) else {}
+
     async def async_change_light_state(
         self,
         home_id: str,
@@ -916,11 +942,8 @@ class EnkiAPI:
     ) -> None:
         """Apply one or more lighting fields in a single change-light-state call."""
         http = await self._get_http()
-        current = await http.get_light_state(home_id, node_id)
-        payload = merge_light_state_payload(
-            current.get("lastReportedValue", {}),
-            changes,
-        )
+        base = await self._current_light_base(http, home_id, node_id)
+        payload = merge_light_state_payload(base, changes)
         await http.change_light_state(home_id, node_id, payload)
 
     async def async_change_light_color(
@@ -932,9 +955,9 @@ class EnkiAPI:
     ) -> None:
         """Set an HS colour and switch the bulb into colour mode."""
         http = await self._get_http()
-        current = await http.get_light_state(home_id, node_id)
+        base = await self._current_light_base(http, home_id, node_id)
         payload = merge_light_state_payload(
-            current.get("lastReportedValue", {}),
+            base,
             {"colorMode": "hs", "hue": hue, "saturation": saturation},
         )
         payload.pop("colorTemperature", None)

--- a/tests/unit/test_light_command_resilience.py
+++ b/tests/unit/test_light_command_resilience.py
@@ -1,0 +1,56 @@
+"""A failed check-light-state read must not block a light command (#143)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from enki.api.client import EnkiAPI
+from enki.exceptions import EnkiConnectionError
+
+
+class _FakeHttp:
+    def __init__(self, *, raise_read: bool) -> None:
+        self.raise_read = raise_read
+        self.posted: dict[str, Any] | None = None
+
+    async def get_light_state(self, home_id: str, node_id: str) -> dict[str, Any]:
+        if self.raise_read:
+            raise EnkiConnectionError(
+                "GET check-light-state failed: HTTP 400",
+                status=400,
+            )
+        return {"lastReportedValue": {"power": "OFF", "brightness": 0.2}}
+
+    async def change_light_state(self, home_id: str, node_id: str, payload: dict[str, Any]) -> None:
+        self.posted = payload
+
+
+def _api_with(fake: _FakeHttp, monkeypatch: pytest.MonkeyPatch) -> EnkiAPI:
+    api = EnkiAPI("user", "pass")
+
+    async def _get_http() -> _FakeHttp:
+        return fake
+
+    monkeypatch.setattr(api, "_get_http", _get_http)
+    return api
+
+
+@pytest.mark.asyncio
+async def test_command_sent_when_state_read_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeHttp(raise_read=True)
+    api = _api_with(fake, monkeypatch)
+    await api.async_change_light_state("home", "node", {"power": "ON", "brightness": 0.5})
+    assert fake.posted is not None  # command went out despite the 400 readback
+    assert fake.posted["power"] == "ON"
+    assert fake.posted["brightness"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_command_merges_full_state_when_read_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeHttp(raise_read=False)
+    api = _api_with(fake, monkeypatch)
+    await api.async_change_light_state("home", "node", {"power": "ON"})
+    assert fake.posted["brightness"] == 0.2  # merged from lastReportedValue


### PR DESCRIPTION
## What

Light commands (`change-light-state`) are a *read-modify-write*: the client first `GET check-light-state` to echo the full `lastReportedValue` back on the POST. That pre-read was unguarded, so if it failed the whole command raised — the light never got commanded.

Now a failed pre-read is tolerated: we log it at debug and fall back to an empty base, so the write still carries the requested fields (`power`, `brightness`, `colorTemperature`, …) instead of aborting. Applies to both `async_change_light_state` and `async_change_light_color`.

## Why

Diagnostics from issue #143 (thanks to the new `api_read_reports`) showed the Lexman connected light **CCT v2** rejects its own state reads with business errors:

- `check-light-state` → `{"errorCode": "BAD_REQUEST"}`
- `check-electrical-power` → `{"errorCode": "SOMETHING_WRONG"}`

The request is well-formed (matches the app's exact contract, works on other lights), so this is Enki rejecting the read for this model — and it shouldn't make the device uncontrollable.

## Scope / caveat

This unblocks the command path. Whether the follow-up `change-light-state` POST is accepted for this specific model is still to be confirmed by the reporter — if the POST also returns a business error, the (now self-describing) error will tell us the next step. The poll path already tolerated these read failures.

## Test plan

- New `test_light_command_resilience.py`: command is still sent when the state read 400s; full-state merge preserved when the read succeeds.
- Full suite green (329 passed, 1 skipped); `ruff check` + `ruff format --check` clean.