### PR TITLE
fix(fan): read power-only fan on/off from electrical power

### DIFF
--- a/custom_components/enki/fan.py
+++ b/custom_components/enki/fan.py
@@ -101,17 +101,21 @@ class EnkiFanEntity(EnkiEntity, FanEntity):
     def is_on(self) -> bool:
         profile = self._device.profile
         reported = self._device.reported
-        speed = reported.fan_speed
-        if speed is not None:
-            return speed > 0
+        # Speed-controlled fans report on/off through the fan speed.
         if profile.supports_fan_speed_control:
-            return False
+            speed = reported.fan_speed
+            return speed is not None and speed > 0
+        # Power-controlled fans (no writable speed range, e.g. Inspire Cadix,
+        # #157) toggle via electrical power, while the cloud keeps fan_speed at
+        # 0 — trusting fan_speed here reverted a just-started fan to OFF. Prefer
+        # the power signal, which turn-on marks optimistically.
         if profile.supports_electrical_power:
             if reported.global_power is not None:
                 return reported.global_power == "ON"
             if reported.electrical_power is not None:
                 return reported.electrical_power == "ON"
-        return False
+        speed = reported.fan_speed
+        return speed is not None and speed > 0
 
     @property
     def percentage(self) -> int | None:

--- a/tests/unit/test_api_routing.py
+++ b/tests/unit/test_api_routing.py
@@ -80,6 +80,43 @@ def test_fan_is_on_ignores_electrical_power_when_speed_supported() -> None:
     assert entity.is_on is False
 
 
+def _power_only_fan(**overrides) -> EnkiDevice:
+    """Inspire Cadix variant with no writable fan-speed range (#157)."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "AD_TCFL_1",
+        "node_id": "node-fan",
+        "device_name": "Inspire Cadix",
+        "device_type": "ceiling_fans",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [
+            "change_fan_speed",
+            "change_light_state",
+            "check_electrical_power",
+            "switch_electrical_power",
+        ],
+        "main_change_capability_id": "switch_electrical_power",
+        "main_change_capability_endpoints": [1, 3],
+        "possible_values": {},  # no fan-speed range → not speed-controlled
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def test_power_fan_is_on_from_power_despite_zero_speed() -> None:
+    # #157: the cloud keeps fan_speed at 0 for a power-only Cadix, so a
+    # just-started fan must read its ON state from electrical power, not speed.
+    device = _power_only_fan(last_reported_value={"fan_speed": 0, "electrical_power": "ON"})
+    assert device.profile.supports_fan_speed_control is False
+    assert EnkiFanEntity(MagicMock(), device).is_on is True
+
+
+def test_power_fan_is_off_when_power_off() -> None:
+    device = _power_only_fan(last_reported_value={"fan_speed": 0, "electrical_power": "OFF"})
+    assert EnkiFanEntity(MagicMock(), device).is_on is False
+
+
 @pytest.mark.asyncio
 async def test_fan_turn_on_uses_airflow_when_speed_state_missing() -> None:
     coordinator = MagicMock()


### PR DESCRIPTION
## Problem (#157)

On an **Inspire Cadix** ceiling fan (`AD_TCFL_1`), turning the fan ON physically works, but Home Assistant reverts the entity to `OFF` after 2–5 s.

## Cause

`EnkiFanEntity.is_on` read the reported `fan_speed` first and returned `speed > 0` whenever a value was present:

```python
speed = reported.fan_speed
if speed is not None:
    return speed > 0
```

This Cadix has **no writable fan-speed range**, so `supports_fan_speed_control` is `False` and turn-on drives the motor through **electrical power** (`_set_motor_power`), which optimistically marks `electrical_power = ON`. But the cloud keeps `fan_speed` at `0` for this model, so `is_on` short-circuited on `fan_speed == 0` and returned `False` — the optimistic power state was never consulted, and the reconcile poll flipped the UI back to OFF.

(The `HTTP 403 "You cannot consume this service"` on `esdk`/`ota` reads in the diagnostics are unrelated metadata reads — non-fatal.)

## Fix

Trust `fan_speed` only for **speed-controlled** fans; for power-controlled fans read on/off from `global_power` / `electrical_power` first.

- Speed-controlled fans: unchanged (`fan_speed > 0`).
- Power-controlled fans with no reported speed: unchanged (already used power).
- **Power-controlled fans reporting `fan_speed = 0`: now read power** → a just-started fan stays ON through the 45 s optimistic hold instead of reverting.

## No regressions

- All fan tests pass (existing `test_fan_is_on_ignores_electrical_power_when_speed_supported` — speed-controlled, `electrical_power = ON`, no speed → still `False`).
- 2 new regression tests for the power-only Cadix (on-from-power, off-from-power).
- Full suite green (341 passed, 1 skipped); `ruff check` + `ruff format --check` clean.

Refs #157