### PR TITLE
fix(referentiel): bump version 2.23.0 → 2.26.0

### DIFF
--- a/custom_components/enki/const.py
+++ b/custom_components/enki/const.py
@@ -56,7 +56,9 @@ DEVICE_TYPE_SENSORS = "sensors"
 DEVICE_TYPE_CAMERAS = "cameras"
 DEVICE_TYPE_BOILER = "boiler"
 
-REFERENTIEL_VERSION = "2.23.0"
+# Sent as ?version= on the referentiel endpoint. A stale value returns an older,
+# thinner capability set — keep it in step with the Enki app (2.26.3 sends 2.26.0).
+REFERENTIEL_VERSION = "2.26.0"
 
 FAN_SPEED_MIN = 1
 FAN_SPEED_MAX = 6


### PR DESCRIPTION
## Why

The referentiel endpoint (`GET /api-enki-referentiel-agg-prod/v1/devices/{id}?version=`) returns a device's capability set **for the requested version**. We were pinned to `2.23.0` while the current Enki app (2.26.3) sends `2.26.0` — a stale version returns an older, thinner capability list, so some devices under-report what they actually support.

Confirmed in the 2.26.3 APK: the referentiel repository calls the endpoint with `version = "2.26.0"`.

## What

Bump `REFERENTIEL_VERSION` to `2.26.0` and add a note to keep it in step with the app on future APK updates.

## Caveat (not fixed here)

Even up to date, the referentiel can still under-report capabilities the API physically accepts (e.g. camera config endpoints work despite not being listed). Those families are better detected by device type + the APK route catalog + graceful probing than by the `capabilities` list alone.

## Test plan

- Full suite green (349 passed, 1 skipped); `ruff check` + `ruff format --check` clean. No test pins the old version.