### PR TITLE
feat(entities): categorize config and diagnostic entities

### DIFF
--- a/custom_components/enki/binary_sensor.py
+++ b/custom_components/enki/binary_sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -106,6 +107,7 @@ _BINARY_SENSOR_SPECS: tuple[dict[str, str | BinarySensorDeviceClass], ...] = (
         "suffix": "sd_card",
         "translation_key": "sd_card",
         "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
     },
 )
 
@@ -149,6 +151,7 @@ def _build_binary_sensor_entities(
                 suffix=str(spec["suffix"]),
                 translation_key=str(spec["translation_key"]),
                 device_class=spec["device_class"],
+                entity_category=spec.get("entity_category"),
             )
         )
     entities.extend(_build_metadata_binary_sensors(coordinator, device))
@@ -180,6 +183,7 @@ def _build_metadata_binary_sensors(
                 suffix="connectivity",
                 translation_key="connectivity",
                 device_class=BinarySensorDeviceClass.CONNECTIVITY,
+                entity_category=EntityCategory.DIAGNOSTIC,
             )
         )
 
@@ -192,6 +196,7 @@ def _build_metadata_binary_sensors(
                 suffix="firmware_update",
                 translation_key="firmware_update",
                 device_class=BinarySensorDeviceClass.UPDATE,
+                entity_category=EntityCategory.DIAGNOSTIC,
             )
         )
 
@@ -212,11 +217,13 @@ class EnkiBinarySensor(EnkiEntity, BinarySensorEntity):
         suffix: str,
         translation_key: str,
         device_class: BinarySensorDeviceClass,
+        entity_category: EntityCategory | None = None,
     ) -> None:
         super().__init__(coordinator, device)
         self._state_key = state_key
         self._attr_translation_key = translation_key
         self._attr_device_class = device_class
+        self._attr_entity_category = entity_category
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-{suffix}"
 
     @property

--- a/custom_components/enki/number.py
+++ b/custom_components/enki/number.py
@@ -8,7 +8,7 @@ from homeassistant.components.number import (
     NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -39,6 +39,7 @@ class EnkiVibrationSensibilityNumber(EnkiEntity, NumberEntity):
 
     _attr_has_entity_name = True
     _attr_translation_key = "vibration_sensibility"
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_native_min_value = 1
     _attr_native_max_value = 5
     _attr_native_step = 1
@@ -74,6 +75,7 @@ class EnkiOffsetTemperatureNumber(EnkiEntity, NumberEntity):
     _attr_translation_key = "offset_temperature"
     _attr_device_class = NumberDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_entity_category = EntityCategory.CONFIG
     _attr_mode = NumberMode.BOX
 
     def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:

--- a/custom_components/enki/select.py
+++ b/custom_components/enki/select.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -73,6 +74,7 @@ class EnkiRollerShutterModeSelect(EnkiEntity, SelectEntity):
 
     _attr_has_entity_name = True
     _attr_translation_key = "roller_shutter_mode"
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
         super().__init__(coordinator, device)

--- a/custom_components/enki/sensor.py
+++ b/custom_components/enki/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
+    EntityCategory,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfTemperature,
@@ -156,6 +157,7 @@ class EnkiBatterySensor(EnkiEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
         super().__init__(coordinator, device)
@@ -186,6 +188,7 @@ class EnkiCameraLastMotionSensor(EnkiEntity, SensorEntity):
 
     _attr_translation_key = "camera_last_motion"
     _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
         super().__init__(coordinator, device)
@@ -201,6 +204,7 @@ class EnkiCameraLastEventSensor(EnkiEntity, SensorEntity):
     """Type of the camera's most recent event (movement / SD state)."""
 
     _attr_translation_key = "camera_last_event"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
         super().__init__(coordinator, device)

--- a/custom_components/enki/switch.py
+++ b/custom_components/enki/switch.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -22,6 +23,7 @@ _SWITCH_SPECS: tuple[dict[str, str], ...] = (
         "suffix": "vibration_detection",
         "translation_key": "vibration_detection",
         "service": "contact_sensor",
+        "entity_category": EntityCategory.CONFIG,
     },
     {
         "switch_capability": "activate_contact_detection",
@@ -30,6 +32,7 @@ _SWITCH_SPECS: tuple[dict[str, str], ...] = (
         "suffix": "contact_detection",
         "translation_key": "contact_detection",
         "service": "contact_sensor",
+        "entity_category": EntityCategory.CONFIG,
     },
     {
         "switch_capability": "switch_siren_status",
@@ -48,6 +51,7 @@ _SWITCH_SPECS: tuple[dict[str, str], ...] = (
         "service": "thermostat",
         "on_value": "ENABLED",
         "off_value": "DISABLED",
+        "entity_category": EntityCategory.CONFIG,
     },
     {
         "switch_capability": "change_occupancy_mode",
@@ -58,6 +62,7 @@ _SWITCH_SPECS: tuple[dict[str, str], ...] = (
         "service": "presence_detector",
         "on_value": "ENABLED",
         "off_value": "DISABLED",
+        "entity_category": EntityCategory.CONFIG,
     },
     {
         "switch_capability": "change_child_lock",
@@ -68,6 +73,7 @@ _SWITCH_SPECS: tuple[dict[str, str], ...] = (
         "service": "thermostat",
         "on_value": "LOCK",
         "off_value": "UNLOCK",
+        "entity_category": EntityCategory.CONFIG,
     },
     {
         "switch_capability": "change_preheating_status",
@@ -78,6 +84,7 @@ _SWITCH_SPECS: tuple[dict[str, str], ...] = (
         "service": "thermostat",
         "on_value": "ENABLED",
         "off_value": "DISABLED",
+        "entity_category": EntityCategory.CONFIG,
     },
 )
 
@@ -174,6 +181,7 @@ def _build_config_switches(
                 service=spec["service"],
                 on_value=spec.get("on_value", "ON"),
                 off_value=spec.get("off_value", "OFF"),
+                entity_category=spec.get("entity_category"),
             )
         )
     return entities
@@ -319,6 +327,7 @@ class EnkiConfigSwitch(EnkiEntity, SwitchEntity):
         service: str,
         on_value: str = "ON",
         off_value: str = "OFF",
+        entity_category: EntityCategory | None = None,
     ) -> None:
         super().__init__(coordinator, device)
         self._switch_capability = switch_capability
@@ -328,6 +337,7 @@ class EnkiConfigSwitch(EnkiEntity, SwitchEntity):
         self._on_value = on_value
         self._off_value = off_value
         self._attr_translation_key = translation_key
+        self._attr_entity_category = entity_category
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-{suffix}"
 
     @property

--- a/tests/unit/test_entity_categories.py
+++ b/tests/unit/test_entity_categories.py
@@ -1,0 +1,108 @@
+"""Entity-category assignments: config knobs vs diagnostics vs primary controls."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from enki.binary_sensor import EnkiBinarySensor
+from enki.domain.models import EnkiDevice
+from enki.number import EnkiOffsetTemperatureNumber, EnkiVibrationSensibilityNumber
+from enki.select import EnkiRollerShutterModeSelect
+from enki.sensor import (
+    EnkiBatterySensor,
+    EnkiCameraLastEventSensor,
+    EnkiCameraLastMotionSensor,
+    EnkiIlluminanceSensor,
+    EnkiTemperatureSensor,
+)
+from enki.switch import _SWITCH_SPECS
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import EntityCategory
+
+CONFIG = EntityCategory.CONFIG
+DIAGNOSTIC = EntityCategory.DIAGNOSTIC
+
+
+def _device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-1",
+        "device_name": "Device",
+        "device_type": "sensors",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [],
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _coordinator(device: EnkiDevice) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.data = [device]
+    coordinator.get_device_by_node = lambda node_id: device
+    return coordinator
+
+
+def _category(entity) -> EntityCategory | None:
+    return getattr(entity, "_attr_entity_category", None)
+
+
+def test_config_switch_specs_are_config_except_siren() -> None:
+    for spec in _SWITCH_SPECS:
+        if spec["suffix"] == "siren":
+            assert "entity_category" not in spec
+        else:
+            assert spec["entity_category"] == CONFIG
+
+
+def test_number_entities_are_config() -> None:
+    device = _device(possible_values={})
+    assert _category(EnkiVibrationSensibilityNumber(_coordinator(device), device)) == CONFIG
+    assert _category(EnkiOffsetTemperatureNumber(_coordinator(device), device)) == CONFIG
+
+
+def test_roller_shutter_mode_select_is_config() -> None:
+    device = _device()
+    assert _category(EnkiRollerShutterModeSelect(_coordinator(device), device)) == CONFIG
+
+
+def test_battery_and_camera_sensors_are_diagnostic() -> None:
+    device = _device()
+    for cls in (EnkiBatterySensor, EnkiCameraLastMotionSensor, EnkiCameraLastEventSensor):
+        assert _category(cls(_coordinator(device), device)) == DIAGNOSTIC
+
+
+def test_primary_sensors_have_no_category() -> None:
+    device = _device()
+    for cls in (EnkiTemperatureSensor, EnkiIlluminanceSensor):
+        assert _category(cls(_coordinator(device), device)) is None
+
+
+def test_firmware_binary_sensor_is_diagnostic() -> None:
+    device = _device()
+    firmware = EnkiBinarySensor(
+        _coordinator(device),
+        device,
+        state_key="firmware_update_available",
+        suffix="firmware_update",
+        translation_key="firmware_update",
+        device_class=BinarySensorDeviceClass.UPDATE,
+        entity_category=DIAGNOSTIC,
+    )
+    assert _category(firmware) == DIAGNOSTIC
+
+
+def test_primary_binary_sensor_has_no_category() -> None:
+    device = _device()
+    motion = EnkiBinarySensor(
+        _coordinator(device),
+        device,
+        state_key="motion_detection",
+        suffix="motion",
+        translation_key="motion",
+        device_class=BinarySensorDeviceClass.MOTION,
+    )
+    assert _category(motion) is None


### PR DESCRIPTION
Aucune entité n'avait de `entity_category` — tout apparaissait pêle-mêle dans les contrôles principaux de l'appareil. Cette PR range la page appareil.

## CONFIG (repliés sous "Configuration")
- Numbers : offset température, sensibilité vibration
- Switches de réglage : détection vibration/contact, mode fenêtre ouverte, mode présence, verrou enfant, préchauffage
- Select : sens de câblage volet (NORMAL/INVERTED)

## DIAGNOSTIC (repliés sous "Diagnostic")
- Sensors : batterie, caméra dernier mouvement / dernier événement
- Binary sensors : mise à jour firmware, connectivité, carte SD retirée

## Restent primaires (aucune catégorie)
Lumières, ventilos, volets, sirène, fil pilote, climate, prises, capteurs temp/humidité/luminosité/conso/production — les contrôles et mesures qu'on veut en avant.

7 tests dédiés, suite complète verte (366), lint OK.

_Note doc : la section entités de SUPPORTED_DEVICES est déjà réécrite dans #170 ; je n'y touche pas ici pour éviter un conflit — un mot sur le regroupement config/diagnostic pourra y être ajouté._