### PR TITLE
feat(auth): reauth flow + translated repair issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Download a [release](https://github.com/cyrilcolinet/enki-integration-hass/relea
 
 ## Troubleshooting
 
-- **Invalid credentials** — Verify email/password in the Enki app; reconfigure the integration
-- **HTTP 403** — Outdated gateway key after Enki app update → [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
+- **Invalid credentials** — Home Assistant prompts you to **re-authenticate** (notification + **Settings → Repairs**); enter your Enki password to reconnect
+- **HTTP 403** — Outdated gateway key after an Enki app update → surfaced as a repair in **Settings → Repairs**; see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
 - **No devices** — Device active in the app, same home
 - **Bug** — [Issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=bug.yml) + `enki` logs
 

--- a/custom_components/enki/__init__.py
+++ b/custom_components/enki/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
 from .exceptions import EnkiAuthError, EnkiConnectionError
@@ -60,8 +60,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnkiConfigEntry) -> bool
         await coordinator.api.async_connect()
     except EnkiAuthError as err:
         await coordinator.api.async_close()
-        notifier.notify_auth_failed()
-        raise ConfigEntryNotReady(f"Invalid Enki credentials: {err}") from err
+        # Trigger HA's reauth flow so the user re-enters the password inline.
+        raise ConfigEntryAuthFailed(f"Invalid Enki credentials: {err}") from err
     except EnkiConnectionError as err:
         await coordinator.api.async_close()
         notify_for_connection_error(notifier, err)

--- a/custom_components/enki/config_flow.py
+++ b/custom_components/enki/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
@@ -145,6 +146,47 @@ class EnkiConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_PASSWORD): str,
                 }
             ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self,
+        entry_data: Mapping[str, Any],
+    ) -> ConfigFlowResult:
+        """Start reauth when stored credentials stop working."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            credentials = {
+                CONF_USERNAME: entry.data[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            try:
+                await _validate_credentials(self.hass, credentials)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                LOGGER.exception("Unexpected error during Enki reauth")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data={**entry.data, **credentials},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            description_placeholders={CONF_USERNAME: entry.data[CONF_USERNAME]},
             errors=errors,
         )
 

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -12,6 +12,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import EnkiAPI
@@ -100,8 +101,9 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         try:
             devices = await self.api.async_get_devices()
         except EnkiAuthError as err:
-            self._notifier.notify_auth_failed()
-            raise UpdateFailed(f"Authentication error: {err}") from err
+            # Surfaces HA's native reauth flow (Settings → Repairs) instead of a
+            # persistent notification, so the user re-enters the password inline.
+            raise ConfigEntryAuthFailed(f"Authentication error: {err}") from err
         except EnkiConnectionError as err:
             notify_for_connection_error(self._notifier, err)
             raise UpdateFailed(f"Cannot reach Enki cloud: {err}") from err

--- a/custom_components/enki/notifications.py
+++ b/custom_components/enki/notifications.py
@@ -1,59 +1,55 @@
-"""Persistent notifications for Enki operational issues."""
+"""Repairs issues for Enki operational problems.
+
+Uses Home Assistant's issue registry (Settings → Repairs) rather than
+hardcoded bilingual persistent notifications: the copy lives in the translation
+files (``strings.json`` / ``translations``) under ``issues`` and HA renders it in
+the user's language. Authentication failures are handled by the reauth flow
+(``ConfigEntryAuthFailed``), not here.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN
 from .exceptions import EnkiConnectionError
 
 _DOCUMENTATION_URL = "https://github.com/cyrilcolinet/enki-integration-hass"
-_ISSUE_TRACKER = f"{_DOCUMENTATION_URL}/issues"
 
 
 def notify_for_connection_error(notifier: EnkiNotifier, err: EnkiConnectionError) -> None:
-    """Map an API transport error to the appropriate persistent notification."""
-    status = err.status
-    if status == 403:
+    """Map an API transport error to the appropriate repair issue."""
+    if err.status == 403:
         notifier.notify_gateway_rejected(service=err.service)
-    elif status == 401:
-        notifier.notify_auth_failed(gateway_hint=True)
-    elif status in {502, 503, 504}:
-        notifier.notify_service_unavailable()
     else:
         notifier.notify_connection_failed()
 
 
 class EnkiNotifier:
-    """Show or dismiss Enki persistent notifications for one config entry."""
+    """Create or clear Enki repair issues for one config entry."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self._hass = hass
         self._entry = entry
 
-    def notify_auth_failed(self, *, gateway_hint: bool = False) -> None:
-        """Credentials rejected by Enki / Keycloak."""
-        self._dismiss(self._id("connection"))
-        self._dismiss(self._id("gateway"))
-        title, message = _auth_copy(self._hass, self._entry.entry_id, gateway_hint=gateway_hint)
-        self._create(self._id("auth"), title, message)
-
     def notify_gateway_rejected(self, *, service: str | None = None) -> None:
-        """HTTP 403 — gateway API key likely outdated."""
-        self._dismiss(self._id("connection"))
-        title, message = _gateway_copy(self._hass, service=service)
-        self._create(self._id("gateway"), title, message)
+        """HTTP 403 — a gateway API key is likely outdated after an app update."""
+        self._delete("connection")
+        self._create(
+            "gateway",
+            translation_key="gateway_key_rejected",
+            placeholders={"service": service or "?"},
+            learn_more_url=f"{_DOCUMENTATION_URL}/blob/main/docs/DEVELOPMENT.md",
+        )
 
     def notify_connection_failed(self) -> None:
         """Network error or unexpected upstream failure."""
-        self._dismiss(self._id("auth"))
-        self._dismiss(self._id("gateway"))
-        title, message = _connection_copy(self._hass)
-        self._create(self._id("connection"), title, message)
+        self._delete("gateway")
+        self._create("connection", translation_key="cloud_unreachable")
 
     def notify_service_unavailable(self) -> None:
         """Enki cloud temporarily unavailable (5xx)."""
@@ -61,15 +57,18 @@ class EnkiNotifier:
 
     def notify_maintenance_mode(self) -> None:
         """Enki cloud reports active maintenance."""
-        title, message = _maintenance_copy(self._hass)
-        self._create(self._id("maintenance"), title, message)
+        self._create(
+            "maintenance",
+            translation_key="maintenance",
+            learn_more_url="https://support.enki-home.com/",
+        )
 
     def dismiss_maintenance_mode(self) -> None:
-        """Clear maintenance notification when Enki reports normal operations."""
-        self._dismiss(self._id("maintenance"))
+        """Clear the maintenance issue when Enki reports normal operations."""
+        self._delete("maintenance")
 
     def sync_maintenance_mode(self, settings: dict[str, Any] | None) -> None:
-        """Show or hide maintenance notification from mobile-config payload."""
+        """Show or hide the maintenance issue from a mobile-config payload."""
         if settings is None:
             return
         if settings.get("maintenance") is True:
@@ -78,140 +77,36 @@ class EnkiNotifier:
             self.dismiss_maintenance_mode()
 
     def dismiss_operational_errors(self) -> None:
-        """Clear auth / gateway / connection notifications after a successful poll."""
-        for suffix in ("auth", "gateway", "connection"):
-            self._dismiss(self._id(suffix))
+        """Clear gateway / connection issues after a successful poll."""
+        self._delete("gateway")
+        self._delete("connection")
 
     def dismiss_all(self) -> None:
-        """Clear every operational notification for this entry (e.g. on unload)."""
+        """Clear every operational issue for this entry (e.g. on unload)."""
         self.dismiss_operational_errors()
-        self._dismiss(self._id("maintenance"))
+        self._delete("maintenance")
 
-    def _id(self, suffix: str) -> str:
-        return f"{DOMAIN}_{suffix}_{self._entry.entry_id}"
+    def _issue_id(self, suffix: str) -> str:
+        return f"{suffix}_{self._entry.entry_id}"
 
-    def _create(self, notification_id: str, title: str, message: str) -> None:
-        persistent_notification.async_create(
+    def _create(
+        self,
+        suffix: str,
+        *,
+        translation_key: str,
+        placeholders: dict[str, str] | None = None,
+        learn_more_url: str | None = None,
+    ) -> None:
+        ir.async_create_issue(
             self._hass,
-            message=message,
-            title=title,
-            notification_id=notification_id,
+            DOMAIN,
+            self._issue_id(suffix),
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=translation_key,
+            translation_placeholders=placeholders,
+            learn_more_url=learn_more_url,
         )
 
-    def _dismiss(self, notification_id: str) -> None:
-        persistent_notification.async_dismiss(self._hass, notification_id)
-
-
-def _configure_url(entry_id: str) -> str:
-    return f"/config/integrations/configure/{entry_id}"
-
-
-def _auth_copy(
-    hass: HomeAssistant,
-    entry_id: str,
-    *,
-    gateway_hint: bool,
-) -> tuple[str, str]:
-    configure_url = _configure_url(entry_id)
-    if hass.config.language.startswith("fr"):
-        title = "Enki — connexion refusée"
-        if gateway_hint:
-            body = (
-                "L'API Enki a rejeté la requête (HTTP 401). "
-                "Vérifiez votre **email et mot de passe** Enki, ou mettez à jour les clés "
-                "gateway si l'app mobile a changé de version.\n\n"
-                f"[Reconfigurer Enki]({configure_url}) · "
-                f"[Documentation]({_DOCUMENTATION_URL})"
-            )
-        else:
-            body = (
-                "Identifiants Enki invalides ou session expirée. "
-                "Utilisez le même **email et mot de passe** que l'application mobile "
-                "Leroy Merlin Enki.\n\n"
-                f"[Reconfigurer Enki]({configure_url})"
-            )
-        return title, body
-
-    title = "Enki — sign-in failed"
-    if gateway_hint:
-        body = (
-            "The Enki API rejected the request (HTTP 401). Check your **email and password**, "
-            "or update gateway API keys if the mobile app was recently upgraded.\n\n"
-            f"[Reconfigure Enki]({configure_url}) · "
-            f"[Documentation]({_DOCUMENTATION_URL})"
-        )
-    else:
-        body = (
-            "Invalid Enki credentials or expired session. Use the same **email and password** "
-            "as the Leroy Merlin Enki mobile app.\n\n"
-            f"[Reconfigure Enki]({configure_url})"
-        )
-    return title, body
-
-
-def _gateway_copy(hass: HomeAssistant, *, service: str | None = None) -> tuple[str, str]:
-    service_hint = f" (`{service}`)" if service else ""
-    if hass.config.language.startswith("fr"):
-        return (
-            "Enki — clé API gateway refusée",
-            (
-                f"L'API Enki a répondu **HTTP 403**{service_hint} : une clé gateway "
-                "(micro-service) est probablement obsolète. Cela arrive quand "
-                "l'application Enki est mise à jour.\n\n"
-                "Mettez à jour les clés via `scripts/extract_gateway_keys.py` ou consultez "
-                f"[la documentation]({_DOCUMENTATION_URL}).\n\n"
-                f"[Signaler un problème]({_ISSUE_TRACKER})"
-            ),
-        )
-    return (
-        "Enki — gateway API key rejected",
-        (
-            f"The Enki API returned **HTTP 403**{service_hint}: a gateway "
-            "(micro-service) API key is likely outdated. This often happens after "
-            "an Enki app update.\n\n"
-            "Refresh keys with `scripts/extract_gateway_keys.py` or see "
-            f"[the documentation]({_DOCUMENTATION_URL}).\n\n"
-            f"[Report an issue]({_ISSUE_TRACKER})"
-        ),
-    )
-
-
-def _maintenance_copy(hass: HomeAssistant) -> tuple[str, str]:
-    if hass.config.language.startswith("fr"):
-        return (
-            "Enki — maintenance en cours",
-            (
-                "L'écosystème Enki signale une **maintenance** en cours. "
-                "Certaines fonctions peuvent être indisponibles temporairement.\n\n"
-                "[Support Enki](https://support.enki-home.com/)"
-            ),
-        )
-    return (
-        "Enki — maintenance in progress",
-        (
-            "The Enki cloud reports **maintenance** in progress. "
-            "Some features may be temporarily unavailable.\n\n"
-            "[Enki support](https://support.enki-home.com/)"
-        ),
-    )
-
-
-def _connection_copy(hass: HomeAssistant) -> tuple[str, str]:
-    if hass.config.language.startswith("fr"):
-        return (
-            "Enki — cloud inaccessible",
-            (
-                "Impossible de joindre le cloud Enki (réseau, timeout ou erreur serveur). "
-                "Les entités ne seront pas mises à jour tant que la connexion "
-                "n'est pas rétablie.\n\n"
-                "Vérifiez votre connexion Internet et les logs Home Assistant (`enki`)."
-            ),
-        )
-    return (
-        "Enki — cloud unreachable",
-        (
-            "Cannot reach the Enki cloud (network, timeout, or server error). "
-            "Entities will not update until connectivity is restored.\n\n"
-            "Check your Internet connection and Home Assistant logs (`enki`)."
-        ),
-    )
+    def _delete(self, suffix: str) -> None:
+        ir.async_delete_issue(self._hass, DOMAIN, self._issue_id(suffix))

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -16,6 +16,13 @@
           "password": "Password"
         }
       },
+      "reauth_confirm": {
+        "title": "Re-authenticate Enki",
+        "description": "The stored credentials for {username} stopped working. Enter the Enki password again.",
+        "data": {
+          "password": "Password"
+        }
+      },
       "telemetry": {
         "title": "Help extend Enki support",
         "description": "Optional opt-in: when a new or unsupported device is detected on your account, Home Assistant can notify you with a **pre-filled GitHub link** (anonymized profile: type, model, capabilities).\n\nNothing is sent automatically — you decide whether to open the link. This helps prioritize heaters, shutters, sockets, and other hardware.\n\nYou can change this anytime under **Enki → Configure**.",
@@ -30,7 +37,8 @@
       "unknown": "Unexpected error. Check Home Assistant logs."
     },
     "abort": {
-      "already_configured": "This Enki account is already configured."
+      "already_configured": "This Enki account is already configured.",
+      "reauth_successful": "Enki re-authenticated successfully."
     }
   },
   "options": {
@@ -233,6 +241,20 @@
       "firmware": {
         "name": "Firmware"
       }
+    }
+  },
+  "issues": {
+    "gateway_key_rejected": {
+      "title": "Enki gateway key rejected",
+      "description": "The Enki API returned HTTP 403 for `{service}`: a gateway (micro-service) key is likely outdated after an Enki app update. Reads and commands on that service will keep failing until the key is refreshed. See the linked guide."
+    },
+    "cloud_unreachable": {
+      "title": "Enki cloud unreachable",
+      "description": "Home Assistant can't reach the Enki cloud (network, timeout, or server error). Entities won't update until connectivity is restored. Check your internet connection and the Home Assistant logs."
+    },
+    "maintenance": {
+      "title": "Enki maintenance in progress",
+      "description": "The Enki cloud reports maintenance in progress. Some features may be temporarily unavailable."
     }
   }
 }

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -16,6 +16,13 @@
           "password": "Password"
         }
       },
+      "reauth_confirm": {
+        "title": "Re-authenticate Enki",
+        "description": "The stored credentials for {username} stopped working. Enter the Enki password again.",
+        "data": {
+          "password": "Password"
+        }
+      },
       "telemetry": {
         "title": "Help extend Enki support",
         "description": "Optional opt-in: when a new or unsupported device is detected on your account, Home Assistant can notify you with a **pre-filled GitHub link** (anonymized profile: type, model, capabilities).\n\nNothing is sent automatically — you decide whether to open the link. This helps prioritize heaters, shutters, sockets, and other hardware.\n\nYou can change this anytime under **Enki → Configure**.",
@@ -30,7 +37,8 @@
       "unknown": "Unexpected error. Check Home Assistant logs."
     },
     "abort": {
-      "already_configured": "This Enki account is already configured."
+      "already_configured": "This Enki account is already configured.",
+      "reauth_successful": "Enki re-authenticated successfully."
     }
   },
   "options": {
@@ -239,6 +247,20 @@
       "firmware": {
         "name": "Firmware"
       }
+    }
+  },
+  "issues": {
+    "gateway_key_rejected": {
+      "title": "Enki gateway key rejected",
+      "description": "The Enki API returned HTTP 403 for `{service}`: a gateway (micro-service) key is likely outdated after an Enki app update. Reads and commands on that service will keep failing until the key is refreshed. See the linked guide."
+    },
+    "cloud_unreachable": {
+      "title": "Enki cloud unreachable",
+      "description": "Home Assistant can't reach the Enki cloud (network, timeout, or server error). Entities won't update until connectivity is restored. Check your internet connection and the Home Assistant logs."
+    },
+    "maintenance": {
+      "title": "Enki maintenance in progress",
+      "description": "The Enki cloud reports maintenance in progress. Some features may be temporarily unavailable."
     }
   }
 }

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -16,6 +16,13 @@
           "password": "Mot de passe"
         }
       },
+      "reauth_confirm": {
+        "title": "Ré-authentifier Enki",
+        "description": "Les identifiants enregistrés pour {username} ne fonctionnent plus. Saisissez à nouveau le mot de passe Enki.",
+        "data": {
+          "password": "Mot de passe"
+        }
+      },
       "telemetry": {
         "title": "Aidez à étendre le support Enki",
         "description": "Option facultative : lorsqu’un appareil nouveau ou non supporté est détecté sur votre compte, Home Assistant peut vous avertir avec un **lien GitHub pré-rempli** (profil anonymisé : type, modèle, capabilities).\n\nRien n’est envoyé automatiquement — vous choisissez d’ouvrir le lien ou non. Cela aide à prioriser radiateurs, volets, prises et autres matériels.\n\nModifiable à tout moment via **Enki → Configurer**.",
@@ -30,7 +37,8 @@
       "unknown": "Erreur inattendue. Consultez les journaux Home Assistant."
     },
     "abort": {
-      "already_configured": "Ce compte Enki est déjà configuré."
+      "already_configured": "Ce compte Enki est déjà configuré.",
+      "reauth_successful": "Enki ré-authentifié avec succès."
     }
   },
   "options": {
@@ -239,6 +247,20 @@
       "firmware": {
         "name": "Micrologiciel"
       }
+    }
+  },
+  "issues": {
+    "gateway_key_rejected": {
+      "title": "Enki — clé gateway refusée",
+      "description": "L'API Enki a répondu HTTP 403 pour `{service}` : une clé gateway (micro-service) est probablement obsolète suite à une mise à jour de l'app Enki. Les lectures et commandes de ce service échoueront tant que la clé n'est pas mise à jour. Voir le guide lié."
+    },
+    "cloud_unreachable": {
+      "title": "Enki — cloud inaccessible",
+      "description": "Home Assistant ne parvient pas à joindre le cloud Enki (réseau, timeout ou erreur serveur). Les entités ne seront pas mises à jour tant que la connexion n'est pas rétablie. Vérifiez votre connexion internet et les logs Home Assistant."
+    },
+    "maintenance": {
+      "title": "Enki — maintenance en cours",
+      "description": "Le cloud Enki signale une maintenance en cours. Certaines fonctions peuvent être temporairement indisponibles."
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,9 +192,14 @@ class _ConfigEntryNotReady(_HomeAssistantError):
     """Minimal ConfigEntryNotReady stand-in — must stay raisable."""
 
 
+class _ConfigEntryAuthFailed(_HomeAssistantError):
+    """Minimal ConfigEntryAuthFailed stand-in — must stay raisable."""
+
+
 _ha_exceptions = sys.modules["homeassistant.exceptions"]
 _ha_exceptions.HomeAssistantError = _HomeAssistantError
 _ha_exceptions.ConfigEntryNotReady = _ConfigEntryNotReady
+_ha_exceptions.ConfigEntryAuthFailed = _ConfigEntryAuthFailed
 
 _device_registry = sys.modules["homeassistant.helpers.device_registry"]
 _device_registry.DeviceInfo = dict

--- a/tests/unit/test_config_flow_reauth.py
+++ b/tests/unit/test_config_flow_reauth.py
@@ -1,0 +1,61 @@
+"""Unit tests for the Enki reauthentication flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from enki.config_flow import CannotConnect, EnkiConfigFlow, InvalidAuth
+
+
+def _flow(entry_data: dict | None = None) -> EnkiConfigFlow:
+    flow = EnkiConfigFlow()
+    flow.hass = MagicMock()
+    entry = MagicMock()
+    entry.data = entry_data or {"username": "user@example.com", "password": "old-secret"}
+    flow._get_reauth_entry = MagicMock(return_value=entry)  # noqa: SLF001
+    flow.async_update_reload_and_abort = MagicMock(return_value={"type": "abort"})
+    flow.async_show_form = MagicMock(return_value={"type": "form"})
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_reauth_shows_form_first() -> None:
+    flow = _flow()
+    await flow.async_step_reauth({"username": "user@example.com"})
+    assert flow.async_show_form.call_args.kwargs["step_id"] == "reauth_confirm"
+    # The account being reauthenticated is shown to the user.
+    placeholders = flow.async_show_form.call_args.kwargs["description_placeholders"]
+    assert placeholders["username"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_reauth_success_updates_entry_with_new_password() -> None:
+    flow = _flow()
+    with patch("enki.config_flow._validate_credentials", new=AsyncMock()):
+        await flow.async_step_reauth_confirm({"password": "new-secret"})
+
+    flow.async_update_reload_and_abort.assert_called_once()
+    data = flow.async_update_reload_and_abort.call_args.kwargs["data"]
+    # Username preserved, password refreshed.
+    assert data["username"] == "user@example.com"
+    assert data["password"] == "new-secret"
+
+
+@pytest.mark.asyncio
+async def test_reauth_invalid_password_reprompts() -> None:
+    flow = _flow()
+    with patch("enki.config_flow._validate_credentials", new=AsyncMock(side_effect=InvalidAuth)):
+        await flow.async_step_reauth_confirm({"password": "wrong"})
+
+    flow.async_update_reload_and_abort.assert_not_called()
+    assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.asyncio
+async def test_reauth_connection_error_reprompts() -> None:
+    flow = _flow()
+    with patch("enki.config_flow._validate_credentials", new=AsyncMock(side_effect=CannotConnect)):
+        await flow.async_step_reauth_confirm({"password": "whatever"})
+
+    assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "cannot_connect"}

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,4 +1,4 @@
-"""Unit tests for Enki operational notifications."""
+"""Unit tests for Enki operational repair issues."""
 
 from __future__ import annotations
 
@@ -12,122 +12,113 @@ from enki.notifications import EnkiNotifier, notify_for_connection_error
 @pytest.fixture
 def notifier() -> tuple[MagicMock, EnkiNotifier]:
     hass = MagicMock()
-    hass.config.language = "en"
     entry = MagicMock()
     entry.entry_id = "test-entry"
     return hass, EnkiNotifier(hass, entry)
 
 
-@patch("enki.notifications.persistent_notification.async_create")
-def test_notify_auth_failed(
+@patch("enki.notifications.ir.async_delete_issue")
+@patch("enki.notifications.ir.async_create_issue")
+def test_gateway_rejected_creates_issue(
     mock_create: MagicMock,
+    mock_delete: MagicMock,
     notifier: tuple[MagicMock, EnkiNotifier],
 ) -> None:
     hass, n = notifier
-    n.notify_auth_failed()
-    mock_create.assert_called_once()
-    assert mock_create.call_args.kwargs["notification_id"] == "enki_auth_test-entry"
-    assert "sign-in failed" in mock_create.call_args.kwargs["title"].lower()
-    assert "/config/integrations/configure/test-entry" in mock_create.call_args.kwargs["message"]
+    n.notify_gateway_rejected(service="api-enki-lighting-prod")
+    assert mock_create.call_args.args[1:] == ("enki", "gateway_test-entry")
+    assert mock_create.call_args.kwargs["translation_key"] == "gateway_key_rejected"
+    assert (
+        mock_create.call_args.kwargs["translation_placeholders"]["service"]
+        == "api-enki-lighting-prod"
+    )
+    # A gateway error supersedes a lingering connection issue.
+    mock_delete.assert_called_once_with(hass, "enki", "connection_test-entry")
 
 
-@patch("enki.notifications.persistent_notification.async_dismiss")
-@patch("enki.notifications.persistent_notification.async_create")
-def test_notify_gateway_rejected(
+@patch("enki.notifications.ir.async_delete_issue")
+@patch("enki.notifications.ir.async_create_issue")
+def test_connection_failed_creates_issue(
     mock_create: MagicMock,
-    mock_dismiss: MagicMock,
-    notifier: tuple[MagicMock, EnkiNotifier],
-) -> None:
-    _, n = notifier
-    n.notify_gateway_rejected()
-    mock_create.assert_called_once()
-    assert mock_create.call_args.kwargs["notification_id"] == "enki_gateway_test-entry"
-    assert "403" in mock_create.call_args.kwargs["message"]
-    mock_dismiss.assert_called_once_with(n._hass, "enki_connection_test-entry")
-
-
-@patch("enki.notifications.persistent_notification.async_dismiss")
-@patch("enki.notifications.persistent_notification.async_create")
-def test_notify_connection_failed(
-    mock_create: MagicMock,
-    mock_dismiss: MagicMock,
+    mock_delete: MagicMock,
     notifier: tuple[MagicMock, EnkiNotifier],
 ) -> None:
     _, n = notifier
     n.notify_connection_failed()
-    mock_create.assert_called_once()
-    assert mock_create.call_args.kwargs["notification_id"] == "enki_connection_test-entry"
-    assert mock_dismiss.call_count == 2
+    assert mock_create.call_args.args[1:] == ("enki", "connection_test-entry")
+    assert mock_create.call_args.kwargs["translation_key"] == "cloud_unreachable"
 
 
-@patch("enki.notifications.persistent_notification.async_dismiss")
+@patch("enki.notifications.ir.async_delete_issue")
 def test_dismiss_operational_errors(
-    mock_dismiss: MagicMock,
+    mock_delete: MagicMock,
     notifier: tuple[MagicMock, EnkiNotifier],
 ) -> None:
     hass, n = notifier
     n.dismiss_operational_errors()
-    assert mock_dismiss.call_count == 3
-    mock_dismiss.assert_any_call(hass, "enki_auth_test-entry")
-    mock_dismiss.assert_any_call(hass, "enki_gateway_test-entry")
-    mock_dismiss.assert_any_call(hass, "enki_connection_test-entry")
+    assert mock_delete.call_count == 2
+    mock_delete.assert_any_call(hass, "enki", "gateway_test-entry")
+    mock_delete.assert_any_call(hass, "enki", "connection_test-entry")
 
 
-@patch("enki.notifications.persistent_notification.async_create")
-def test_notify_for_connection_error_maps_403(
+@patch("enki.notifications.ir.async_delete_issue")
+@patch("enki.notifications.ir.async_create_issue")
+def test_connection_error_maps_403_to_gateway(
     mock_create: MagicMock,
+    mock_delete: MagicMock,
     notifier: tuple[MagicMock, EnkiNotifier],
 ) -> None:
     _, n = notifier
     notify_for_connection_error(n, EnkiConnectionError("forbidden", status=403))
-    assert mock_create.call_args.kwargs["notification_id"] == "enki_gateway_test-entry"
+    assert mock_create.call_args.kwargs["translation_key"] == "gateway_key_rejected"
 
 
-@patch("enki.notifications.persistent_notification.async_create")
-def test_french_auth_copy(mock_create: MagicMock) -> None:
-    hass = MagicMock()
-    hass.config.language = "fr-FR"
-    entry = MagicMock()
-    entry.entry_id = "abc"
-    EnkiNotifier(hass, entry).notify_auth_failed()
-    assert "connexion refusée" in mock_create.call_args.kwargs["title"].lower()
-
-
-@patch("enki.notifications.persistent_notification.async_dismiss")
-@patch("enki.notifications.persistent_notification.async_create")
-def test_sync_maintenance_mode_shows_notification(
+@patch("enki.notifications.ir.async_delete_issue")
+@patch("enki.notifications.ir.async_create_issue")
+def test_connection_error_maps_other_to_cloud_unreachable(
     mock_create: MagicMock,
-    mock_dismiss: MagicMock,
+    mock_delete: MagicMock,
+    notifier: tuple[MagicMock, EnkiNotifier],
+) -> None:
+    _, n = notifier
+    notify_for_connection_error(n, EnkiConnectionError("boom", status=500))
+    assert mock_create.call_args.kwargs["translation_key"] == "cloud_unreachable"
+
+
+@patch("enki.notifications.ir.async_delete_issue")
+@patch("enki.notifications.ir.async_create_issue")
+def test_sync_maintenance_shows_issue(
+    mock_create: MagicMock,
+    mock_delete: MagicMock,
     notifier: tuple[MagicMock, EnkiNotifier],
 ) -> None:
     _, n = notifier
     n.sync_maintenance_mode({"maintenance": True})
-    mock_create.assert_called_once()
-    assert mock_create.call_args.kwargs["notification_id"] == "enki_maintenance_test-entry"
-    mock_dismiss.assert_not_called()
+    assert mock_create.call_args.kwargs["translation_key"] == "maintenance"
+    mock_delete.assert_not_called()
 
 
-@patch("enki.notifications.persistent_notification.async_dismiss")
-@patch("enki.notifications.persistent_notification.async_create")
-def test_sync_maintenance_mode_dismisses_when_clear(
+@patch("enki.notifications.ir.async_delete_issue")
+@patch("enki.notifications.ir.async_create_issue")
+def test_sync_maintenance_clears_issue(
     mock_create: MagicMock,
-    mock_dismiss: MagicMock,
+    mock_delete: MagicMock,
     notifier: tuple[MagicMock, EnkiNotifier],
 ) -> None:
     hass, n = notifier
     n.sync_maintenance_mode({"maintenance": False})
     mock_create.assert_not_called()
-    mock_dismiss.assert_called_once_with(hass, "enki_maintenance_test-entry")
+    mock_delete.assert_called_once_with(hass, "enki", "maintenance_test-entry")
 
 
-@patch("enki.notifications.persistent_notification.async_dismiss")
-@patch("enki.notifications.persistent_notification.async_create")
-def test_sync_maintenance_mode_skips_when_settings_unavailable(
+@patch("enki.notifications.ir.async_delete_issue")
+@patch("enki.notifications.ir.async_create_issue")
+def test_sync_maintenance_skips_when_unavailable(
     mock_create: MagicMock,
-    mock_dismiss: MagicMock,
+    mock_delete: MagicMock,
     notifier: tuple[MagicMock, EnkiNotifier],
 ) -> None:
     _, n = notifier
     n.sync_maintenance_mode(None)
     mock_create.assert_not_called()
-    mock_dismiss.assert_not_called()
+    mock_delete.assert_not_called()

--- a/tests/unit/test_setup_entry.py
+++ b/tests/unit/test_setup_entry.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import enki
 import pytest
 from enki.exceptions import EnkiAuthError, EnkiConnectionError
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 
 def _make_coordinator() -> MagicMock:
@@ -38,16 +38,22 @@ def _patched_dependencies(coordinator: MagicMock):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "error",
-    [EnkiAuthError("bad credentials"), EnkiConnectionError("cloud down")],
+    ("error", "expected"),
+    [
+        (EnkiAuthError("bad credentials"), ConfigEntryAuthFailed),
+        (EnkiConnectionError("cloud down"), ConfigEntryNotReady),
+    ],
 )
-async def test_whenConnectFails_thenApiSessionIsClosed(error: Exception) -> None:
+async def test_whenConnectFails_thenApiSessionIsClosed(
+    error: Exception,
+    expected: type[Exception],
+) -> None:
     # Given
     coordinator = _make_coordinator()
     coordinator.api.async_connect.side_effect = error
 
-    # When
-    with _patched_dependencies(coordinator), pytest.raises(ConfigEntryNotReady):
+    # When: an auth error triggers reauth, a connection error a retry
+    with _patched_dependencies(coordinator), pytest.raises(expected):
         await enki.async_setup_entry(_make_hass(), MagicMock())
 
     # Then


### PR DESCRIPTION
Deux problèmes d'un coup : pas de reauth, et beaucoup de texte FR/EN hardcodé dans `notifications.py`.

## Reauth
Les identifiants invalides/expirés lèvent maintenant `ConfigEntryAuthFailed` (au setup **et** au polling) → HA lance son **flow de ré-authentification natif** (notification + Settings → Réparations). L'utilisateur ressaisit juste son mot de passe inline, plus besoin de reconfigurer à la main. L'email est pré-rempli.

## Notifications → Repairs traduits
Les notifications persistantes bilingues en dur (403 clé gateway, cloud injoignable, maintenance) deviennent des **issues Repairs** avec `translation_key`. La copie vit désormais dans `strings.json` / `translations/{en,fr}.json` (`issues`), et HA l'affiche **dans la langue de l'utilisateur**. Plus aucun texte FR hardcodé dans le code.

- L'auth n'est plus une notif : c'est le flow reauth natif.
- Le 403 gateway pointe vers DEVELOPMENT.md (learn-more).

## Tests
- Nouveau `test_config_flow_reauth.py` (form, succès, mauvais mot de passe, erreur réseau).
- `test_notifications.py` réécrit pour le issue_registry.
- `test_setup_entry.py` : l'auth attend `ConfigEntryAuthFailed`, la connexion `ConfigEntryNotReady`.
- conftest : stub `ConfigEntryAuthFailed`.
- Suite complète verte (362), lint OK.

README troubleshooting mis à jour.