### PR TITLE
feat(update): expose device firmware in Settings → Updates

### DIFF
--- a/custom_components/enki/__init__.py
+++ b/custom_components/enki/__init__.py
@@ -34,6 +34,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.UPDATE,
 ]
 
 type EnkiConfigEntry = ConfigEntry[EnkiCoordinator]

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -228,6 +228,11 @@
       "thermostat": {
         "name": "Thermostat"
       }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
     }
   }
 }

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -234,6 +234,11 @@
       "thermostat": {
         "name": "Thermostat"
       }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
     }
   }
 }

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -234,6 +234,11 @@
       "thermostat": {
         "name": "Thermostat"
       }
+    },
+    "update": {
+      "firmware": {
+        "name": "Micrologiciel"
+      }
     }
   }
 }

--- a/custom_components/enki/update.py
+++ b/custom_components/enki/update.py
@@ -1,0 +1,56 @@
+"""Update platform exposing Enki device firmware in Settings → Updates."""
+
+from __future__ import annotations
+
+from homeassistant.components.update import UpdateDeviceClass, UpdateEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import EnkiCoordinator
+from .domain.models import EnkiDevice
+from .entity import EnkiEntity
+
+_OTA_CAPABILITY = "ota_inventory"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: EnkiCoordinator = entry.runtime_data
+    async_add_entities(
+        EnkiFirmwareUpdate(coordinator, device)
+        for device in coordinator.data or []
+        if _OTA_CAPABILITY in set(device.capabilities)
+    )
+
+
+class EnkiFirmwareUpdate(EnkiEntity, UpdateEntity):
+    """Firmware state from the Enki OTA endpoints (read-only — install via Enki app)."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "firmware"
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+
+    def __init__(self, coordinator: EnkiCoordinator, device: EnkiDevice) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{DOMAIN}-{device.node_id}-firmware-update"
+
+    @property
+    def installed_version(self) -> str | None:
+        return self._device.reported.firmware_version
+
+    @property
+    def latest_version(self) -> str | None:
+        reported = self._device.reported
+        latest = reported.firmware_latest_version
+        if latest:
+            return latest
+        # Enki sometimes reports "an update exists" without a version string;
+        # a value distinct from installed keeps HA showing the update as available.
+        if reported.firmware_update_available:
+            return "unknown"
+        return reported.firmware_version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,3 +298,8 @@ _number.NumberEntity = _HaEntity
 
 _select = sys.modules["homeassistant.components.select"]
 _select.SelectEntity = _HaEntity
+
+_update = MagicMock()
+_update.UpdateEntity = _HaEntity
+_update.UpdateDeviceClass = MagicMock()
+sys.modules["homeassistant.components.update"] = _update

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,0 +1,51 @@
+"""Unit tests for the firmware update entity."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from enki.domain.models import EnkiDevice
+from enki.update import EnkiFirmwareUpdate
+
+
+def _device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-1",
+        "device_name": "Device",
+        "device_type": "sensors",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["ota_inventory"],
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _entity(reported: dict) -> EnkiFirmwareUpdate:
+    device = _device(last_reported_value=reported)
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.data = [device]
+    coordinator.get_device_by_node = lambda node_id: device
+    return EnkiFirmwareUpdate(coordinator, device)
+
+
+def test_installed_and_latest_from_versions() -> None:
+    e = _entity({"firmware_version": "1.2.0", "firmware_latest_version": "1.3.0"})
+    assert e.installed_version == "1.2.0"
+    assert e.latest_version == "1.3.0"
+    assert e._attr_unique_id == "enki-node-1-firmware-update"  # noqa: SLF001
+
+
+def test_up_to_date_when_no_latest_and_no_flag() -> None:
+    e = _entity({"firmware_version": "1.2.0", "firmware_update_available": False})
+    assert e.latest_version == "1.2.0"  # equal to installed → up to date
+
+
+def test_available_without_version_signals_update() -> None:
+    e = _entity({"firmware_version": "1.2.0", "firmware_update_available": True})
+    # No latest string, but an update exists: latest must differ from installed.
+    assert e.latest_version == "unknown"
+    assert e.latest_version != e.installed_version


### PR DESCRIPTION
Ajoute une entité `update` par appareil OTA-capable : version installée + dernière version firmware (depuis les endpoints OTA Enki), visible dans **Paramètres → Mises à jour**.

- **Read-only** : l'installation se fait dans l'app Enki (pas d'INSTALL feature).
- `latest_version` = `firmware_latest_version` si connue ; sinon `unknown` quand Enki signale une MàJ sans numéro (pour que HA affiche bien "disponible") ; sinon égale à l'installée (à jour).
- Le `binary_sensor` firmware existant est **conservé** (pas de breaking change).

3 tests, suite complète verte (362), lint + JSON OK.

_Note doc : la section "Device info" de SUPPORTED_DEVICES est réécrite dans #170 ; j'ajouterai la ligne update là-bas pour éviter un conflit ici._