### PR TITLE
refactor(telemetry): move notifications to translated repair issues

### DIFF
--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -255,6 +255,18 @@
     "maintenance": {
       "title": "Enki maintenance in progress",
       "description": "The Enki cloud reports maintenance in progress. Some features may be temporarily unavailable."
+    },
+    "telemetry_nudge": {
+      "title": "Enki — help prioritize new device support",
+      "description": "Turn on opt-in telemetry under Enki → Configure to be notified when an unsupported Enki device is detected on your account. Only anonymized data (type, model, capabilities) is used — nothing is sent without a click. This helps prioritize support for heaters, shutters, sockets, and other hardware."
+    },
+    "new_device_profile": {
+      "title": "Enki — new device profile",
+      "description": "A new device profile was detected: {summary}. Anonymized data only — nothing is sent without your action. Use the Learn more link to open a pre-filled GitHub issue."
+    },
+    "unsupported_device": {
+      "title": "Enki — unsupported device",
+      "description": "The device profile {summary} is not supported by the integration yet. Use the Learn more link to request support on GitHub."
     }
   }
 }

--- a/custom_components/enki/telemetry/nudge.py
+++ b/custom_components/enki/telemetry/nudge.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.storage import Store
 
 from ..const import CONF_TELEMETRY, CONF_TELEMETRY_ONBOARDING, DOMAIN, LOGGER
 
 STORAGE_VERSION = 1
 TELEMETRY_NUDGE_LEGACY_VERSION = "1.0.6"
-NOTIFICATION_ID_PREFIX = f"{DOMAIN}_telemetry_nudge"
+_LEARN_MORE_URL = (
+    "https://github.com/cyrilcolinet/enki-integration-hass/blob/main/docs/TELEMETRY.md"
+)
 
 
 def parse_version(version: str) -> tuple[int, ...]:
@@ -89,18 +91,21 @@ class EnkiTelemetryNudge:
         return version_is_before(first_seen, TELEMETRY_NUDGE_LEGACY_VERSION)
 
     async def _show_notification(self) -> None:
-        title, message = _nudge_copy(self._hass, self._entry.entry_id)
-        persistent_notification.async_create(
+        ir.async_create_issue(
             self._hass,
-            message=message,
-            title=title,
-            notification_id=f"{NOTIFICATION_ID_PREFIX}_{self._entry.entry_id}",
+            DOMAIN,
+            f"telemetry_nudge_{self._entry.entry_id}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="telemetry_nudge",
+            learn_more_url=_LEARN_MORE_URL,
         )
 
     async def _dismiss_notification(self) -> None:
-        persistent_notification.async_dismiss(
+        ir.async_delete_issue(
             self._hass,
-            f"{NOTIFICATION_ID_PREFIX}_{self._entry.entry_id}",
+            DOMAIN,
+            f"telemetry_nudge_{self._entry.entry_id}",
         )
 
     async def _load_meta(self) -> dict[str, Any]:
@@ -113,34 +118,6 @@ class EnkiTelemetryNudge:
         from .. import __version__
 
         return __version__
-
-
-def _nudge_copy(hass: HomeAssistant, entry_id: str) -> tuple[str, str]:
-    configure_url = f"/config/integrations/configure/{entry_id}"
-    if hass.config.language.startswith("fr"):
-        return (
-            "Enki — accélérez le support de nouveaux appareils",
-            (
-                "Activez la **télémétrie opt-in** pour être averti lorsqu'un appareil "
-                "Enki non supporté est détecté chez vous.\n\n"
-                "Données **anonymisées** (type, modèle, capabilities) — "
-                "aucun envoi automatique, seulement un lien GitHub pré-rempli "
-                "si vous le souhaitez.\n\n"
-                "Cela aide à prioriser radiateurs, volets, prises et autres matériels.\n\n"
-                f"[Ouvrir les options Enki]({configure_url})"
-            ),
-        )
-    return (
-        "Enki — help prioritize new device support",
-        (
-            "Turn on **opt-in telemetry** to get notified when an unsupported Enki "
-            "device is detected on your account.\n\n"
-            "**Anonymized** data only (type, model, capabilities) — "
-            "nothing is sent automatically; you get a pre-filled GitHub link if you choose.\n\n"
-            "This helps prioritize heaters, shutters, sockets, and other hardware.\n\n"
-            f"[Open Enki options]({configure_url})"
-        ),
-    )
 
 
 async def async_handle_telemetry_nudge(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components import persistent_notification
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.storage import Store
 
 from ..const import CONF_TELEMETRY, DOMAIN, LOGGER
@@ -111,27 +111,27 @@ class EnkiTelemetryReporter:
         )
 
     def _dismiss_profile_notification(self, fingerprint: str) -> None:
-        persistent_notification.async_dismiss(
+        ir.async_delete_issue(
             self._hass,
-            notification_id=f"{DOMAIN}_profile_{fingerprint[:16]}",
+            DOMAIN,
+            f"profile_{fingerprint[:16]}",
         )
 
     def _notify_new_profile(self, export_dict: dict[str, Any], fingerprint: str) -> None:
         summary = format_telemetry_notification_summary(export_dict)
         issue_url = build_github_new_issue_url(export_dict, fingerprint)
-        supported = export_dict.get("supported_by_integration")
-        title, message = _profile_notification_copy(
-            self._hass,
-            summary=summary,
-            issue_url=issue_url,
-            supported=bool(supported),
-        )
+        supported = bool(export_dict.get("supported_by_integration"))
+        translation_key = "new_device_profile" if supported else "unsupported_device"
 
-        persistent_notification.async_create(
+        ir.async_create_issue(
             self._hass,
-            message=message,
-            title=title,
-            notification_id=f"{DOMAIN}_profile_{fingerprint[:16]}",
+            DOMAIN,
+            f"profile_{fingerprint[:16]}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=translation_key,
+            translation_placeholders={"summary": summary},
+            learn_more_url=issue_url,
         )
 
     async def _load_reported(self) -> set[str]:
@@ -165,47 +165,3 @@ def _ha_version(hass: HomeAssistant) -> str:
         return str(__version__)
     except ImportError:
         return "not available"
-
-
-def _profile_notification_copy(
-    hass: HomeAssistant,
-    *,
-    summary: str,
-    issue_url: str,
-    supported: bool,
-) -> tuple[str, str]:
-    language = getattr(hass.config, "language", None) or "en"
-    if language.startswith("fr"):
-        if supported:
-            return (
-                "Enki — nouveau profil d'appareil",
-                (
-                    f"Profil détecté : **{summary}**.\n\n"
-                    "Données anonymisées — rien n'est envoyé sans votre action.\n\n"
-                    f"[Ouvrir une issue GitHub pré-remplie]({issue_url})"
-                ),
-            )
-        return (
-            "Enki — appareil non supporté",
-            (
-                f"Profil **{summary}** non géré par l'intégration.\n\n"
-                f"[Proposer le support sur GitHub]({issue_url})"
-            ),
-        )
-
-    if supported:
-        return (
-            "Enki — new device profile",
-            (
-                f"Profile detected: **{summary}**.\n\n"
-                "Anonymized data only — nothing is sent without your action.\n\n"
-                f"[Open a pre-filled GitHub issue]({issue_url})"
-            ),
-        )
-    return (
-        "Enki — unsupported device",
-        (
-            f"Profile **{summary}** is not supported by the integration yet.\n\n"
-            f"[Request support on GitHub]({issue_url})"
-        ),
-    )

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -261,6 +261,18 @@
     "maintenance": {
       "title": "Enki maintenance in progress",
       "description": "The Enki cloud reports maintenance in progress. Some features may be temporarily unavailable."
+    },
+    "telemetry_nudge": {
+      "title": "Enki — help prioritize new device support",
+      "description": "Turn on opt-in telemetry under Enki → Configure to be notified when an unsupported Enki device is detected on your account. Only anonymized data (type, model, capabilities) is used — nothing is sent without a click. This helps prioritize support for heaters, shutters, sockets, and other hardware."
+    },
+    "new_device_profile": {
+      "title": "Enki — new device profile",
+      "description": "A new device profile was detected: {summary}. Anonymized data only — nothing is sent without your action. Use the Learn more link to open a pre-filled GitHub issue."
+    },
+    "unsupported_device": {
+      "title": "Enki — unsupported device",
+      "description": "The device profile {summary} is not supported by the integration yet. Use the Learn more link to request support on GitHub."
     }
   }
 }

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -261,6 +261,18 @@
     "maintenance": {
       "title": "Enki — maintenance en cours",
       "description": "Le cloud Enki signale une maintenance en cours. Certaines fonctions peuvent être temporairement indisponibles."
+    },
+    "telemetry_nudge": {
+      "title": "Enki — accélérez le support de nouveaux appareils",
+      "description": "Activez la télémétrie opt-in dans Enki → Configurer pour être averti lorsqu'un appareil Enki non supporté est détecté sur votre compte. Seules des données anonymisées (type, modèle, capacités) sont utilisées — rien n'est envoyé sans un clic. Cela aide à prioriser le support des radiateurs, volets, prises et autres matériels."
+    },
+    "new_device_profile": {
+      "title": "Enki — nouveau profil d'appareil",
+      "description": "Un nouveau profil d'appareil a été détecté : {summary}. Données anonymisées uniquement — rien n'est envoyé sans votre action. Utilisez le lien En savoir plus pour ouvrir une issue GitHub pré-remplie."
+    },
+    "unsupported_device": {
+      "title": "Enki — appareil non supporté",
+      "description": "Le profil d'appareil {summary} n'est pas encore pris en charge par l'intégration. Utilisez le lien En savoir plus pour demander le support sur GitHub."
     }
   }
 }

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -41,7 +41,7 @@ async def test_telemetry_skipped_when_disabled() -> None:
 
     reporter = EnkiTelemetryReporter(hass, entry, entry.runtime_data)
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_create",
+        "enki.telemetry.reporter.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([_record()])
@@ -59,15 +59,18 @@ async def test_telemetry_notifies_new_profile() -> None:
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_create",
+        "enki.telemetry.reporter.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([_record()])
         notify.assert_called_once()
         reporter._store.async_save.assert_awaited()
-        message = notify.call_args.kwargs["message"]
-        assert "github.com" in message
-        assert "equation_radiator" in message
+        assert notify.call_args.kwargs["translation_key"] == "unsupported_device"
+        learn_more_url = notify.call_args.kwargs["learn_more_url"]
+        assert "github.com" in learn_more_url
+        assert "equation_radiator" in learn_more_url
+        summary = notify.call_args.kwargs["translation_placeholders"]["summary"]
+        assert "radiator" in summary
 
 
 @pytest.mark.asyncio
@@ -81,7 +84,7 @@ async def test_telemetry_dedupes_fingerprint() -> None:
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_create",
+        "enki.telemetry.reporter.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([_record()])
@@ -118,7 +121,7 @@ async def test_telemetry_skips_fully_supported_profile() -> None:
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_create",
+        "enki.telemetry.reporter.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([record])
@@ -148,7 +151,7 @@ async def test_telemetry_skips_out_of_scope_sonoff() -> None:
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_create",
+        "enki.telemetry.reporter.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([record])
@@ -185,7 +188,7 @@ async def test_telemetry_notifies_when_api_errors_block_primary_poll() -> None:
     entry.runtime_data.api.poll_state_for_fingerprint.return_value = {}
 
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_create",
+        "enki.telemetry.reporter.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([record])
@@ -227,7 +230,7 @@ async def test_telemetry_does_not_renotify_reported_fingerprint() -> None:
     entry.runtime_data.api.poll_state_for_fingerprint.return_value = {}
 
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_create",
+        "enki.telemetry.reporter.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([record])
@@ -272,12 +275,12 @@ async def test_telemetry_dismisses_notification_when_profile_is_healthy() -> Non
     }
 
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_dismiss",
+        "enki.telemetry.reporter.ir.async_delete_issue",
         new_callable=MagicMock,
     ) as dismiss:
         await reporter.async_report([record])
         dismiss.assert_called_once()
-        assert dismiss.call_args.kwargs["notification_id"] == f"enki_profile_{fingerprint[:16]}"
+        assert dismiss.call_args.args[2] == f"profile_{fingerprint[:16]}"
 
 
 @pytest.mark.asyncio
@@ -292,7 +295,7 @@ async def test_telemetry_tolerates_corrupt_storage() -> None:
     reporter._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     with patch(
-        "enki.telemetry.reporter.persistent_notification.async_create",
+        "enki.telemetry.reporter.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await reporter.async_report([_record()])

--- a/tests/unit/test_telemetry_nudge.py
+++ b/tests/unit/test_telemetry_nudge.py
@@ -37,11 +37,11 @@ async def test_nudge_skipped_when_telemetry_enabled() -> None:
 
     with (
         patch(
-            "enki.telemetry.nudge.persistent_notification.async_create",
+            "enki.telemetry.nudge.ir.async_create_issue",
             new_callable=MagicMock,
         ) as notify,
         patch(
-            "enki.telemetry.nudge.persistent_notification.async_dismiss",
+            "enki.telemetry.nudge.ir.async_delete_issue",
             new_callable=MagicMock,
         ),
     ):
@@ -62,7 +62,7 @@ async def test_nudge_skipped_after_onboarding_step() -> None:
     nudge._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     with patch(
-        "enki.telemetry.nudge.persistent_notification.async_create",
+        "enki.telemetry.nudge.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await nudge.async_handle_setup()
@@ -83,13 +83,13 @@ async def test_nudge_shown_once_for_legacy_install() -> None:
     nudge._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     with patch(
-        "enki.telemetry.nudge.persistent_notification.async_create",
+        "enki.telemetry.nudge.ir.async_create_issue",
         new_callable=MagicMock,
     ) as notify:
         await nudge.async_handle_setup()
         notify.assert_called_once()
-        message = notify.call_args.kwargs["message"]
-        assert "options" in message.lower()
+        assert notify.call_args.args[2] == "telemetry_nudge_entry1"
+        assert notify.call_args.kwargs["translation_key"] == "telemetry_nudge"
 
         nudge._store.async_load = AsyncMock(  # type: ignore[method-assign]
             return_value={"telemetry_nudge_dismissed": True, "first_seen_version": "legacy"}
@@ -111,8 +111,9 @@ async def test_nudge_dismissed_when_telemetry_turned_on() -> None:
     nudge._store.async_save = AsyncMock()  # type: ignore[method-assign]
 
     with patch(
-        "enki.telemetry.nudge.persistent_notification.async_dismiss",
+        "enki.telemetry.nudge.ir.async_delete_issue",
         new_callable=MagicMock,
     ) as dismiss:
         await nudge.async_handle_setup()
         dismiss.assert_called_once()
+        assert dismiss.call_args.args[2] == "telemetry_nudge_entry1"


### PR DESCRIPTION
Dernier bloc de texte FR/EN hardcodé : les notifications télémétrie (`telemetry/nudge.py` + `telemetry/reporter.py`). Converties en **Repairs traduits**, comme les notifs opérationnelles (#173).

## Changements
- **nudge opt-in** → issue Repairs `telemetry_nudge` (learn-more → docs/TELEMETRY.md).
- **profil détecté / appareil non supporté** → issues `new_device_profile` / `unsupported_device`, placeholder `{summary}`, learn-more = l'URL GitHub pré-remplie.
- Copie FR/EN supprimée du code (`_nudge_copy`, `_profile_notification_copy`) → déplacée dans `strings.json` / `translations/{en,fr}.json` (`issues`). HA affiche dans la langue de l'utilisateur.
- Toute la logique de gating/dedup/storage **inchangée** — seul le mécanisme change.

## Tests
- `test_telemetry.py` + `test_telemetry_nudge.py` adaptés au issue_registry (intention préservée).
- **359 passed**, ruff + JSON OK. Plus aucun FR hardcodé dans `telemetry/*.py`.

Se combine avec #173 (même objet `issues` dans les traductions) — conflit de merge trivial à résoudre.