### PR TITLE
test: raise unit coverage 74% → 84%

### DIFF
--- a/tests/unit/test_button_entities.py
+++ b/tests/unit/test_button_entities.py
@@ -1,0 +1,86 @@
+"""Unit tests for scenario, shutter-preset, and impulse-relay buttons."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.button import (
+    EnkiImpulseRelayButton,
+    EnkiScenarioButton,
+    EnkiShutterPresetButton,
+)
+from enki.domain.models import EnkiDevice, EnkiScenario
+
+
+def _device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-1",
+        "device_name": "Gate",
+        "device_type": "access_and_motorizations",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [],
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _coordinator(scenarios: list[EnkiScenario] | None = None) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.api.scenarios = scenarios or []
+    coordinator.api.async_activate_scenario = AsyncMock()
+    coordinator.api.async_execute_shutter_preset = AsyncMock()
+    coordinator.api.async_power_on_with_timer = AsyncMock()
+    return coordinator
+
+
+# --- scenario button --------------------------------------------------------
+
+
+def test_scenario_available_when_enabled() -> None:
+    scenario = EnkiScenario(home_id="home-1", scenario_id="s1", label="Movie", enabled=True)
+    button = EnkiScenarioButton(_coordinator([scenario]), "home-1", "s1")
+    assert button.available is True
+
+
+def test_scenario_unavailable_when_missing_or_disabled() -> None:
+    disabled = EnkiScenario(home_id="home-1", scenario_id="s1", label="Movie", enabled=False)
+    assert EnkiScenarioButton(_coordinator([disabled]), "home-1", "s1").available is False
+    assert EnkiScenarioButton(_coordinator([]), "home-1", "s1").available is False
+
+
+@pytest.mark.asyncio
+async def test_scenario_press_activates() -> None:
+    coordinator = _coordinator()
+    await EnkiScenarioButton(coordinator, "home-1", "s1").async_press()
+    coordinator.api.async_activate_scenario.assert_awaited_once_with("home-1", "s1")
+
+
+def test_scenario_device_info_groups_under_virtual_device() -> None:
+    info = EnkiScenarioButton(_coordinator(), "home-1", "s1").device_info
+    assert info["identifiers"] == {("enki", "home-1", "scenarios")}
+
+
+# --- shutter preset + impulse relay ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shutter_preset_press_executes_preset() -> None:
+    device = _device()
+    coordinator = _coordinator()
+    await EnkiShutterPresetButton(coordinator, device, "MORNING").async_press()
+    coordinator.api.async_execute_shutter_preset.assert_awaited_once_with(
+        "home-1", "node-1", "MORNING"
+    )
+
+
+@pytest.mark.asyncio
+async def test_impulse_relay_press_triggers_timer() -> None:
+    device = _device()
+    coordinator = _coordinator()
+    await EnkiImpulseRelayButton(coordinator, device).async_press()
+    coordinator.api.async_power_on_with_timer.assert_awaited_once_with("home-1", "node-1")

--- a/tests/unit/test_camera_snapshot.py
+++ b/tests/unit/test_camera_snapshot.py
@@ -1,0 +1,87 @@
+"""Unit tests for the camera event-snapshot image fetch."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from enki.camera import EnkiEventSnapshotCamera
+from enki.domain.models import EnkiDevice
+
+
+def _device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-cam",
+        "device_name": "Camera",
+        "device_type": "cameras",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["check_camera_events"],
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _camera(reported: dict) -> EnkiEventSnapshotCamera:
+    device = _device(last_reported_value=reported)
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.get_device_by_node = lambda node_id: device
+    entity = EnkiEventSnapshotCamera(coordinator, device)
+    entity.hass = MagicMock()
+    return entity
+
+
+def _session_returning(status: int, body: bytes) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.read = AsyncMock(return_value=body)
+
+    @asynccontextmanager
+    async def _get(_url):
+        yield response
+
+    session = MagicMock()
+    session.get = _get
+    return session
+
+
+@pytest.mark.asyncio
+async def test_no_url_returns_none() -> None:
+    cam = _camera({})
+    assert await cam.async_camera_image() is None
+
+
+@pytest.mark.asyncio
+async def test_fetches_and_caches_image() -> None:
+    cam = _camera({"camera_last_image_url": "https://x/snap.jpg"})
+    with patch(
+        "enki.camera.async_get_clientsession",
+        return_value=_session_returning(200, b"JPEGDATA"),
+    ):
+        assert await cam.async_camera_image() == b"JPEGDATA"
+    # Same URL → served from cache, no session call.
+    with patch("enki.camera.async_get_clientsession", side_effect=AssertionError("refetched")):
+        assert await cam.async_camera_image() == b"JPEGDATA"
+
+
+@pytest.mark.asyncio
+async def test_non_200_returns_none_without_cache() -> None:
+    cam = _camera({"camera_last_image_url": "https://x/a.jpg"})
+    with patch(
+        "enki.camera.async_get_clientsession",
+        return_value=_session_returning(404, b""),
+    ):
+        assert await cam.async_camera_image() is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_error_returns_none() -> None:
+    cam = _camera({"camera_last_image_url": "https://x/a.jpg"})
+    session = MagicMock()
+    session.get = MagicMock(side_effect=RuntimeError("boom"))
+    with patch("enki.camera.async_get_clientsession", return_value=session):
+        assert await cam.async_camera_image() is None

--- a/tests/unit/test_climate_entity.py
+++ b/tests/unit/test_climate_entity.py
@@ -1,0 +1,90 @@
+"""Unit tests for the thermostat climate entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.climate import EnkiThermostatClimate
+from enki.domain.models import EnkiDevice
+from homeassistant.components.climate.const import HVACAction, HVACMode
+from homeassistant.const import ATTR_TEMPERATURE
+
+
+def _device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-1",
+        "device_name": "Radiator",
+        "device_type": "heaters_and_pilot_wires",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["change_thermostat_target_temperature"],
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _entity(reported: dict) -> EnkiThermostatClimate:
+    device = _device(last_reported_value=reported)
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.get_device_by_node = lambda node_id: device
+    coordinator.update_cached_value = MagicMock()
+    coordinator.api.async_set_thermostat_target_temperature = AsyncMock()
+    return EnkiThermostatClimate(coordinator, device)
+
+
+def test_reports_current_and_target_temperature() -> None:
+    e = _entity({"current_temperature": 20.5, "thermostat_target_temperature": 21.0})
+    assert e.current_temperature == 20.5
+    assert e.target_temperature == 21.0
+
+
+def test_hvac_mode_off_at_frost_setpoint() -> None:
+    # default range min is 7 °C → target at/below that is "off".
+    assert _entity({"thermostat_target_temperature": 7.0}).hvac_mode == HVACMode.OFF
+    assert _entity({"thermostat_target_temperature": 20.0}).hvac_mode == HVACMode.HEAT
+
+
+def test_hvac_action_maps_running_state() -> None:
+    assert _entity({"thermostat_running_state": "HEAT"}).hvac_action == HVACAction.HEATING
+    assert _entity({"thermostat_running_state": "IDLE"}).hvac_action == HVACAction.IDLE
+    assert _entity({}).hvac_action is None
+
+
+@pytest.mark.asyncio
+async def test_set_temperature_posts_and_caches() -> None:
+    e = _entity({})
+    await e.async_set_temperature(**{ATTR_TEMPERATURE: 19.5})
+    e.coordinator.api.async_set_thermostat_target_temperature.assert_awaited_once_with(
+        "home-1", "node-1", 19.5
+    )
+    e.coordinator.update_cached_value.assert_called_once_with(
+        "node-1", "thermostat_target_temperature", 19.5
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_temperature_ignored_without_value() -> None:
+    e = _entity({})
+    await e.async_set_temperature()
+    e.coordinator.api.async_set_thermostat_target_temperature.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_hvac_off_drops_to_frost() -> None:
+    e = _entity({"thermostat_target_temperature": 21.0})
+    await e.async_set_hvac_mode(HVACMode.OFF)
+    # off → target set to the range minimum (7 °C default).
+    args = e.coordinator.api.async_set_thermostat_target_temperature.await_args.args
+    assert args[2] == 7.0
+
+
+@pytest.mark.asyncio
+async def test_set_hvac_heat_from_off_sets_default_target() -> None:
+    e = _entity({"thermostat_target_temperature": 7.0})
+    await e.async_set_hvac_mode(HVACMode.HEAT)
+    args = e.coordinator.api.async_set_thermostat_target_temperature.await_args.args
+    assert args[2] > 7.0

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -1,0 +1,143 @@
+"""Unit tests for the Enki user / telemetry / options / reconfigure flows."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from enki.config_flow import CannotConnect, EnkiConfigFlow, EnkiOptionsFlow, InvalidAuth
+
+
+def _flow() -> EnkiConfigFlow:
+    flow = EnkiConfigFlow()
+    flow.hass = MagicMock()
+    flow.context = {}
+    flow.async_show_form = MagicMock(return_value={"type": "form"})
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+    flow.async_set_unique_id = AsyncMock()
+    flow._abort_if_unique_id_configured = MagicMock()  # noqa: SLF001
+    return flow
+
+
+# --- user step --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_step_shows_form_without_input() -> None:
+    flow = _flow()
+    await flow.async_step_user()
+    assert flow.async_show_form.call_args.kwargs["step_id"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_user_step_valid_advances_to_telemetry() -> None:
+    flow = _flow()
+    creds = {"username": "a@b.c", "password": "secret"}
+    with patch("enki.config_flow._validate_credentials", new=AsyncMock()):
+        await flow.async_step_user(creds)
+    # credentials stashed, telemetry form shown next
+    assert flow.context["credentials"] == creds
+    assert flow.async_show_form.call_args.kwargs["step_id"] == "telemetry"
+
+
+@pytest.mark.asyncio
+async def test_user_step_invalid_auth_shows_error() -> None:
+    flow = _flow()
+    with patch("enki.config_flow._validate_credentials", new=AsyncMock(side_effect=InvalidAuth)):
+        await flow.async_step_user({"username": "a@b.c", "password": "bad"})
+    assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.asyncio
+async def test_user_step_cannot_connect_shows_error() -> None:
+    flow = _flow()
+    with patch("enki.config_flow._validate_credentials", new=AsyncMock(side_effect=CannotConnect)):
+        await flow.async_step_user({"username": "a@b.c", "password": "x"})
+    assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.asyncio
+async def test_user_step_unexpected_error_shows_unknown() -> None:
+    flow = _flow()
+    with patch(
+        "enki.config_flow._validate_credentials", new=AsyncMock(side_effect=RuntimeError("boom"))
+    ):
+        await flow.async_step_user({"username": "a@b.c", "password": "x"})
+    assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "unknown"}
+
+
+# --- telemetry step (entry creation) ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_telemetry_step_creates_entry() -> None:
+    flow = _flow()
+    flow.context["credentials"] = {"username": "A@B.c", "password": "secret"}
+    await flow.async_step_telemetry({"telemetry": True})
+    flow.async_set_unique_id.assert_awaited_once_with("a@b.c")
+    flow._abort_if_unique_id_configured.assert_called_once()  # noqa: SLF001
+    data = flow.async_create_entry.call_args.kwargs["data"]
+    assert data["username"] == "A@B.c"
+    options = flow.async_create_entry.call_args.kwargs["options"]
+    assert options["telemetry"] is True
+
+
+@pytest.mark.asyncio
+async def test_telemetry_step_without_credentials_restarts_user() -> None:
+    flow = _flow()
+    await flow.async_step_telemetry({"telemetry": True})
+    # no credentials in context → falls back to the user form
+    assert flow.async_show_form.call_args.kwargs["step_id"] == "user"
+
+
+# --- reconfigure ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_success_updates_entry() -> None:
+    flow = _flow()
+    entry = MagicMock()
+    entry.data = {"username": "a@b.c", "password": "old"}
+    entry.unique_id = "a@b.c"
+    flow._get_reconfigure_entry = MagicMock(return_value=entry)  # noqa: SLF001
+    flow.async_update_reload_and_abort = MagicMock(return_value={"type": "abort"})
+    with patch("enki.config_flow._validate_credentials", new=AsyncMock()):
+        await flow.async_step_reconfigure({"username": "a@b.c", "password": "new"})
+    data = flow.async_update_reload_and_abort.call_args.kwargs["data"]
+    assert data["password"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_invalid_auth_shows_error() -> None:
+    flow = _flow()
+    entry = MagicMock()
+    entry.data = {"username": "a@b.c", "password": "old"}
+    flow._get_reconfigure_entry = MagicMock(return_value=entry)  # noqa: SLF001
+    with patch("enki.config_flow._validate_credentials", new=AsyncMock(side_effect=InvalidAuth)):
+        await flow.async_step_reconfigure({"username": "a@b.c", "password": "bad"})
+    assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "invalid_auth"}
+
+
+# --- options flow -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_options_flow_saves_interval_and_telemetry() -> None:
+    entry = MagicMock()
+    entry.options = {"scan_interval": 30, "telemetry": False}
+    options = EnkiOptionsFlow(entry)
+    options.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+    await options.async_step_init({"scan_interval": 60, "telemetry": True})
+    saved = options.async_create_entry.call_args.kwargs["data"]
+    assert saved["scan_interval"] == 60
+    assert saved["telemetry"] is True
+
+
+@pytest.mark.asyncio
+async def test_options_flow_shows_form_without_input() -> None:
+    entry = MagicMock()
+    entry.options = {}
+    options = EnkiOptionsFlow(entry)
+    options.async_show_form = MagicMock(return_value={"type": "form"})
+    await options.async_step_init()
+    assert options.async_show_form.call_args.kwargs["step_id"] == "init"

--- a/tests/unit/test_coordinator_lifecycle.py
+++ b/tests/unit/test_coordinator_lifecycle.py
@@ -1,0 +1,273 @@
+"""Coverage for the Enki coordinator: polling, error routing, optimistic cache."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.coordinator import (
+    EnkiCoordinator,
+    _override_apply,
+    _override_current,
+)
+from enki.domain.models import EnkiDevice
+from enki.exceptions import EnkiAuthError, EnkiConnectionError
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+
+def _device(node_id: str = "node", **last_reported) -> EnkiDevice:
+    return EnkiDevice(
+        home_id="home",
+        device_id="dev",
+        node_id=node_id,
+        device_name="Device",
+        device_type="ceiling_fans",
+        is_enabled=True,
+        state="ACTIVE",
+        last_reported_value=dict(last_reported),
+    )
+
+
+def _make_coordinator() -> EnkiCoordinator:
+    """A fully constructed coordinator (exercises __init__) with stubbed collaborators."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.data = {"username": "user@example.com", "password": "secret"}
+    entry.options = {}
+    coordinator = EnkiCoordinator(hass, entry)
+    coordinator.hass = hass
+    coordinator.api = MagicMock()
+    coordinator.api.discovery_records = []
+    coordinator.api.async_get_devices = AsyncMock(return_value=[])
+    coordinator.api.async_refresh_scenarios = AsyncMock()
+    coordinator.api.async_fetch_mobile_settings = AsyncMock(return_value={})
+    coordinator._notifier = MagicMock()
+    coordinator._telemetry = MagicMock()
+    coordinator._telemetry.async_report = AsyncMock()
+    return coordinator
+
+
+def test_init_wires_api_and_state() -> None:
+    coordinator = _make_coordinator()
+    assert coordinator.api is not None
+    assert coordinator._overrides == {}
+    assert coordinator._fan_light_restore == {}
+
+
+@pytest.mark.asyncio
+async def test_update_data_success_returns_devices() -> None:
+    coordinator = _make_coordinator()
+    device = _device()
+    coordinator.data = [device]
+    coordinator.api.async_get_devices = AsyncMock(return_value=[device])
+
+    result = await coordinator._async_update_data()
+
+    assert result == [device]
+    coordinator._notifier.dismiss_operational_errors.assert_called_once()
+    coordinator._telemetry.async_report.assert_awaited_once()
+    coordinator.api.async_refresh_scenarios.assert_awaited_once()
+    coordinator._notifier.sync_maintenance_mode.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_update_data_auth_error_raises_config_entry_auth_failed() -> None:
+    coordinator = _make_coordinator()
+    coordinator.api.async_get_devices = AsyncMock(side_effect=EnkiAuthError("bad creds"))
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_update_data_connection_error_raises_update_failed_and_notifies() -> None:
+    coordinator = _make_coordinator()
+    coordinator.api.async_get_devices = AsyncMock(side_effect=EnkiConnectionError("down"))
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+
+@pytest.mark.asyncio
+async def test_update_data_swallows_telemetry_and_scenario_errors() -> None:
+    coordinator = _make_coordinator()
+    device = _device()
+    coordinator.data = [device]
+    coordinator.api.async_get_devices = AsyncMock(return_value=[device])
+    coordinator._telemetry.async_report = AsyncMock(side_effect=RuntimeError("telemetry boom"))
+    coordinator.api.async_refresh_scenarios = AsyncMock(side_effect=RuntimeError("scenarios boom"))
+
+    # Neither optional side task may break the poll.
+    result = await coordinator._async_update_data()
+    assert result == [device]
+
+
+@pytest.mark.asyncio
+async def test_maintenance_check_swallows_errors() -> None:
+    coordinator = _make_coordinator()
+    coordinator.api.async_fetch_mobile_settings = AsyncMock(side_effect=RuntimeError("nope"))
+
+    await coordinator._async_sync_maintenance_notification()
+
+    coordinator._notifier.sync_maintenance_mode.assert_not_called()
+
+
+def test_get_device_by_node_without_data_returns_none() -> None:
+    coordinator = _make_coordinator()
+    coordinator.data = None
+    assert coordinator.get_device_by_node("node") is None
+
+
+def test_get_device_by_node_finds_and_misses() -> None:
+    coordinator = _make_coordinator()
+    device = _device()
+    coordinator.data = [device]
+    assert coordinator.get_device_by_node("node") is device
+    assert coordinator.get_device_by_node("other") is None
+
+
+def test_request_reconcile_schedules_refresh() -> None:
+    coordinator = _make_coordinator()
+    coordinator.async_request_refresh = MagicMock(return_value="coro")
+    coordinator.request_reconcile()
+    coordinator.hass.async_create_task.assert_called_once_with("coro")
+
+
+def test_update_cached_value_noop_when_device_missing() -> None:
+    coordinator = _make_coordinator()
+    coordinator.data = [_device()]
+    coordinator.async_set_updated_data = MagicMock()
+
+    coordinator.update_cached_value("unknown-node", "power", "ON")
+
+    assert coordinator._overrides == {}
+    coordinator.async_set_updated_data.assert_not_called()
+
+
+def test_update_cached_nested_writes_and_records_override() -> None:
+    coordinator = _make_coordinator()
+    device = _device()
+    coordinator.data = [device]
+    coordinator.async_set_updated_data = MagicMock()
+
+    coordinator.update_cached_nested("node", "settings", "mode", "AUTO")
+
+    assert device.last_reported_value["settings"] == {"mode": "AUTO"}
+    assert ("nested", "settings", "mode") in coordinator._overrides["node"]
+    coordinator.async_set_updated_data.assert_called_once()
+
+
+def test_update_cached_nested_noop_when_device_missing() -> None:
+    coordinator = _make_coordinator()
+    coordinator.data = [_device()]
+    coordinator.update_cached_nested("missing", "settings", "mode", "AUTO")
+    assert coordinator._overrides == {}
+
+
+def test_update_endpoint_power_patches_endpoint_and_records() -> None:
+    coordinator = _make_coordinator()
+    device = _device(electrical_endpoints=[{"id": 2, "lastReportedValue": "OFF"}])
+    coordinator.data = [device]
+    coordinator.async_set_updated_data = MagicMock()
+
+    coordinator.update_endpoint_power("node", 2, "ON")
+
+    assert device.last_reported_value["electrical_endpoints"][0]["lastReportedValue"] == "ON"
+    assert ("endpoint", 2) in coordinator._overrides["node"]
+
+
+def test_update_endpoint_power_noop_when_device_missing() -> None:
+    coordinator = _make_coordinator()
+    coordinator.data = [_device()]
+    coordinator.update_endpoint_power("missing", 1, "ON")
+    assert coordinator._overrides == {}
+
+
+def test_remember_and_pop_fan_light_state() -> None:
+    coordinator = _make_coordinator()
+    coordinator.remember_fan_light_state("node", {1: "ON", 3: "OFF"})
+    assert coordinator.pop_fan_light_state("node") == {1: "ON", 3: "OFF"}
+    # Popped once, gone afterwards.
+    assert coordinator.pop_fan_light_state("node") is None
+
+
+def test_apply_overrides_drops_node_absent_from_poll() -> None:
+    coordinator = _make_coordinator()
+    coordinator.data = [_device(light_power="OFF")]
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.update_cached_value("node", "light_power", "ON")
+
+    # The device disappears from the fresh poll -> its overrides are dropped.
+    result = coordinator._apply_optimistic_overrides([])
+
+    assert result == []
+    assert coordinator._overrides == {}
+
+
+def test_apply_overrides_reapplies_nested_value() -> None:
+    coordinator = _make_coordinator()
+    device = _device()
+    coordinator.data = [device]
+    coordinator.async_set_updated_data = MagicMock()
+    coordinator.update_cached_nested("node", "settings", "mode", "AUTO")
+
+    fresh = _device(settings={"mode": "ECO"})
+    coordinator._apply_optimistic_overrides([fresh])
+
+    assert fresh.last_reported_value["settings"]["mode"] == "AUTO"
+
+
+# --- module-level override read/apply helpers --------------------------------
+
+
+def test_override_current_top() -> None:
+    device = _device(power="ON")
+    assert _override_current(device, ("top", "power")) == "ON"
+
+
+def test_override_current_nested() -> None:
+    device = _device(settings={"mode": "ECO"})
+    assert _override_current(device, ("nested", "settings", "mode")) == "ECO"
+    # Missing / non-dict parent yields None.
+    assert _override_current(_device(), ("nested", "settings", "mode")) is None
+
+
+def test_override_current_endpoint_dict_and_string() -> None:
+    dict_form = _device(electrical_endpoints=[{"id": 3, "lastReportedValue": {"power": "ON"}}])
+    assert _override_current(dict_form, ("endpoint", 3)) == "ON"
+
+    string_form = _device(electrical_endpoints=[{"id": 3, "lastReportedValue": "OFF"}])
+    assert _override_current(string_form, ("endpoint", 3)) == "OFF"
+
+
+def test_override_current_endpoint_missing_returns_none() -> None:
+    device = _device(electrical_endpoints=[{"id": 1, "lastReportedValue": "ON"}])
+    assert _override_current(device, ("endpoint", 9)) is None
+
+
+def test_override_current_unknown_kind_returns_none() -> None:
+    assert _override_current(_device(), ("bogus", "x")) is None
+
+
+def test_override_apply_top_and_nested() -> None:
+    device = _device()
+    _override_apply(device, ("top", "power"), "ON")
+    assert device.last_reported_value["power"] == "ON"
+
+    _override_apply(device, ("nested", "settings", "mode"), "AUTO")
+    assert device.last_reported_value["settings"]["mode"] == "AUTO"
+
+
+def test_override_apply_endpoint_dict_updates_power_key() -> None:
+    device = _device(electrical_endpoints=[{"id": 3, "lastReportedValue": {"power": "OFF"}}])
+    _override_apply(device, ("endpoint", 3), "ON")
+    assert device.last_reported_value["electrical_endpoints"][0]["lastReportedValue"]["power"] == (
+        "ON"
+    )
+
+
+def test_override_apply_endpoint_string_replaces_value() -> None:
+    device = _device(electrical_endpoints=[{"id": 3, "lastReportedValue": "OFF"}])
+    _override_apply(device, ("endpoint", 3), "ON")
+    assert device.last_reported_value["electrical_endpoints"][0]["lastReportedValue"] == "ON"

--- a/tests/unit/test_entity_base.py
+++ b/tests/unit/test_entity_base.py
@@ -1,0 +1,83 @@
+"""Unit tests for the shared EnkiEntity base."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from enki.domain.models import EnkiDevice
+from enki.entity import EnkiEntity
+
+
+def _device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-1",
+        "device_name": "Living room",
+        "device_type": "sensors",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [],
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _coordinator(device: EnkiDevice | None, *, success: bool = True) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.last_update_success = success
+    coordinator.get_device_by_node = lambda node_id: device
+    return coordinator
+
+
+def test_node_id_and_device_accessors() -> None:
+    device = _device()
+    entity = EnkiEntity(_coordinator(device), device)
+    assert entity.node_id == "node-1"
+    assert entity.device is device
+
+
+def test_available_true_when_active_and_polling() -> None:
+    device = _device()
+    assert EnkiEntity(_coordinator(device), device).available is True
+
+
+def test_unavailable_when_poll_failed() -> None:
+    device = _device()
+    assert EnkiEntity(_coordinator(device, success=False), device).available is False
+
+
+def test_unavailable_when_device_gone() -> None:
+    device = _device()
+    assert EnkiEntity(_coordinator(None), device).available is False
+
+
+def test_unavailable_when_deactivated() -> None:
+    device = _device(state="DEACTIVATED")
+    assert EnkiEntity(_coordinator(device), device).available is False
+
+
+def test_handle_coordinator_update_refreshes_device() -> None:
+    old = _device()
+    fresh = _device(device_name="Renamed")
+    entity = EnkiEntity(_coordinator(fresh), old)
+    entity.async_write_ha_state = MagicMock()
+    entity._handle_coordinator_update()  # noqa: SLF001
+    assert entity.device is fresh
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_device_info_carries_identity_and_firmware() -> None:
+    device = _device(
+        last_reported_value={
+            "firmware_version": "1.2.3",
+            "manufacturerId": "Lexman",
+            "modelNumber": "smart_plug",
+        }
+    )
+    info = EnkiEntity(_coordinator(device), device).device_info
+    assert info["identifiers"] == {("enki", "node-1")}
+    assert info["name"] == "Living room"
+    assert info["manufacturer"] == "Lexman"
+    assert info["model"] == "Smart Plug"
+    assert info["sw_version"] == "1.2.3"

--- a/tests/unit/test_fan_entity.py
+++ b/tests/unit/test_fan_entity.py
@@ -1,0 +1,395 @@
+"""Coverage for the EnkiFanEntity: speed, presets, direction, and power fans."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.domain.models import EnkiDevice
+from enki.fan import EnkiFanEntity, async_setup_entry
+from homeassistant.components.fan import (
+    DIRECTION_FORWARD,
+    DIRECTION_REVERSE,
+    FanEntityFeature,
+)
+
+
+def _coordinator() -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.api.async_set_fan_speed = AsyncMock()
+    coordinator.api.async_set_fan_rotation = AsyncMock()
+    coordinator.api.async_set_airflow_mode = AsyncMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    coordinator.update_endpoint_power = MagicMock()
+    coordinator.request_reconcile = MagicMock()
+    coordinator.remember_fan_light_state = MagicMock()
+    coordinator.pop_fan_light_state = MagicMock(return_value=None)
+    coordinator.batch_updates = MagicMock(return_value=nullcontext())
+    return coordinator
+
+
+def _speed_fan(**overrides) -> EnkiDevice:
+    """Speed-controlled fan (writable range) with airflow presets and rotation."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-fan",
+        "node_id": "node-fan",
+        "device_name": "Inspire Siroco",
+        "device_type": "ceiling_fans",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [
+            "change_fan_speed",
+            "change_fan_rotation_direction",
+            "change_airflow_mode",
+        ],
+        "possible_values": {
+            "change_fan_speed": {"format": "RANGE", "range": {"min": 0.0, "max": 6.0}},
+            "change_airflow_mode": {
+                "format": "VALUES",
+                "values": ["MANUAL", "BREEZE", "BOOST"],
+            },
+        },
+        "last_reported_value": {},
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def _power_fan(**overrides) -> EnkiDevice:
+    """Power-controlled fan without a writable speed range (ON/OFF only)."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-pfan",
+        "node_id": "node-pfan",
+        "device_name": "Basic Fan",
+        "device_type": "ceiling_fans",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["switch_electrical_power"],
+        "possible_values": {},
+        "last_reported_value": {},
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+# --- setup / features --------------------------------------------------------
+
+
+def test_setup_entry_creates_one_fan_per_fan_device() -> None:
+    coordinator = _coordinator()
+    coordinator.data = [_speed_fan(), _power_fan()]
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    added: list = []
+
+    import asyncio
+
+    asyncio.run(async_setup_entry(MagicMock(), entry, lambda entities: added.extend(entities)))
+
+    assert len(added) == 2
+    assert all(isinstance(entity, EnkiFanEntity) for entity in added)
+
+
+def test_supported_features_speed_fan_has_speed_direction_preset() -> None:
+    fan = EnkiFanEntity(_coordinator(), _speed_fan())
+    features = fan.supported_features
+    assert features & FanEntityFeature.TURN_ON
+    assert features & FanEntityFeature.TURN_OFF
+    assert features & FanEntityFeature.SET_SPEED
+    assert features & FanEntityFeature.DIRECTION
+    assert features & FanEntityFeature.PRESET_MODE
+
+
+def test_supported_features_power_fan_has_no_speed() -> None:
+    fan = EnkiFanEntity(_coordinator(), _power_fan())
+    features = fan.supported_features
+    assert features & FanEntityFeature.TURN_ON
+    assert not features & FanEntityFeature.SET_SPEED
+
+
+def test_speed_count_and_max_speed() -> None:
+    fan = EnkiFanEntity(_coordinator(), _speed_fan())
+    assert fan.speed_count == 6
+    assert fan._max_fan_speed == 6  # noqa: SLF001
+
+
+# --- presets -----------------------------------------------------------------
+
+
+def test_preset_modes_listed_from_metadata() -> None:
+    fan = EnkiFanEntity(_coordinator(), _speed_fan())
+    assert fan.preset_modes == ["manual", "breeze", "boost"]
+
+
+def test_preset_modes_none_when_unsupported() -> None:
+    fan = EnkiFanEntity(_coordinator(), _power_fan())
+    assert fan.preset_modes is None
+    assert fan.preset_mode is None
+
+
+def test_preset_mode_reflects_reported_airflow() -> None:
+    fan = EnkiFanEntity(_coordinator(), _speed_fan(last_reported_value={"airflow_mode": "BREEZE"}))
+    assert fan.preset_mode == "breeze"
+
+
+def test_preset_mode_none_when_reported_not_in_list() -> None:
+    fan = EnkiFanEntity(_coordinator(), _speed_fan(last_reported_value={"airflow_mode": "SLEEP"}))
+    assert fan.preset_mode is None
+
+
+def test_icon_uses_preset_icon_when_active() -> None:
+    fan = EnkiFanEntity(_coordinator(), _speed_fan(last_reported_value={"airflow_mode": "BREEZE"}))
+    assert fan.icon == "mdi:weather-windy"
+
+
+def test_icon_defaults_to_fan_ceiling() -> None:
+    fan = EnkiFanEntity(_coordinator(), _power_fan())
+    assert fan.icon == "mdi:fan-ceiling"
+
+
+@pytest.mark.asyncio
+async def test_set_preset_mode_writes_enki_mode() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan())
+
+    await fan.async_set_preset_mode("breeze")
+
+    coordinator.api.async_set_airflow_mode.assert_awaited_once_with("home-1", "node-fan", "BREEZE")
+    coordinator.update_cached_value.assert_called_once_with("node-fan", "airflow_mode", "BREEZE")
+    coordinator.request_reconcile.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_set_preset_mode_rejects_unknown() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan())
+    with pytest.raises(ValueError, match="Unsupported preset mode"):
+        await fan.async_set_preset_mode("hurricane")
+
+
+@pytest.mark.asyncio
+async def test_set_preset_mode_ignored_when_unsupported() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _power_fan())
+    await fan.async_set_preset_mode("breeze")
+    coordinator.api.async_set_airflow_mode.assert_not_called()
+
+
+# --- direction ---------------------------------------------------------------
+
+
+def test_current_direction_from_reported() -> None:
+    fan = EnkiFanEntity(
+        _coordinator(), _speed_fan(last_reported_value={"airflow_rotation": DIRECTION_REVERSE})
+    )
+    assert fan.current_direction == DIRECTION_REVERSE
+
+
+def test_supports_direction_via_reported_flag() -> None:
+    # A fan without a rotation capability but whose cloud state advertises support.
+    device = _power_fan(last_reported_value={"airflow_rotation_supported": True})
+    fan = EnkiFanEntity(_coordinator(), device)
+    assert fan.supported_features & FanEntityFeature.DIRECTION
+
+
+@pytest.mark.asyncio
+async def test_set_direction_writes_and_reconciles() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan())
+
+    await fan.async_set_direction(DIRECTION_FORWARD)
+
+    coordinator.api.async_set_fan_rotation.assert_awaited_once_with(
+        "home-1", "node-fan", DIRECTION_FORWARD
+    )
+    coordinator.update_cached_value.assert_called_once_with(
+        "node-fan", "airflow_rotation", DIRECTION_FORWARD
+    )
+    coordinator.request_reconcile.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_set_direction_ignores_invalid() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan())
+    await fan.async_set_direction("sideways")
+    coordinator.api.async_set_fan_rotation.assert_not_called()
+
+
+# --- on/off + percentage (speed fan) -----------------------------------------
+
+
+def test_is_on_speed_fan_tracks_speed() -> None:
+    on = EnkiFanEntity(_coordinator(), _speed_fan(last_reported_value={"fan_speed": 3}))
+    off = EnkiFanEntity(_coordinator(), _speed_fan(last_reported_value={"fan_speed": 0}))
+    unknown = EnkiFanEntity(_coordinator(), _speed_fan())
+    assert on.is_on is True
+    assert off.is_on is False
+    assert unknown.is_on is False
+
+
+def test_percentage_speed_fan() -> None:
+    fan = EnkiFanEntity(_coordinator(), _speed_fan(last_reported_value={"fan_speed": 3}))
+    assert fan.percentage == 50
+    zero = EnkiFanEntity(_coordinator(), _speed_fan(last_reported_value={"fan_speed": 0}))
+    assert zero.percentage == 0
+    unknown = EnkiFanEntity(_coordinator(), _speed_fan())
+    assert unknown.percentage is None
+
+
+def test_percentage_none_for_power_fan() -> None:
+    fan = EnkiFanEntity(_coordinator(), _power_fan())
+    assert fan.percentage is None
+
+
+@pytest.mark.asyncio
+async def test_turn_on_with_percentage_sets_speed() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan())
+
+    await fan.async_turn_on(percentage=50)
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 3)
+    coordinator.update_cached_value.assert_any_call("node-fan", "fan_speed", 3)
+
+
+@pytest.mark.asyncio
+async def test_turn_on_zero_percentage_turns_off() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan(last_reported_value={"fan_speed": 2}))
+
+    await fan.async_turn_on(percentage=0)
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 0)
+
+
+@pytest.mark.asyncio
+async def test_turn_on_without_percentage_restores_last_speed() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan(last_reported_value={"fan_speed": 4}))
+
+    await fan.async_turn_on()
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 4)
+
+
+@pytest.mark.asyncio
+async def test_turn_on_without_speed_defaults_to_one() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan())
+
+    await fan.async_turn_on()
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 1)
+
+
+@pytest.mark.asyncio
+async def test_turn_on_applies_preset_when_given() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan())
+
+    await fan.async_turn_on(preset_mode="boost", percentage=17)
+
+    coordinator.api.async_set_airflow_mode.assert_awaited_once_with("home-1", "node-fan", "BOOST")
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 1)
+
+
+@pytest.mark.asyncio
+async def test_turn_off_speed_fan_sets_zero() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan(last_reported_value={"fan_speed": 3}))
+
+    await fan.async_turn_off()
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 0)
+
+
+@pytest.mark.asyncio
+async def test_set_percentage_maps_to_speed() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan())
+
+    await fan.async_set_percentage(100)
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 6)
+
+
+@pytest.mark.asyncio
+async def test_set_percentage_zero_turns_off() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _speed_fan(last_reported_value={"fan_speed": 2}))
+
+    await fan.async_set_percentage(0)
+
+    coordinator.api.async_set_fan_speed.assert_awaited_once_with("home-1", "node-fan", 0)
+
+
+@pytest.mark.asyncio
+async def test_set_percentage_ignored_for_power_fan() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _power_fan())
+
+    await fan.async_set_percentage(50)
+
+    coordinator.api.async_set_fan_speed.assert_not_called()
+
+
+# --- on/off (power fan) ------------------------------------------------------
+
+
+def test_is_on_power_fan_prefers_power_signal() -> None:
+    on = EnkiFanEntity(_coordinator(), _power_fan(last_reported_value={"power": "ON"}))
+    off = EnkiFanEntity(_coordinator(), _power_fan(last_reported_value={"power": "OFF"}))
+    assert on.is_on is True
+    assert off.is_on is False
+
+
+def test_is_on_power_fan_falls_back_to_electrical_power() -> None:
+    fan = EnkiFanEntity(_coordinator(), _power_fan(last_reported_value={"electrical_power": "ON"}))
+    assert fan.is_on is True
+
+
+def test_is_on_power_fan_falls_back_to_speed() -> None:
+    # No power signals at all -> last resort is the (non-writable) fan speed.
+    fan = EnkiFanEntity(_coordinator(), _power_fan(last_reported_value={"fan_speed": 2}))
+    assert fan.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_turn_on_power_fan_switches_power() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _power_fan())
+
+    await fan.async_turn_on()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1", "node-pfan", "ON", endpoint=None
+    )
+    coordinator.update_cached_value.assert_any_call("node-pfan", "power", "ON")
+    coordinator.request_reconcile.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_turn_on_power_fan_zero_percentage_does_nothing() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _power_fan())
+
+    await fan.async_turn_on(percentage=0)
+
+    coordinator.api.async_switch_electrical_power.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_turn_off_power_fan_switches_power_off() -> None:
+    coordinator = _coordinator()
+    fan = EnkiFanEntity(coordinator, _power_fan())
+
+    await fan.async_turn_off()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1", "node-pfan", "OFF", endpoint=None
+    )

--- a/tests/unit/test_light_entities.py
+++ b/tests/unit/test_light_entities.py
@@ -1,0 +1,554 @@
+"""Coverage for the Enki light platform: entity build + on/off/color writes."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import nullcontext
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.domain.models import EnkiDevice
+from enki.light import (
+    EnkiFanLightEntity,
+    EnkiLightEntity,
+    _build_light_entities,
+    async_setup_entry,
+)
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_HS_COLOR,
+    ColorMode,
+)
+
+
+def _coordinator() -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.api.async_change_light_state = AsyncMock()
+    coordinator.api.async_change_light_color = AsyncMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    coordinator.update_cached_value = MagicMock()
+    coordinator.update_endpoint_power = MagicMock()
+    coordinator.request_reconcile = MagicMock()
+    coordinator.batch_updates = MagicMock(return_value=nullcontext())
+    return coordinator
+
+
+def _color_light(**overrides) -> EnkiDevice:
+    """Full colour light: brightness + color temp + hs, driven by light-state API."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-light",
+        "node_id": "node-light",
+        "device_name": "Colour Bulb",
+        "device_type": "lights",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [
+            "change_brightness",
+            "change_color_temperature",
+            "change_hue",
+            "change_saturation",
+            "change_light_state",
+            "check_light_state",
+        ],
+        "possible_values": {
+            "change_brightness": {"range": {"min": 1, "max": 100}},
+            "change_color_temperature": {"values": ["T2700K", "T4000K", "T6500K"]},
+            "change_light_state": {"format": "OBJECT"},
+        },
+        "last_reported_value": {},
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def _multi_gang_light(**overrides) -> EnkiDevice:
+    """Light-state light with two switchable power endpoints (per-endpoint on/off)."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-gang",
+        "node_id": "node-gang",
+        "device_name": "Double Gang",
+        "device_type": "lights",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["change_light_state", "check_light_state", "switch_electrical_power"],
+        "possible_values": {"change_light_state": {"format": "OBJECT"}},
+        "main_change_capability_id": "switch_electrical_power",
+        "main_change_capability_endpoints": [1, 2],
+        "last_reported_value": {
+            "electrical_endpoints": [
+                {"id": 1, "lastReportedValue": "ON"},
+                {"id": 2, "lastReportedValue": "OFF"},
+            ],
+        },
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def _electrical_light(**overrides) -> EnkiDevice:
+    """Light node without light-state: on/off only via switch_electrical_power."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-elec",
+        "node_id": "node-elec",
+        "device_name": "Relay Light",
+        "device_type": "lights",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["switch_electrical_power"],
+        "possible_values": {},
+        "last_reported_value": {},
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def _single_fan_light(**overrides) -> EnkiDevice:
+    """Ceiling fan with a single (node-global) light kit driven by light-state."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-sfan",
+        "node_id": "node-sfan",
+        "device_name": "Inspire Siroco",
+        "device_type": "ceiling_fans",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["change_fan_speed", "change_light_state", "check_light_state"],
+        "possible_values": {
+            "change_fan_speed": {"range": {"min": 0.0, "max": 6.0}},
+            "change_light_state": {"format": "OBJECT"},
+            "change_brightness": {"range": {"min": 1, "max": 100}},
+            "change_color_temperature": {"values": ["T2748K", "T6500K"]},
+        },
+        "last_reported_value": {},
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def _outlet(**overrides) -> EnkiDevice:
+    """Power-only outlet — not a controllable light."""
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-outlet",
+        "node_id": "node-outlet",
+        "device_name": "Outlet",
+        "device_type": "plugs",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": ["switch_electrical_power"],
+        "possible_values": {},
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+# --- setup / build -----------------------------------------------------------
+
+
+def test_async_setup_entry_adds_built_entities() -> None:
+    coordinator = _coordinator()
+    coordinator.data = [_color_light(), _outlet()]
+    entry = MagicMock()
+    entry.runtime_data = coordinator
+    added: list = []
+
+    asyncio.run(async_setup_entry(MagicMock(), entry, lambda entities: added.extend(entities)))
+
+    # Only the colour light is a controllable light; the outlet is skipped.
+    assert len(added) == 1
+    assert isinstance(added[0], EnkiLightEntity)
+
+
+def test_build_skips_non_controllable() -> None:
+    assert _build_light_entities(_coordinator(), _outlet()) == []
+
+
+def test_build_single_light_entity() -> None:
+    entities = _build_light_entities(_coordinator(), _color_light())
+    assert len(entities) == 1
+    assert isinstance(entities[0], EnkiLightEntity)
+    assert entities[0]._attr_unique_id == "enki-node-light-light"  # noqa: SLF001
+
+
+def test_build_multi_endpoint_light_entities() -> None:
+    entities = _build_light_entities(_coordinator(), _multi_gang_light())
+    assert len(entities) == 2
+    assert {entity._endpoint_id for entity in entities} == {1, 2}  # noqa: SLF001
+    assert len({entity._attr_unique_id for entity in entities}) == 2  # noqa: SLF001
+
+
+def test_build_single_fan_light_entity() -> None:
+    entities = _build_light_entities(_coordinator(), _single_fan_light())
+    assert len(entities) == 1
+    assert isinstance(entities[0], EnkiFanLightEntity)
+    assert entities[0]._endpoint_id is None  # noqa: SLF001
+
+
+# --- EnkiLightEntity: construction + supported color modes --------------------
+
+
+def test_color_light_declares_color_modes() -> None:
+    entity = EnkiLightEntity(_coordinator(), _color_light(), suffix="light")
+    assert ColorMode.COLOR_TEMP in {ColorMode.COLOR_TEMP}  # sanity for stub identity
+    # color temp bounds resolved from possibleValues
+    assert entity._attr_min_color_temp_kelvin == 2700  # noqa: SLF001
+    assert entity._attr_max_color_temp_kelvin == 6500  # noqa: SLF001
+
+
+def test_color_temp_without_values_uses_default_kelvin() -> None:
+    device = _color_light(
+        capabilities=["change_color_temperature", "change_light_state", "check_light_state"],
+        possible_values={"change_light_state": {"format": "OBJECT"}},
+    )
+    entity = EnkiLightEntity(_coordinator(), device, suffix="light")
+    assert entity._attr_min_color_temp_kelvin == 2000  # DEFAULT_MIN_KELVIN  # noqa: SLF001
+    assert entity._attr_max_color_temp_kelvin == 6500  # DEFAULT_MAX_KELVIN  # noqa: SLF001
+
+
+def test_onoff_only_light_falls_back_to_onoff_mode() -> None:
+    entity = EnkiLightEntity(_coordinator(), _multi_gang_light(), suffix="light_a", endpoint_id=1)
+    # No brightness/color caps but has electrical power -> ONOFF is supported.
+    assert entity._attr_supported_color_modes  # noqa: SLF001
+
+
+# --- EnkiLightEntity: properties ---------------------------------------------
+
+
+def test_is_on_endpoint_light() -> None:
+    device = _multi_gang_light()
+    on = EnkiLightEntity(_coordinator(), device, suffix="a", endpoint_id=1)
+    off = EnkiLightEntity(_coordinator(), device, suffix="b", endpoint_id=2)
+    assert on.is_on is True
+    assert off.is_on is False
+
+
+def test_is_on_endpoint_unknown_returns_false() -> None:
+    device = _multi_gang_light(last_reported_value={"electrical_endpoints": []})
+    entity = EnkiLightEntity(_coordinator(), device, suffix="a", endpoint_id=1)
+    assert entity.is_on is False
+
+
+def test_is_on_light_state_uses_global_power() -> None:
+    on = EnkiLightEntity(
+        _coordinator(), _color_light(last_reported_value={"power": "ON"}), suffix="l"
+    )
+    off = EnkiLightEntity(
+        _coordinator(), _color_light(last_reported_value={"power": "OFF"}), suffix="l"
+    )
+    missing = EnkiLightEntity(_coordinator(), _color_light(), suffix="l")
+    assert on.is_on is True
+    assert off.is_on is False
+    assert missing.is_on is False
+
+
+def test_is_on_electrical_light() -> None:
+    on = EnkiLightEntity(
+        _coordinator(),
+        _electrical_light(last_reported_value={"electrical_power": "ON"}),
+        suffix="l",
+    )
+    assert on.is_on is True
+
+
+def test_brightness_scales_to_255() -> None:
+    entity = EnkiLightEntity(
+        _coordinator(), _color_light(last_reported_value={"brightness": 50}), suffix="l"
+    )
+    assert entity.brightness == 128
+    none_entity = EnkiLightEntity(_coordinator(), _color_light(), suffix="l")
+    assert none_entity.brightness is None
+
+
+def test_color_temp_kelvin_parsed() -> None:
+    entity = EnkiLightEntity(
+        _coordinator(), _color_light(last_reported_value={"colorTemperature": "T4000K"}), suffix="l"
+    )
+    assert entity.color_temp_kelvin == 4000
+    none_entity = EnkiLightEntity(_coordinator(), _color_light(), suffix="l")
+    assert none_entity.color_temp_kelvin is None
+
+
+def test_hs_color_returns_none_without_hs_mode() -> None:
+    entity = EnkiLightEntity(
+        _coordinator(),
+        _color_light(last_reported_value={"hue": 0.5, "saturation": 0.5}),
+        suffix="l",
+    )
+    entity._attr_supported_color_modes = None  # noqa: SLF001
+    assert entity.hs_color is None
+
+
+def test_hs_color_denormalizes_when_hs_supported() -> None:
+    entity = EnkiLightEntity(
+        _coordinator(),
+        _color_light(last_reported_value={"hue": 0.5, "saturation": 0.5}),
+        suffix="l",
+    )
+    entity._attr_supported_color_modes = {ColorMode.HS}  # noqa: SLF001
+    assert entity.hs_color == (180.0, 50.0)
+
+
+def test_color_mode_prefers_attr() -> None:
+    entity = EnkiLightEntity(_coordinator(), _color_light(), suffix="l")
+    entity._attr_color_mode = ColorMode.COLOR_TEMP  # noqa: SLF001
+    assert entity.color_mode is ColorMode.COLOR_TEMP
+
+
+def test_color_mode_fallbacks() -> None:
+    entity = EnkiLightEntity(
+        _coordinator(), _color_light(last_reported_value={"colorMode": "hs"}), suffix="l"
+    )
+    entity._attr_color_mode = None  # noqa: SLF001
+    assert entity.color_mode is ColorMode.HS
+
+    entity2 = EnkiLightEntity(
+        _coordinator(), _color_light(last_reported_value={"colorMode": "ct"}), suffix="l"
+    )
+    entity2._attr_color_mode = None  # noqa: SLF001
+    assert entity2.color_mode is ColorMode.COLOR_TEMP
+
+    entity3 = EnkiLightEntity(
+        _coordinator(), _color_light(last_reported_value={"colorTemperature": "T3000K"}), suffix="l"
+    )
+    entity3._attr_color_mode = None  # noqa: SLF001
+    assert entity3.color_mode is ColorMode.COLOR_TEMP
+
+    entity4 = EnkiLightEntity(_coordinator(), _color_light(), suffix="l")
+    entity4._attr_color_mode = None  # noqa: SLF001
+    entity4._attr_supported_color_modes = {ColorMode.HS}  # noqa: SLF001
+    assert entity4.color_mode is ColorMode.HS
+
+    entity5 = EnkiLightEntity(_coordinator(), _color_light(), suffix="l")
+    entity5._attr_color_mode = None  # noqa: SLF001
+    entity5._attr_supported_color_modes = set()  # noqa: SLF001
+    assert entity5.color_mode is None
+
+
+# --- EnkiLightEntity: turn on/off --------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_turn_on_electrical_light() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _electrical_light(), suffix="l")
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1", "node-elec", "ON", endpoint=None
+    )
+    coordinator.update_cached_value.assert_any_call("node-elec", "electrical_power", "ON")
+
+
+@pytest.mark.asyncio
+async def test_turn_off_electrical_light() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _electrical_light(), suffix="l")
+
+    await entity.async_turn_off()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1", "node-elec", "OFF", endpoint=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_on_electrical_light_with_endpoint_caches_endpoint_power() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _electrical_light(), suffix="a", endpoint_id=1)
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1", "node-elec", "ON", endpoint=1
+    )
+    coordinator.update_endpoint_power.assert_called_once_with("node-elec", 1, "ON")
+
+
+@pytest.mark.asyncio
+async def test_turn_on_endpoint_light_uses_endpoint_power() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _multi_gang_light(), suffix="a", endpoint_id=2)
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1", "node-gang", "ON", endpoint=2
+    )
+    coordinator.api.async_change_light_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_turn_off_endpoint_light_uses_endpoint_power() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _multi_gang_light(), suffix="a", endpoint_id=1)
+
+    await entity.async_turn_off()
+
+    coordinator.api.async_switch_electrical_power.assert_awaited_once_with(
+        "home-1", "node-gang", "OFF", endpoint=1
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_on_with_hs_color() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _color_light(), suffix="l")
+
+    await entity.async_turn_on(**{ATTR_HS_COLOR: (180.0, 50.0)})
+
+    coordinator.api.async_change_light_color.assert_awaited_once()
+    args = coordinator.api.async_change_light_color.await_args.args
+    assert args[0] == "home-1" and args[1] == "node-light"
+    coordinator.update_cached_value.assert_any_call("node-light", "colorMode", "hs")
+    coordinator.update_cached_value.assert_any_call("node-light", "power", "ON")
+
+
+@pytest.mark.asyncio
+async def test_turn_on_with_brightness_via_light_state() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _color_light(), suffix="l")
+
+    await entity.async_turn_on(**{ATTR_BRIGHTNESS: 255})
+
+    coordinator.api.async_change_light_state.assert_awaited_once()
+    changes = coordinator.api.async_change_light_state.await_args.args[2]
+    assert changes["power"] == "ON"
+    assert changes["brightness"] == 100
+    coordinator.update_cached_value.assert_any_call("node-light", "brightness", 100)
+
+
+@pytest.mark.asyncio
+async def test_turn_on_with_color_temp_via_light_state() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _color_light(), suffix="l")
+
+    await entity.async_turn_on(**{ATTR_COLOR_TEMP_KELVIN: 4100})
+
+    changes = coordinator.api.async_change_light_state.await_args.args[2]
+    # 4100 K snaps to the nearest catalogued value (4000 K).
+    assert changes["colorTemperature"] == "T4000K"
+    coordinator.update_cached_value.assert_any_call("node-light", "colorMode", "ct")
+
+
+@pytest.mark.asyncio
+async def test_turn_on_plain_sets_power_on() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _color_light(), suffix="l")
+
+    await entity.async_turn_on()
+
+    changes = coordinator.api.async_change_light_state.await_args.args[2]
+    assert changes == {"power": "ON"}
+    coordinator.update_cached_value.assert_any_call("node-light", "power", "ON")
+
+
+@pytest.mark.asyncio
+async def test_turn_on_zero_brightness_turns_off() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _color_light(), suffix="l")
+
+    await entity.async_turn_on(**{ATTR_BRIGHTNESS: 1})
+
+    # Sub-minimum brightness collapses to a turn-off.
+    coordinator.api.async_change_light_state.assert_awaited_once_with(
+        "home-1", "node-light", {"power": "OFF"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_off_light_state() -> None:
+    coordinator = _coordinator()
+    entity = EnkiLightEntity(coordinator, _color_light(), suffix="l")
+
+    await entity.async_turn_off()
+
+    coordinator.api.async_change_light_state.assert_awaited_once_with(
+        "home-1", "node-light", {"power": "OFF"}
+    )
+    coordinator.update_cached_value.assert_any_call("node-light", "power", "OFF")
+
+
+# --- EnkiFanLightEntity ------------------------------------------------------
+
+
+def test_fan_light_is_on_global_and_endpoint() -> None:
+    glob = EnkiFanLightEntity(
+        _coordinator(), _single_fan_light(last_reported_value={"light_power": "ON"})
+    )
+    assert glob.is_on is True
+
+    device = _single_fan_light(
+        last_reported_value={"electrical_endpoints": [{"id": 3, "lastReportedValue": "ON"}]}
+    )
+    ep = EnkiFanLightEntity(_coordinator(), device, endpoint_id=3, suffix="light_a")
+    assert ep.is_on is True
+
+
+def test_fan_light_brightness_and_color_temp() -> None:
+    device = _single_fan_light(
+        last_reported_value={"brightness": 100, "colorTemperature": "T4000K"}
+    )
+    entity = EnkiFanLightEntity(_coordinator(), device)
+    assert entity.brightness == 255
+    assert entity.color_temp_kelvin == 4000
+
+    empty = EnkiFanLightEntity(_coordinator(), _single_fan_light())
+    assert empty.brightness is None
+    assert empty.color_temp_kelvin is None
+
+
+@pytest.mark.asyncio
+async def test_fan_light_turn_on_global_light_state() -> None:
+    coordinator = _coordinator()
+    entity = EnkiFanLightEntity(coordinator, _single_fan_light())
+
+    await entity.async_turn_on()
+
+    coordinator.api.async_change_light_state.assert_awaited_once()
+    coordinator.request_reconcile.assert_called_once()
+    coordinator.update_cached_value.assert_any_call("node-sfan", "light_power", "ON")
+
+
+@pytest.mark.asyncio
+async def test_fan_light_turn_on_with_brightness_and_color_temp() -> None:
+    coordinator = _coordinator()
+    entity = EnkiFanLightEntity(coordinator, _single_fan_light())
+
+    await entity.async_turn_on(**{ATTR_BRIGHTNESS: 255, ATTR_COLOR_TEMP_KELVIN: 6000})
+
+    changes = coordinator.api.async_change_light_state.await_args.args[2]
+    assert changes["brightness"] == 100
+    assert changes["colorTemperature"] == "T6500K"
+    coordinator.update_cached_value.assert_any_call("node-sfan", "brightness", 100)
+    coordinator.update_cached_value.assert_any_call("node-sfan", "colorTemperature", "T6500K")
+
+
+@pytest.mark.asyncio
+async def test_fan_light_turn_on_low_brightness_turns_off() -> None:
+    coordinator = _coordinator()
+    entity = EnkiFanLightEntity(coordinator, _single_fan_light())
+
+    await entity.async_turn_on(**{ATTR_BRIGHTNESS: 1})
+
+    coordinator.api.async_change_light_state.assert_awaited_once_with(
+        "home-1", "node-sfan", {"power": "OFF"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_fan_light_turn_off_global() -> None:
+    coordinator = _coordinator()
+    entity = EnkiFanLightEntity(coordinator, _single_fan_light())
+
+    await entity.async_turn_off()
+
+    coordinator.api.async_change_light_state.assert_awaited_once_with(
+        "home-1", "node-sfan", {"power": "OFF"}
+    )
+    coordinator.update_cached_value.assert_any_call("node-sfan", "light_power", "OFF")
+    coordinator.request_reconcile.assert_called_once()

--- a/tests/unit/test_production_coverage.py
+++ b/tests/unit/test_production_coverage.py
@@ -1,0 +1,58 @@
+"""Branch coverage for the solar production value parser."""
+
+from __future__ import annotations
+
+from enki.lib.production import parse_production_value
+
+
+def test_numeric_values_pass_through_as_float() -> None:
+    assert parse_production_value(0) == 0.0
+    assert parse_production_value(250) == 250.0
+    assert parse_production_value(12.5) == 12.5
+
+
+def test_string_with_unit_uses_bff_parser() -> None:
+    assert parse_production_value("109 W") == 109.0
+    assert parse_production_value("42.3 kWh") == 42.3
+
+
+def test_plain_numeric_string() -> None:
+    assert parse_production_value("88") == 88.0
+
+
+def test_non_numeric_string_returns_none() -> None:
+    # parse_bff_power fails and the float() fallback raises ValueError.
+    assert parse_production_value("not-a-number") is None
+
+
+def test_dict_value_key() -> None:
+    assert parse_production_value({"value": "109 W"}) == 109.0
+
+
+def test_dict_last_reported_value_key() -> None:
+    assert parse_production_value({"lastReportedValue": 305}) == 305.0
+
+
+def test_dict_amount_key() -> None:
+    assert parse_production_value({"amount": 7.5}) == 7.5
+
+
+def test_dict_nested_value() -> None:
+    assert parse_production_value({"value": {"amount": "12 W"}}) == 12.0
+
+
+def test_dict_first_matching_key_wins_over_later() -> None:
+    assert parse_production_value({"value": 1, "amount": 999}) == 1.0
+
+
+def test_dict_with_unparseable_value_returns_none() -> None:
+    assert parse_production_value({"value": "??"}) is None
+
+
+def test_dict_without_known_keys_returns_none() -> None:
+    assert parse_production_value({"foo": 1}) is None
+
+
+def test_none_and_other_types_return_none() -> None:
+    assert parse_production_value(None) is None
+    assert parse_production_value([1, 2, 3]) is None

--- a/tests/unit/test_select_entities.py
+++ b/tests/unit/test_select_entities.py
@@ -1,0 +1,83 @@
+"""Unit tests for the pilot-wire and roller-shutter-mode selects."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from enki.domain.models import EnkiDevice
+from enki.select import EnkiPilotWireSelect, EnkiRollerShutterModeSelect
+
+
+def _device(**kwargs) -> EnkiDevice:
+    defaults = {
+        "home_id": "home-1",
+        "device_id": "dev-1",
+        "node_id": "node-1",
+        "device_name": "Heater",
+        "device_type": "heaters_and_pilot_wires",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [],
+    }
+    defaults.update(kwargs)
+    return EnkiDevice(**defaults)
+
+
+def _coordinator(device: EnkiDevice) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.get_device_by_node = lambda node_id: device
+    coordinator.update_cached_value = MagicMock()
+    coordinator.api.async_set_pilot_wire_mode = AsyncMock()
+    coordinator.api.async_set_roller_shutter_mode = AsyncMock()
+    return coordinator
+
+
+# --- pilot wire -------------------------------------------------------------
+
+
+def test_pilot_wire_default_options_and_current() -> None:
+    device = _device(last_reported_value={"pilot_wire_state": "ECO"})
+    entity = EnkiPilotWireSelect(_coordinator(device), device)
+    assert "eco" in entity._attr_options  # noqa: SLF001
+    assert entity.current_option == "eco"
+
+
+def test_pilot_wire_current_none_when_unknown_value() -> None:
+    device = _device(last_reported_value={"pilot_wire_state": 123})
+    assert EnkiPilotWireSelect(_coordinator(device), device).current_option is None
+
+
+@pytest.mark.asyncio
+async def test_pilot_wire_select_posts_uppercase() -> None:
+    device = _device()
+    coordinator = _coordinator(device)
+    await EnkiPilotWireSelect(coordinator, device).async_select_option("comfort")
+    coordinator.api.async_set_pilot_wire_mode.assert_awaited_once_with(
+        "home-1", "node-1", "COMFORT"
+    )
+    coordinator.update_cached_value.assert_called_once_with("node-1", "pilot_wire_state", "COMFORT")
+
+
+# --- roller shutter mode ----------------------------------------------------
+
+
+def test_shutter_mode_options_and_current() -> None:
+    device = _device(last_reported_value={"roller_shutter_mode": "INVERTED"})
+    entity = EnkiRollerShutterModeSelect(_coordinator(device), device)
+    assert entity._attr_options == ["normal", "inverted"]  # noqa: SLF001
+    assert entity.current_option == "inverted"
+
+
+@pytest.mark.asyncio
+async def test_shutter_mode_select_posts_uppercase() -> None:
+    device = _device()
+    coordinator = _coordinator(device)
+    await EnkiRollerShutterModeSelect(coordinator, device).async_select_option("normal")
+    coordinator.api.async_set_roller_shutter_mode.assert_awaited_once_with(
+        "home-1", "node-1", "NORMAL"
+    )
+    coordinator.update_cached_value.assert_called_once_with(
+        "node-1", "roller_shutter_mode", "NORMAL"
+    )


### PR DESCRIPTION
Additive unit tests for the lowest-covered modules — no source changes, no test reorg (that's a separate follow-up). Coverage **74% → 84%**, **519 tests** pass.

## Per-file deltas
| Module | Before | After |
|---|---|---|
| `coordinator.py` | 65% | 100% |
| `entity.py` | 64% | 100% |
| `lib/production.py` | 48% | 100% |
| `fan.py` | 65% | 99% |
| `light.py` | 43% | 98% |
| `camera.py` | 0% | 95% |
| `climate.py` | 44% | 93% |
| `select.py` | 54% | 89% |
| `config_flow.py` | 45% | 83% |

## New test files
- `test_entity_base.py` — EnkiEntity availability, device_info, coordinator refresh
- `test_camera_snapshot.py` — snapshot fetch (cache, non-200, error paths)
- `test_select_entities.py`, `test_button_entities.py`, `test_climate_entity.py`
- `test_config_flow.py` — user/telemetry/options/reconfigure flows
- `test_coordinator_lifecycle.py` — update lifecycle, auth/connection errors, optimistic overrides
- `test_fan_entity.py`, `test_light_entities.py`, `test_production_coverage.py`

Remaining gaps are niche/unreachable branches. The **test folder reorg** (mirror `custom_components/enki/` structure) will land as a dedicated follow-up once the in-flight PRs are merged, to avoid churn.