### PR TITLE
feat(automation): device triggers for Enki binary sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisi
 - **Cameras** (Lexman/Meari) — `camera` (last-event snapshot), `sensor` (last motion, last event), `binary_sensor` (SD card); live video is not available (TUTK Kalay P2P native SDK) — [#135](https://github.com/cyrilcolinet/enki-integration-hass/issues/135)
 - **Scenarios** (Enki cloud) — `button`
 
+### Device triggers
+
+Enki sensors expose native automation triggers in the HA editor — **"motion detected"**, **"leak detected"**, **"window opened"**, **"vibration detected"**, etc. — so you can build automations without hand-writing state triggers (**Settings → Automations → Create → Device**).
+
 ### Blueprints
 
 Ready-made automations under `blueprints/automation/enki/` — import via **Settings → Automations & scenes → Blueprints → Import**.

--- a/custom_components/enki/device_trigger.py
+++ b/custom_components/enki/device_trigger.py
@@ -1,0 +1,118 @@
+"""Device automation triggers for Enki binary sensors.
+
+Exposes native "motion detected", "leak detected", "window opened", … triggers
+in the Home Assistant automation editor, so users don't have to hand-write state
+triggers. Each trigger is translated to a state trigger on the matching Enki
+binary-sensor entity.
+"""
+
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant.components.binary_sensor import (
+    DOMAIN as BINARY_SENSOR_DOMAIN,
+)
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+)
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import state as state_trigger
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+# device_class -> {trigger_type: (from_state, to_state)}
+_TRIGGERS_BY_CLASS: dict[BinarySensorDeviceClass, dict[str, tuple[str, str]]] = {
+    BinarySensorDeviceClass.MOTION: {
+        "motion_detected": (STATE_OFF, STATE_ON),
+        "motion_stopped": (STATE_ON, STATE_OFF),
+    },
+    BinarySensorDeviceClass.OCCUPANCY: {
+        "presence_detected": (STATE_OFF, STATE_ON),
+        "presence_cleared": (STATE_ON, STATE_OFF),
+    },
+    BinarySensorDeviceClass.MOISTURE: {
+        "leak_detected": (STATE_OFF, STATE_ON),
+        "leak_cleared": (STATE_ON, STATE_OFF),
+    },
+    BinarySensorDeviceClass.WINDOW: {
+        "window_opened": (STATE_OFF, STATE_ON),
+        "window_closed": (STATE_ON, STATE_OFF),
+    },
+    BinarySensorDeviceClass.OPENING: {
+        "opened": (STATE_OFF, STATE_ON),
+        "closed": (STATE_ON, STATE_OFF),
+    },
+    BinarySensorDeviceClass.VIBRATION: {
+        "vibration_detected": (STATE_OFF, STATE_ON),
+    },
+}
+
+# Flattened trigger_type -> (from_state, to_state); trigger types are unique.
+_TRIGGER_STATES: dict[str, tuple[str, str]] = {
+    trigger_type: states
+    for mapping in _TRIGGERS_BY_CLASS.values()
+    for trigger_type, states in mapping.items()
+}
+TRIGGER_TYPES = frozenset(_TRIGGER_STATES)
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict[str, str]]:
+    """List the device triggers available for one Enki device."""
+    registry = er.async_get(hass)
+    triggers: list[dict[str, str]] = []
+    for entry in er.async_entries_for_device(registry, device_id, include_disabled_entities=False):
+        if entry.domain != BINARY_SENSOR_DOMAIN or entry.platform != DOMAIN:
+            continue
+        device_class = entry.device_class or entry.original_device_class
+        for trigger_type in _TRIGGERS_BY_CLASS.get(device_class, {}):
+            triggers.append(
+                {
+                    CONF_PLATFORM: "device",
+                    CONF_DOMAIN: DOMAIN,
+                    CONF_DEVICE_ID: device_id,
+                    CONF_ENTITY_ID: entry.id,
+                    CONF_TYPE: trigger_type,
+                }
+            )
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a device trigger by delegating to the core state trigger."""
+    from_state, to_state = _TRIGGER_STATES[config[CONF_TYPE]]
+    state_config = {
+        CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+        state_trigger.CONF_FROM: from_state,
+        state_trigger.CONF_TO: to_state,
+    }
+    state_config = await state_trigger.async_validate_trigger_config(hass, state_config)
+    return await state_trigger.async_attach_trigger(
+        hass, state_config, action, trigger_info, platform_type="device"
+    )

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -268,5 +268,20 @@
       "title": "Enki — unsupported device",
       "description": "The device profile {summary} is not supported by the integration yet. Use the Learn more link to request support on GitHub."
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "motion_detected": "{entity_name} detected motion",
+      "motion_stopped": "{entity_name} stopped detecting motion",
+      "presence_detected": "{entity_name} detected presence",
+      "presence_cleared": "{entity_name} presence cleared",
+      "leak_detected": "{entity_name} detected a leak",
+      "leak_cleared": "{entity_name} leak cleared",
+      "window_opened": "{entity_name} window opened",
+      "window_closed": "{entity_name} window closed",
+      "opened": "{entity_name} opened",
+      "closed": "{entity_name} closed",
+      "vibration_detected": "{entity_name} detected vibration"
+    }
   }
 }

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -274,5 +274,20 @@
       "title": "Enki — unsupported device",
       "description": "The device profile {summary} is not supported by the integration yet. Use the Learn more link to request support on GitHub."
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "motion_detected": "{entity_name} detected motion",
+      "motion_stopped": "{entity_name} stopped detecting motion",
+      "presence_detected": "{entity_name} detected presence",
+      "presence_cleared": "{entity_name} presence cleared",
+      "leak_detected": "{entity_name} detected a leak",
+      "leak_cleared": "{entity_name} leak cleared",
+      "window_opened": "{entity_name} window opened",
+      "window_closed": "{entity_name} window closed",
+      "opened": "{entity_name} opened",
+      "closed": "{entity_name} closed",
+      "vibration_detected": "{entity_name} detected vibration"
+    }
   }
 }

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -274,5 +274,20 @@
       "title": "Enki — appareil non supporté",
       "description": "Le profil d'appareil {summary} n'est pas encore pris en charge par l'intégration. Utilisez le lien En savoir plus pour demander le support sur GitHub."
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "motion_detected": "{entity_name} a détecté un mouvement",
+      "motion_stopped": "{entity_name} ne détecte plus de mouvement",
+      "presence_detected": "{entity_name} a détecté une présence",
+      "presence_cleared": "{entity_name} présence dissipée",
+      "leak_detected": "{entity_name} a détecté une fuite",
+      "leak_cleared": "{entity_name} fuite dissipée",
+      "window_opened": "{entity_name} fenêtre ouverte",
+      "window_closed": "{entity_name} fenêtre fermée",
+      "opened": "{entity_name} ouvert",
+      "closed": "{entity_name} fermé",
+      "vibration_detected": "{entity_name} a détecté une vibration"
+    }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,3 +308,34 @@ _update = MagicMock()
 _update.UpdateEntity = _HaEntity
 _update.UpdateDeviceClass = MagicMock()
 sys.modules["homeassistant.components.update"] = _update
+
+# --- device automation triggers (device_trigger.py) ---
+_ha_const.CONF_DEVICE_ID = "device_id"
+_ha_const.CONF_DOMAIN = "domain"
+_ha_const.CONF_ENTITY_ID = "entity_id"
+_ha_const.CONF_PLATFORM = "platform"
+_ha_const.CONF_TYPE = "type"
+_ha_const.STATE_ON = "on"
+_ha_const.STATE_OFF = "off"
+_binary_sensor.DOMAIN = "binary_sensor"
+
+for _name in (
+    "homeassistant.components.device_automation",
+    "homeassistant.components.homeassistant",
+    "homeassistant.components.homeassistant.triggers",
+    "homeassistant.components.homeassistant.triggers.state",
+    "homeassistant.helpers.trigger",
+    "homeassistant.helpers.typing",
+    "homeassistant.helpers.config_validation",
+):
+    sys.modules.setdefault(_name, MagicMock())
+
+sys.modules["homeassistant.components.device_automation"].DEVICE_TRIGGER_BASE_SCHEMA = MagicMock()
+_state_trigger = sys.modules["homeassistant.components.homeassistant.triggers.state"]
+_state_trigger.CONF_FROM = "from"
+_state_trigger.CONF_TO = "to"
+# Wire submodule attributes so `from ...triggers import state` yields the stub above.
+sys.modules["homeassistant.components.homeassistant"].triggers = sys.modules[
+    "homeassistant.components.homeassistant.triggers"
+]
+sys.modules["homeassistant.components.homeassistant.triggers"].state = _state_trigger

--- a/tests/unit/core/test_device_trigger.py
+++ b/tests/unit/core/test_device_trigger.py
@@ -1,0 +1,80 @@
+"""Unit tests for Enki binary-sensor device triggers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from enki import device_trigger
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+
+def _entry(*, domain="binary_sensor", platform="enki", device_class=None, entity_id="id-1"):
+    return SimpleNamespace(
+        domain=domain,
+        platform=platform,
+        device_class=device_class,
+        original_device_class=device_class,
+        id=entity_id,
+    )
+
+
+def test_trigger_types_cover_expected_events() -> None:
+    for t in ("motion_detected", "leak_detected", "window_opened", "vibration_detected"):
+        assert t in device_trigger.TRIGGER_TYPES
+    # every trigger type maps to an (from, to) state pair
+    assert all(len(v) == 2 for v in device_trigger._TRIGGER_STATES.values())  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_get_triggers_builds_motion_and_leak() -> None:
+    entries = [
+        _entry(device_class=BinarySensorDeviceClass.MOTION, entity_id="e-motion"),
+        _entry(device_class=BinarySensorDeviceClass.MOISTURE, entity_id="e-leak"),
+    ]
+    with patch.object(device_trigger.er, "async_entries_for_device", return_value=entries):
+        triggers = await device_trigger.async_get_triggers(MagicMock(), "dev-1")
+
+    types = {t["type"] for t in triggers}
+    assert {"motion_detected", "motion_stopped", "leak_detected", "leak_cleared"} <= types
+    assert all(t["domain"] == "enki" and t["device_id"] == "dev-1" for t in triggers)
+
+
+@pytest.mark.asyncio
+async def test_get_triggers_skips_foreign_and_non_binary() -> None:
+    entries = [
+        _entry(platform="zha", device_class=BinarySensorDeviceClass.MOTION),
+        _entry(domain="sensor", device_class=BinarySensorDeviceClass.MOTION),
+        _entry(device_class=None),  # no device class → no triggers
+    ]
+    with patch.object(device_trigger.er, "async_entries_for_device", return_value=entries):
+        triggers = await device_trigger.async_get_triggers(MagicMock(), "dev-1")
+    assert triggers == []
+
+
+@pytest.mark.asyncio
+async def test_attach_trigger_translates_to_state_trigger() -> None:
+    config = {"type": "motion_detected", "entity_id": "binary_sensor.enki_motion"}
+    with (
+        patch.object(
+            device_trigger.state_trigger,
+            "async_validate_trigger_config",
+            new=AsyncMock(side_effect=lambda hass, cfg: cfg),
+        ),
+        patch.object(
+            device_trigger.state_trigger,
+            "async_attach_trigger",
+            new=AsyncMock(return_value="unsub"),
+        ) as attach,
+    ):
+        result = await device_trigger.async_attach_trigger(
+            MagicMock(), config, MagicMock(), MagicMock()
+        )
+
+    assert result == "unsub"
+    sent_config = attach.await_args.args[1]
+    # motion_detected fires on off → on
+    assert sent_config["from"] == "off"
+    assert sent_config["to"] == "on"
+    assert sent_config["entity_id"] == "binary_sensor.enki_motion"

--- a/tests/unit/core/test_platform_imports.py
+++ b/tests/unit/core/test_platform_imports.py
@@ -18,6 +18,9 @@ PLATFORM_MODULES = (
     "number",
     "select",
     "button",
+    "update",
+    "camera",
+    "device_trigger",
     "config_flow",
     "migration",
 )


### PR DESCRIPTION
Enki binary sensors now expose **native device triggers** in the HA automation editor — no more hand-written state triggers.

## Triggers (by sensor device class)
- motion → **motion detected** / **motion stopped**
- occupancy/presence → **presence detected** / **presence cleared**
- moisture → **leak detected** / **leak cleared**
- window → **window opened** / **window closed**
- opening (door/garage) → **opened** / **closed**
- vibration → **vibration detected**

`device_trigger.py` follows the standard HA pattern: it lists triggers from the device's Enki binary-sensor entities (via the entity registry) and delegates attachment to the core state trigger. Trigger labels are translated (EN/FR) under `device_automation.trigger_type`.

## Tests
Contrary to my earlier reservation, it **is** unit-testable in the stubbed harness: `test_device_trigger.py` covers the trigger-type map, `async_get_triggers` (build + filter foreign/non-binary entities), and `async_attach_trigger` (correct from/to state translation). Added to the smoke-import list too. **526 tests pass**, lint + JSON clean.

README updated with a "Device triggers" note.