### PR TITLE
feat(api): debug-log accepted outbound commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Download a [release](https://github.com/cyrilcolinet/enki-integration-hass/relea
 - **Invalid credentials** — Home Assistant prompts you to **re-authenticate** (notification + **Settings → Repairs**); enter your Enki password to reconnect
 - **HTTP 403** — Outdated gateway key after an Enki app update → surfaced as a repair in **Settings → Repairs**; see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
 - **No devices** — Device active in the app, same home
+- **Commands accepted but device doesn't react** — enable debug logging (`logger:` → `custom_components.enki: debug`); each accepted command logs its exact route and endpoint, which pinpoints a wrong-endpoint routing issue
 - **Bug** — [Issue](https://github.com/cyrilcolinet/enki-integration-hass/issues/new?template=bug.yml) + `enki` logs
 
 ## Resources

--- a/custom_components/enki/api/transport.py
+++ b/custom_components/enki/api/transport.py
@@ -209,6 +209,16 @@ class EnkiHttpClient:
                         body,
                     ),
                 )
+            # Log the accepted route so command-routing issues (e.g. a wrong
+            # endpoint selector on multi-endpoint fans) are visible in debug logs
+            # without a proxy capture.
+            LOGGER.debug(
+                "Enki command accepted: POST %s params=%s json=%s -> HTTP %s",
+                path,
+                params,
+                json,
+                response.status,
+            )
 
     async def get_homes(self) -> list[str]:
         data = await self.get_json("home", "/api-enki-home-prod/v1/homes")

--- a/tests/unit/api/test_api_transport.py
+++ b/tests/unit/api/test_api_transport.py
@@ -82,3 +82,30 @@ async def test_get_json_error_attaches_anonymized_report() -> None:
     assert report["status"] == 400
     assert report["request_headers"]["Authorization"] == "***"
     assert report["response_body"] == {"message": "invalid nodeId"}
+
+
+@pytest.mark.asyncio
+async def test_post_command_debug_logs_accepted_route() -> None:
+    from unittest.mock import patch
+
+    url = f"{ENKI_BASE_URL}/api-enki-power-prod/v1/power/n1/switch-electrical-power"
+    async with aiohttp.ClientSession() as session:
+        with aioresponses() as mocked, patch("enki.api.transport.LOGGER") as logger:
+            mocked.post(f"{url}?endpoints=2", status=202, body="")
+            client = EnkiHttpClient(_FakeAuth(), session)
+            await client.post_command(
+                "power",
+                "/api-enki-power-prod/v1/power/n1/switch-electrical-power",
+                home_id="h1",
+                params={"endpoints": 2},
+                json={"value": "OFF"},
+            )
+
+    logger.debug.assert_called_once()
+    fmt = logger.debug.call_args.args[0]
+    args = logger.debug.call_args.args[1:]
+    assert "command accepted" in fmt.lower()
+    # route, params (endpoint selector) and payload are all in the log record
+    assert "/switch-electrical-power" in args[0]
+    assert args[1] == {"endpoints": 2}
+    assert args[2] == {"value": "OFF"}


### PR DESCRIPTION
Small diagnostic win prompted by #178 (Inspire Cadix accepts HA commands but the device doesn't react).

Right now only **failed** commands are logged — an accepted (2xx) command that silently no-ops on the device leaves no trace, so diagnosing a wrong-endpoint routing issue needs a mitmproxy capture.

This logs every accepted command's **route, endpoint selector and payload** at debug level:

```
Enki command accepted: POST /api-enki-power-prod/v1/power/{node}/switch-electrical-power params={'endpoints': 2} json={'value': 'OFF'} -> HTTP 202
```

So a reporter can just enable `custom_components.enki: debug` and send the log line instead of capturing traffic.

- Debug level only (no change at default log level).
- Test added; README troubleshooting note. 527 tests pass, lint clean.

Refs #178