### PR TITLE
docs: install from the default HACS store

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cyrilcolinet/enki-integration-hass/actions/workflows/ci.yml"><img src="https://github.com/cyrilcolinet/enki-integration-hass/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/cyrilcolinet/enki-integration-hass" alt="License MIT"></a>
   <a href="https://www.home-assistant.io/"><img src="https://img.shields.io/badge/Home%20Assistant-2025.1+-41BDF5?logo=home-assistant&logoColor=white" alt="Home Assistant 2025.1+"></a>
-  <a href="https://hacs.xyz/"><img src="https://img.shields.io/badge/HACS-Custom-41BDF5.svg" alt="HACS Custom"></a>
+  <a href="https://hacs.xyz/"><img src="https://img.shields.io/badge/HACS-Default-41BDF5.svg" alt="HACS Default"></a>
 </p>
 
 <p align="center">
@@ -107,31 +107,34 @@ Per-device detail: [docs/SUPPORTED_DEVICES.md](docs/SUPPORTED_DEVICES.md) · His
 
 ### HACS (recommended)
 
+Enki is in the **default HACS store** — no custom repository needed.
+
 <p align="center">
   <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=cyrilcolinet&repository=enki-integration-hass&category=integration">
     <img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open in HACS">
   </a>
 </p>
 
-1. **HACS** → **Integrations** → **⋮** → **Custom repositories**
-2. URL: `https://github.com/cyrilcolinet/enki-integration-hass` — category **Integration**
-3. **Explore & download repositories** → **Enki** → **Download**
-4. **Restart** Home Assistant
-
-Default HACS store (goal): [docs/HACS.md](docs/HACS.md#default-hacs-store)
-
-Upgrading from [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)? See [docs/MIGRATION.md](docs/MIGRATION.md).
-
-### Add the integration
-
-1. In the **Enki app**, finish pairing and configuration for every device you want in Home Assistant
-2. **Settings** → **Devices & services** → **Add integration**
-3. Search for **Enki** — enter Enki email and password
+1. **HACS** → search **Enki** → **Download** (the badge above opens it directly on your instance)
+2. **Restart** Home Assistant
+3. **Settings** → **Devices & services** → **Add integration** → **Enki** — enter your Enki email and password
 4. Entities appear after the first poll (~30 s)
+
+<details>
+<summary>Not listed yet? Add it as a custom repository</summary>
+
+A freshly added default-store entry can take a while to reach every HACS instance. Until it shows up in search:
+
+1. **HACS** → **⋮** → **Custom repositories**
+2. URL `https://github.com/cyrilcolinet/enki-integration-hass`, category **Integration** → **Add**
+3. Search **Enki** → **Download** → **Restart** Home Assistant
+</details>
 
 ### Manual install
 
-Download a [release](https://github.com/cyrilcolinet/enki-integration-hass/releases) or clone this repo, copy `custom_components/enki/` into `config/custom_components/`, restart HA.
+Download a [release](https://github.com/cyrilcolinet/enki-integration-hass/releases) or clone this repo, copy `custom_components/enki/` into `config/custom_components/`, restart HA, then add the integration under **Settings → Devices & services**.
+
+Upgrading from [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)? See [docs/MIGRATION.md](docs/MIGRATION.md).
 
 ## Configuration
 

--- a/docs/HACS.md
+++ b/docs/HACS.md
@@ -2,9 +2,15 @@
 
 Checklist aligned with the [official HACS documentation](https://www.hacs.xyz/docs/publish/).
 
-## Custom repository (current install)
+**Status: published in the default HACS store.** Users install Enki straight from
+HACS (search **Enki**) — no custom repository needed. The custom-repository flow
+below is only a fallback while a HACS instance catches up with the default-store
+sync.
 
-Until inclusion in the default store, users add the repo manually or via the **Open in HACS** badge.
+## Custom repository (fallback)
+
+If the default-store entry hasn't synced to a given instance yet, add the repo
+manually or via the **Open in HACS** badge.
 
 1. **Public** GitHub repository
 2. [`hacs.json`](../hacs.json) at the root with at least `name`
@@ -40,11 +46,14 @@ HACS shows the last 5 releases when they exist.
 
 Releases are automated via [release-please](../docs/RELEASE.md): merge the `chore: release X.Y.Z` PR on `main` — the workflow creates the GitHub Release and uploads `enki.zip`.
 
-## Default HACS store
+## Default HACS store — done ✅
 
 Procedure: [Include default repositories](https://www.hacs.xyz/docs/publish/include/)
 
-**Repository status:** technical prerequisites are covered by CI on every push/PR:
+The [hacs/default](https://github.com/hacs/default) PR adding
+`cyrilcolinet/enki-integration-hass` to the `integration` file is **merged**, so
+the integration ships in the default store. The technical prerequisites below are
+kept green by CI on every push/PR:
 
 | Prerequisite | Status |
 |-----------|--------|
@@ -54,7 +63,7 @@ Procedure: [Include default repositories](https://www.hacs.xyz/docs/publish/incl
 | At least **one** GitHub release | ✅ [releases](https://github.com/cyrilcolinet/enki-integration-hass/releases) |
 | Brand `custom_components/enki/brand/` | ✅ `icon.png` (256) + `icon@2x.png` (512) — served locally by HA **2026.3+** ([Brands Proxy API](https://developers.home-assistant.io/blog/2026/02/24/brands-proxy-api)); **no longer need** a PR on [home-assistant/brands](https://github.com/home-assistant/brands) (new custom integrations rejected since Feb 2026) |
 
-**Remaining publication step:** PR on [hacs/default](https://github.com/hacs/default) (`integration` file), **alphabetical** entry: `cyrilcolinet/enki-integration-hass`.
+The `integration` entry is alphabetical: `cyrilcolinet/enki-integration-hass`. If the repo is ever renamed or moved, update that entry (and open a new PR) to keep the default-store listing valid.
 
 ## Local validation
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -13,7 +13,7 @@ Your email and password stay in the existing config entry. No need to add Enki a
 
 ## HACS updates — automatic?
 
-Custom repositories do **not** update silently by default. HACS shows an **Update** badge when a new release is available — you still click **Update**, then restart HA.
+HACS does **not** update silently by default. It shows an **Update** badge when a new release is available — you still click **Update**, then restart HA.
 
 To enable automatic updates: **HACS** → **Integrations** → **Enki** → enable automatic updates (if available in your HACS version).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,7 +33,7 @@ Short version: [README](../README.md) · detailed view below.
 | 🔜 Soon | Camera config controls (motion on/off, sensitivity) | REST-doable on Meari cameras; needs an indoor-camera owner to validate write endpoints ([#165](https://github.com/cyrilcolinet/enki-integration-hass/issues/165)) |
 | ⏳ Not planned | Camera live video | TUTK Kalay Nebula P2P — native SDK, no Python path |
 | ⏳ Not planned | Enki alarm | no API identified |
-| ✅ Prerequisite OK | Default HACS store | CI HACS + Hassfest green, releases published — [PR to `hacs/default`](HACS.md#default-hacs-store) |
+| ✅ Published | Default HACS store | listed in the default store — install from HACS directly (see [HACS.md](HACS.md)) |
 
 ## Tooling
 


### PR DESCRIPTION
Now that the [hacs/default](https://github.com/hacs/default) PR is merged, Enki ships in the default HACS store — so the install docs shouldn't tell people to add a custom repository first.

- **README** — HACS install is now "search Enki → Download"; the custom-repository steps move into a collapsible fallback (for instances that haven't synced the default store yet). Badge `HACS-Custom` → `HACS-Default`.
- **docs/HACS.md** — status marked "published in the default store ✅"; the hacs/default PR marked merged.
- **docs/ROADMAP.md** — default-store row → ✅ Published (fixes the now-stale anchor).
- **docs/MIGRATION.md** — "custom repositories don't update silently" → "HACS doesn't update silently" (no longer a custom repo).

Docs only.