### PR TITLE
fix(manifest): drop aiohttp requirement

### DIFF
--- a/custom_components/enki/manifest.json
+++ b/custom_components/enki/manifest.json
@@ -12,8 +12,6 @@
   "loggers": [
     "enki"
   ],
-  "requirements": [
-    "aiohttp>=3.9"
-  ],
+  "requirements": [],
   "version": "1.19.0"
 }


### PR DESCRIPTION
HACS review feedback from @frenck on the default-store submission: `manifest.json` declared `aiohttp>=3.9`, but Home Assistant core already ships aiohttp. Declaring it can only push the dependency resolver in a direction core didn't intend. We import aiohttp directly (auth/transport/client) — importing it is fine; requiring it is not.

`requirements` is now empty. No code change, 527 tests pass.