### PR TITLE
docs: add unofficial-project disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
 
 The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisio, Evology, Noirot, Envertech, …) through the **Leroy Merlin cloud**. This integration exposes in Home Assistant **everything visible in the Enki app** — using Enki **API capabilities** from the referentiel, like the mobile app, rather than a fixed model list.
 
+> **Disclaimer — unofficial project:** This is a community-maintained integration. It is **not** official, **not** affiliated with, and **not** endorsed by Leroy Merlin, ADEO, or Enki. The author and maintainers are **independent** and do **not** work for Enki. Full details: [docs/DISCLAIMER.md](docs/DISCLAIMER.md).
+
 ## Why this integration?
 
 - **Connection** — Enki email + password (OAuth Keycloak)
@@ -158,12 +160,13 @@ Upgrading from [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-
 - 🗺️ [Roadmap](docs/ROADMAP.md)
 - 🛠️ [Development & APK keys](docs/DEVELOPMENT.md)
 - 📡 [Opt-in telemetry](docs/TELEMETRY.md)
+- ⚠️ [Disclaimer — unofficial project](docs/DISCLAIMER.md)
 - 🏠 [Enki support](https://support.enki-home.com/)
 - 🔗 [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
 
 ## Credits & license
 
-**Community** integration, not affiliated with Leroy Merlin, Adeo, or Enki. Unofficial cloud API, subject to change.
+**Community** integration, not affiliated with Leroy Merlin, ADEO, or Enki — see the [disclaimer](docs/DISCLAIMER.md). Unofficial cloud API, subject to change.
 
 - Based on [CyrilP/hass-enki-component](https://github.com/CyrilP/hass-enki-component)
 

--- a/docs/DISCLAIMER.md
+++ b/docs/DISCLAIMER.md
@@ -1,0 +1,27 @@
+# Disclaimer
+
+## Unofficial project
+
+This Home Assistant integration is a **community project**. It is **not** an official Enki / Leroy Merlin product or service.
+
+- **Not affiliated** with Leroy Merlin, ADEO, or the Enki brand
+- **Not endorsed or sponsored** by Leroy Merlin, ADEO, or Enki
+- **Not maintained by Enki** — support for this integration comes from the open-source community via GitHub issues, not from Enki / Leroy Merlin customer support
+
+For official product support, use [Enki support](https://support.enki-home.com/) and the Enki mobile app.
+
+## Author and maintainers
+
+The integration was created and is maintained by independent contributors ([@cyrilcolinet](https://github.com/cyrilcolinet) and others). **None of them are Enki, Leroy Merlin, or ADEO employees** unless explicitly stated otherwise in a given contribution.
+
+## How it works
+
+The integration talks to the **Enki cloud API** — the same Adeo / Leroy Merlin cloud the mobile app uses — authenticating with **your own Enki account** (email + password, via Keycloak). It is **not** an official SDK: the endpoints and per-service gateway keys were documented by observing the mobile app, and Enki has neither published nor certified this integration. No credentials or data are sent anywhere other than the Enki cloud your app already talks to.
+
+## Trademarks
+
+"Enki", "Leroy Merlin", "ADEO", and device brand names (Lexman, Equation, Inspire, Eglo, Sedea, Edisio, Evology, Nodon, …) are trademarks of their respective owners. Their use in this repository is for **identification only** (compatible hardware and services). No affiliation or endorsement is implied.
+
+## No warranty
+
+This software is provided **as is** under the [MIT License](../LICENSE). The Enki cloud API is unofficial and may change, break, or disable this integration without notice; gateway keys may rotate on app updates. Use at your own risk, with your own account.


### PR DESCRIPTION
Adds a proper disclaimer, mirroring what I did on the eurevia-regate-rsmart repo:

- **`docs/DISCLAIMER.md`** — unofficial community project; not affiliated with / endorsed by Leroy Merlin, ADEO, or Enki; independent maintainers; how it works (unofficial Enki cloud API, your own account); trademarks for identification only; no warranty (MIT, API may change).
- **README** — a disclaimer blockquote right under the intro, plus links in the Resources list and Credits.

Docs only.