### PR TITLE
fix(telemetry): mark hue/saturation as covered for RGB lights

### DIFF
--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -447,6 +447,13 @@ class EnkiCapabilityProfile:
         )
 
     @property
+    def supports_rgb_color(self) -> bool:
+        """RGB bulbs expose an HS color mode when both hue and saturation change."""
+        return _supports(self.capabilities, self.possible_values, "change_hue") and _supports(
+            self.capabilities, self.possible_values, "change_saturation"
+        )
+
+    @property
     def supports_brightness_control(self) -> bool:
         return (
             _supports(

--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -43,6 +43,8 @@ _CAPABILITY_PROBES: dict[str, str] = {
     "change_airflow_mode": "supports_airflow_mode",
     "change_brightness": "supports_brightness_control",
     "change_color_temperature": "supports_color_temperature",
+    "change_hue": "supports_rgb_color",
+    "change_saturation": "supports_rgb_color",
     "change_fan_rotation_direction": "supports_fan_rotation",
     "change_fan_speed": "supports_fan_speed",
     "change_light_state": "supports_light_state",

--- a/tests/unit/domain/test_rgb_coverage.py
+++ b/tests/unit/domain/test_rgb_coverage.py
@@ -1,0 +1,57 @@
+"""RGB (hue/saturation) capabilities must count as covered (#187)."""
+
+from __future__ import annotations
+
+from enki.domain.capabilities import EnkiCapabilityProfile
+from enki.domain.profile import build_discovery_record
+from enki.domain.telemetry_coverage import capability_is_covered
+from enki.domain.telemetry_enrichment import uncovered_capabilities
+
+# Lexman connected light v2 (ref 603f0fa8f91f) from the #187 telemetry report.
+_LEXMAN_RGB_CAPS = [
+    "change_brightness",
+    "change_color_temperature",
+    "change_hue",
+    "change_light_state",
+    "change_saturation",
+    "check_electrical_power",
+    "check_light_state",
+    "switch_electrical_power",
+]
+
+
+def _profile(caps: list[str]) -> EnkiCapabilityProfile:
+    return EnkiCapabilityProfile(
+        device_type="lights",
+        capabilities=frozenset(caps),
+        possible_values={},
+        bff_device_type="lights",
+    )
+
+
+def test_supports_rgb_color_needs_both_hue_and_saturation() -> None:
+    assert _profile(_LEXMAN_RGB_CAPS).supports_rgb_color is True
+    assert _profile(["change_hue"]).supports_rgb_color is False
+    assert _profile(["change_saturation"]).supports_rgb_color is False
+
+
+def test_hue_and_saturation_are_covered_for_rgb_light() -> None:
+    profile = _profile(_LEXMAN_RGB_CAPS)
+    assert capability_is_covered("change_hue", profile) is True
+    assert capability_is_covered("change_saturation", profile) is True
+
+
+def test_rgb_light_reports_no_uncovered_color_capabilities() -> None:
+    record = build_discovery_record(
+        device_type="lights",
+        bff_device_type="lights",
+        capabilities=_LEXMAN_RGB_CAPS,
+        possible_values={},
+        manufacturer="Lexman",
+        model="ref 603f0fa8f91f",
+        firmware_version="2.0.0",
+        supported_by_integration=True,
+    )
+    missing = uncovered_capabilities(record)
+    assert "change_hue" not in missing
+    assert "change_saturation" not in missing


### PR DESCRIPTION
The #187 telemetry report (Lexman connected light v2) flagged `change_hue` / `change_saturation` as uncovered — but they're actually implemented: with both present the light exposes an HS color mode (`light.py`). They were just missing from the coverage map, so RGB bulbs generated a false "capability gap" report.

Adds a `supports_rgb_color` probe (both hue + saturation present) and maps both capabilities to it. 3 tests, 530 pass.

Refs #187