### PR TITLE
fix(api): stop polling a service the gateway refuses

### DIFF
--- a/custom_components/enki/api/transport.py
+++ b/custom_components/enki/api/transport.py
@@ -25,6 +25,11 @@ from .gateway_registry import OPTIONAL_KEY_TRANSPORT_IDS, WIRED_PATH_PREFIXES
 
 _ERROR_BODY_MAX = 200
 
+# The Adeo gateway's wording when an API key is not authorized for a service.
+# It is a standing decision on their side, not a transient failure: every read
+# on that micro-service answers the same 403 until they re-open it.
+_SERVICE_FORBIDDEN_MARKER = "cannot consume this service"
+
 
 def _http_error_message(method: str, path: str, status: int, body: str) -> str:
     """Build an error message that carries the response body's reason, if any.
@@ -60,6 +65,7 @@ class EnkiHttpClient:
         self._auth = auth
         self._session = session
         self._key_store = key_store or GatewayKeyStore()
+        self._forbidden_services: set[str] = set()
 
     @property
     def session(self) -> aiohttp.ClientSession:
@@ -71,6 +77,30 @@ class EnkiHttpClient:
 
     async def ensure_token(self) -> None:
         await self._auth.ensure_valid(self._session)
+
+    @property
+    def forbidden_services(self) -> frozenset[str]:
+        """Micro-services the gateway refused to serve during this session."""
+        return frozenset(self._forbidden_services)
+
+    def _note_forbidden(self, service: str, path: str, body: str) -> None:
+        """Remember a gateway-level refusal so we stop polling that service.
+
+        A 403 carrying the gateway's own wording means the API key is not
+        authorized for the whole micro-service. Retrying is pointless — these
+        reads run every polling cycle, so without this they flood the log until
+        the next restart. The first one still raises, so diagnostics keep a trace.
+        """
+        if _SERVICE_FORBIDDEN_MARKER not in body.lower():
+            return
+        if service not in self._forbidden_services:
+            self._forbidden_services.add(service)
+            LOGGER.warning(
+                "Enki gateway refuses service %r (GET %s -> 403); skipping its reads "
+                "until Home Assistant restarts",
+                service,
+                path,
+            )
 
     def _service_api_key(self, service: str) -> str | None:
         api_key = self._key_store.get_transport_key(service)
@@ -121,6 +151,8 @@ class EnkiHttpClient:
         not_found_ok: bool = False,
     ) -> dict[str, Any]:
         """GET returning parsed JSON; raises on unexpected status."""
+        if service in self._forbidden_services:
+            return {}
         url = f"{ENKI_BASE_URL}{path}"
 
         async def _get() -> aiohttp.ClientResponse:
@@ -143,6 +175,11 @@ class EnkiHttpClient:
                 return {}
             if response.status != 200:
                 body = await response.text()
+                if response.status == 403:
+                    # Record the refusal, then raise once so diagnostics and
+                    # read-error telemetry keep a trace; later reads on that
+                    # service short-circuit above.
+                    self._note_forbidden(service, path, body)
                 raise EnkiConnectionError(
                     _http_error_message("GET", path, response.status, body),
                     status=response.status,

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,6 +19,8 @@ Every microservice call sends:
 
 Gateway keys are bundled in `custom_components/enki/const.py`. They are **embedded in the Enki mobile APK** (one key per micro-service), not fetched from a central API. Refresh them after an app update with `scripts/extract_gateway_keys.py` (see [DEVELOPMENT.md](DEVELOPMENT.md)). Requests failing with `401`/`403` usually mean outdated credentials or gateway keys — Home Assistant shows a **persistent notification** with guidance.
 
+A `403 {"message":"You cannot consume this service"}` is different: the gateway is refusing the key for a whole micro-service, for every account, and no key refresh fixes it — Adeo has to re-open the API product. The transport records the first one (so it still reaches diagnostics and read-error telemetry), then stops reading that service until Home Assistant restarts, instead of retrying on every polling cycle. `api-enki-consumption-prod` and `api-enki-ota-prod` have been in that state since August 2026 — the keys we ship are byte-for-byte the ones app 2.26.3 uses.
+
 ## Discovery flow
 
 ```mermaid

--- a/tests/unit/api/test_api_transport.py
+++ b/tests/unit/api/test_api_transport.py
@@ -109,3 +109,48 @@ async def test_post_command_debug_logs_accepted_route() -> None:
     assert "/switch-electrical-power" in args[0]
     assert args[1] == {"endpoints": 2}
     assert args[2] == {"value": "OFF"}
+
+
+@pytest.mark.asyncio
+async def test_gateway_403_stops_further_reads_on_that_service() -> None:
+    """A gateway-level 403 raises once, then that service is skipped (#190).
+
+    `api-enki-consumption-prod` and `api-enki-ota-prod` started refusing the key
+    shipped with the app for every account. Those reads run on each polling
+    cycle, so retrying only floods the log.
+    """
+    body = '{"message":"You cannot consume this service"}'
+    url = f"{ENKI_BASE_URL}/api-enki-consumption-prod/v1/consumption/n1/check-instant-consumption"
+    path = "/api-enki-consumption-prod/v1/consumption/n1/check-instant-consumption"
+
+    async with aiohttp.ClientSession() as session:
+        with aioresponses() as mocked:
+            mocked.get(url, status=403, body=body)
+            client = EnkiHttpClient(_FakeAuth(), session)
+
+            with pytest.raises(EnkiConnectionError) as first:
+                await client.get_json("consumption", path)
+            assert first.value.status == 403
+
+            # No second HTTP call is registered on the mock: a further read would
+            # raise ConnectionError from aioresponses if it hit the network.
+            assert await client.get_json("consumption", path) == {}
+            assert "consumption" in client.forbidden_services
+
+            # Other services are untouched by one service's refusal.
+            assert "ota" not in client.forbidden_services
+
+
+@pytest.mark.asyncio
+async def test_unrelated_403_still_raises_every_time() -> None:
+    """A 403 without the gateway's wording is not a service-wide refusal."""
+    async with aiohttp.ClientSession() as session:
+        with aioresponses() as mocked:
+            mocked.get(f"{ENKI_BASE_URL}/probe", status=403, body='{"message":"Forbidden node"}')
+            mocked.get(f"{ENKI_BASE_URL}/probe", status=403, body='{"message":"Forbidden node"}')
+            client = EnkiHttpClient(_FakeAuth(), session)
+
+            for _ in range(2):
+                with pytest.raises(EnkiConnectionError):
+                    await client.get_json("lighting", "/probe")
+            assert not client.forbidden_services


### PR DESCRIPTION
`api-enki-consumption-prod` et `api-enki-ota-prod` répondent `403 {"message":"You cannot consume this service"}` sur tous les comptes depuis août. J'ai vérifié dans l'APK 2.26.3 : les clés qu'on embarque sont exactement celles que l'app utilise sur ces base URLs, et l'app n'envoie aucun en-tête supplémentaire. Ce n'est donc pas une clé périmée — c'est le produit d'API qu'Adeo a fermé côté gateway.

Ces deux lectures sont optionnelles et tournent à chaque cycle de polling, d'où un log rempli toutes les 30 s.

Le transport garde la première refus (diagnostics et télémétrie de read-error la voient toujours), puis arrête de lire ce service jusqu'au prochain redémarrage. Un `403` qui ne porte pas la formulation du gateway continue de remonter à chaque fois — ça reste une erreur ponctuelle, pas une fermeture de service.

Refs #190
