### PR TITLE
fix(binary-sensor): map OPEN for contact sensors

### DIFF
--- a/custom_components/enki/binary_sensor.py
+++ b/custom_components/enki/binary_sensor.py
@@ -11,16 +11,23 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .coordinator import EnkiCoordinator
 from .domain.models import EnkiDevice
 from .entity import EnkiEntity
+
+# (state_key, value) pairs already reported as unmapped — keeps the log to one
+# line per new enum instead of one per polling cycle.
+_UNMAPPED_SEEN: set[tuple[str, str]] = set()
 
 _ENUM_TO_BOOL = {
     "MOTION_DETECTED": True,
     "NO_MOTION_DETECTED": False,
     "VIBRATION_DETECTED": True,
     "NO_VIBRATION_DETECTED": False,
+    # The API reports contacts and shutter openings as OPEN; OPENED never comes
+    # back from the gateway but stays mapped, it costs nothing (#198).
+    "OPEN": True,
     "OPENED": True,
     "CLOSED": False,
     "WATER_DETECTED": True,
@@ -252,6 +259,21 @@ class EnkiBinarySensor(EnkiEntity, BinarySensorEntity):
             mapped = _ENUM_TO_BOOL.get(raw.upper())
             if mapped is not None:
                 return mapped
+            # An unmapped enum silently becomes "unknown" in Home Assistant, which
+            # is what #198 looked like from the outside. Say so once per value.
+            self._log_unmapped(raw)
         if isinstance(raw, bool):
             return raw
         return None
+
+    def _log_unmapped(self, raw: str) -> None:
+        seen = (self._state_key, raw.upper())
+        if seen in _UNMAPPED_SEEN:
+            return
+        _UNMAPPED_SEEN.add(seen)
+        LOGGER.debug(
+            "Unmapped %s value %r on node %s: reporting unknown",
+            self._state_key,
+            raw,
+            self.node_id,
+        )

--- a/tests/unit/entities/test_contact_open_state.py
+++ b/tests/unit/entities/test_contact_open_state.py
@@ -1,0 +1,55 @@
+"""Contact sensors report OPEN, not OPENED (issue #198)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from enki.binary_sensor import _build_binary_sensor_entities
+from enki.domain.models import EnkiDevice
+
+_CAPABILITY = "check_contact_sensor_state"
+
+
+def _sensor(value: str | None):
+    device = EnkiDevice(
+        home_id="home",
+        device_id="dev",
+        node_id="node-contact",
+        device_name="Porte cuisine",
+        device_type="sensors",
+        is_enabled=True,
+        state="ACTIVE",
+        capabilities=[_CAPABILITY, "check_vibration_detection"],
+        last_reported_value={"contact_sensor_state": value} if value else {},
+    )
+    return next(
+        e
+        for e in _build_binary_sensor_entities(MagicMock(), device)
+        if e._state_key == "contact_sensor_state"
+    )
+
+
+def test_open_is_on() -> None:
+    # The gateway's own enum for check_contact_sensor_state is OPEN / CLOSED;
+    # mapping only OPENED left every opening as "unknown" in Home Assistant.
+    assert _sensor("OPEN").is_on is True
+
+
+def test_opened_still_maps_for_safety() -> None:
+    assert _sensor("OPENED").is_on is True
+
+
+def test_closed_is_off() -> None:
+    assert _sensor("CLOSED").is_on is False
+
+
+def test_unknown_enum_stays_none_and_logs_once() -> None:
+    from unittest.mock import patch
+
+    import enki.binary_sensor as module
+
+    module._UNMAPPED_SEEN.clear()
+    with patch.object(module, "LOGGER") as logger:
+        assert _sensor("AJAR").is_on is None
+        assert _sensor("AJAR").is_on is None
+    assert logger.debug.call_count == 1


### PR DESCRIPTION
Les capteurs d'ouverture Lexman passaient à `unknown` à chaque ouverture au lieu de `open`.

L'énum du gateway pour `check_contact_sensor_state` est **`OPEN` / `CLOSED`** — vérifié dans l'app, qui mappe `common.opened → "OPEN"`. On ne connaissait que `OPENED`, donc la valeur tombait à côté de la table et l'entité repassait à `unknown`. `CLOSED` marchait, d'où un historique qui alternait entre « Fermé » et « Inconnu ».

`OPENED` reste mappé au cas où, ça ne coûte rien.

Au passage : une valeur inconnue est maintenant loguée une fois (par clé d'état et par valeur), au lieu de disparaître silencieusement en `unknown`. C'est exactement ce qui aurait rendu ce bug visible tout de suite.

Refs #198
