### PR TITLE
fix(fan): keep manual light changes over the Cadix restore

### DIFF
--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -191,6 +191,17 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         """Return and clear the pre-fan light snapshot, if any."""
         return self._fan_light_restore.pop(node_id, None)
 
+    def revise_fan_light_state(self, node_id: str, endpoint_id: int, power: str) -> None:
+        """Fold a manual light change into a pending pre-fan snapshot (#196).
+
+        Turning a light off while the fan runs must survive the fan stopping;
+        without this the restore replays the state captured before the fan
+        started and switches the light back on.
+        """
+        saved = self._fan_light_restore.get(node_id)
+        if saved is not None and endpoint_id in saved:
+            saved[endpoint_id] = power
+
     def _record_override(self, node_id: str, path: tuple, value: Any) -> None:
         self._overrides.setdefault(node_id, {})[path] = (
             value,

--- a/custom_components/enki/platforms/light/behavior.py
+++ b/custom_components/enki/platforms/light/behavior.py
@@ -69,7 +69,7 @@ class EnkiLightBehaviorMixin:
             power,
             endpoint=endpoint_id,
         )
-        self.coordinator.update_endpoint_power(self._device.node_id, endpoint_id, power)
+        self._cache_endpoint_power(endpoint_id, power)
 
     def _light_endpoints_have_mixed_power(self: EnkiEntity) -> bool:
         return self._device.reported.light_endpoints_have_mixed_power(self._light_endpoint_ids())
@@ -128,10 +128,19 @@ class EnkiLightBehaviorMixin:
         endpoint_id: int | None = None,
     ) -> None:
         if endpoint_id is not None:
-            self.coordinator.update_endpoint_power(self._device.node_id, endpoint_id, power)
+            self._cache_endpoint_power(endpoint_id, power)
             return
         for gang_id in self._light_endpoint_ids():
-            self.coordinator.update_endpoint_power(self._device.node_id, gang_id, power)
+            self._cache_endpoint_power(gang_id, power)
+
+    def _cache_endpoint_power(self: EnkiEntity, endpoint_id: int, power: str) -> None:
+        """Patch the cached endpoint power, and the pending fan-light snapshot.
+
+        A light switched by hand while the fan runs must not be reverted when the
+        fan stops and the pre-fan configuration is restored (#196).
+        """
+        self.coordinator.update_endpoint_power(self._device.node_id, endpoint_id, power)
+        self.coordinator.revise_fan_light_state(self._device.node_id, endpoint_id, power)
 
     @staticmethod
     def _parse_color_temp_values(possible_values: dict[str, Any]) -> list[int]:

--- a/tests/unit/entities/test_fan_multi_light.py
+++ b/tests/unit/entities/test_fan_multi_light.py
@@ -9,6 +9,7 @@ to its own Home Assistant entity with independent per-endpoint on/off state.
 from __future__ import annotations
 
 from contextlib import nullcontext
+from types import MethodType
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -310,3 +311,63 @@ async def test_cadix_fan_speed_change_while_running_does_not_recouple() -> None:
     coordinator.remember_fan_light_state.assert_not_called()
     coordinator.pop_fan_light_state.assert_not_called()
     coordinator.update_endpoint_power.assert_not_called()
+
+
+def _coordinator_with_real_snapshot() -> MagicMock:
+    """Mock coordinator whose fan-light snapshot methods are the real ones."""
+    coordinator = _coordinator()
+    coordinator._fan_light_restore = {}
+    for name in (
+        "remember_fan_light_state",
+        "pop_fan_light_state",
+        "revise_fan_light_state",
+    ):
+        setattr(coordinator, name, MethodType(getattr(EnkiCoordinator, name), coordinator))
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_light_switched_off_while_fan_runs_stays_off_after_stop() -> None:
+    """Issue #196: the restore must not undo a manual change made meanwhile.
+
+    Both lights on, fan started (the ring goes off in firmware), then the user
+    switches the main light off and stops the fan. The pre-fan snapshot said the
+    main light was on, so restoring it verbatim switched it back on and Home
+    Assistant showed both lights lit.
+    """
+    coordinator = _coordinator_with_real_snapshot()
+    device = _cadix(
+        last_reported_value={
+            "electrical_endpoints": [
+                {"id": 1, "lastReportedValue": "ON"},  # main
+                {"id": 2, "lastReportedValue": "ON"},  # motor
+                {"id": 3, "lastReportedValue": "ON"},  # ambient ring
+            ],
+        },
+    )
+    fan = EnkiFanEntity(coordinator, device)
+    main = EnkiFanLightEntity(coordinator, device, endpoint_id=1, suffix="light_a")
+
+    await fan.async_turn_on(percentage=50)
+    assert coordinator._fan_light_restore["node-cadix"] == {1: "ON", 3: "ON"}
+
+    await main.async_turn_off()
+    assert coordinator._fan_light_restore["node-cadix"] == {1: "OFF", 3: "ON"}
+
+    device.last_reported_value["fan_speed"] = 3  # running, so turning off stops it
+    coordinator.update_endpoint_power.reset_mock()
+    await fan.async_turn_off()
+
+    restored = {(c.args[1], c.args[2]) for c in coordinator.update_endpoint_power.call_args_list}
+    assert (1, "OFF") in restored  # user's choice wins
+    assert (3, "ON") in restored  # ring still comes back, as the device does
+
+
+@pytest.mark.asyncio
+async def test_manual_light_change_without_running_fan_touches_no_snapshot() -> None:
+    coordinator = _coordinator_with_real_snapshot()
+    light = EnkiFanLightEntity(coordinator, _cadix(), endpoint_id=1, suffix="light_a")
+
+    await light.async_turn_off()
+
+    assert coordinator._fan_light_restore == {}


### PR DESCRIPTION
Séquence rapportée : les deux lumières allumées → ventilo allumé (le firmware éteint l'anneau) → on éteint la lumière principale à la main → ventilo éteint → **les deux lumières s'affichent allumées** dans Home Assistant.

Cause : le couplage Cadix (#106) capture la configuration lumière avant le démarrage du ventilo et la rejoue à l'arrêt. Le snapshot disait « principale = ON », donc l'extinction manuelle faite entre-temps était écrasée par la restauration.

Chaque écriture manuelle sur un endpoint est maintenant répercutée dans le snapshot en attente : la restauration ne ramène que ce que l'utilisateur n'a pas touché. Dans la séquence ci-dessus, la principale reste éteinte et l'anneau se rallume — ce que fait aussi l'appareil.

Le rallumage de l'anneau par le firmware n'est pas de notre ressort (l'app Enki fait pareil), mais l'état affiché correspond maintenant à la réalité.

2 tests ajoutés, dont la séquence complète du rapport.

Refs #196
