### PR TITLE
feat(switch): support DIO outlets as assumed-state switches

### DIFF
--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -125,6 +125,20 @@ class EnkiCapabilityProfile:
         )
 
     @property
+    def supports_electrical_power_read(self) -> bool:
+        """True when the outlet reports its state, not only accepts commands.
+
+        One-way RF outlets (DIO, …) declare ``switch_electrical_power`` alone:
+        the cloud never learns whether the plug actually switched, so Home
+        Assistant has to treat their state as assumed (#203).
+        """
+        return _supports(
+            self.capabilities,
+            self.possible_values,
+            "check_electrical_power",
+        )
+
+    @property
     def channel_power_indices(self) -> list[int]:
         """1-based channel numbers of a multi-channel in-wall power module.
 

--- a/custom_components/enki/lib/enki_scope.py
+++ b/custom_components/enki/lib/enki_scope.py
@@ -8,6 +8,8 @@ _ENKI_ECOSYSTEM_MANUFACTURERS = frozenset(
     {
         "adeo",
         "acova",
+        # DIO is an Enki hub partner (433 MHz RF outlets), not third-party Zigbee.
+        "dio",
         "edisio",
         "eglo",
         "enki",

--- a/custom_components/enki/switch.py
+++ b/custom_components/enki/switch.py
@@ -205,6 +205,13 @@ class EnkiOutletSwitch(EnkiEntity, SwitchEntity):
         super().__init__(coordinator, device)
         self._endpoint_id = endpoint_id
         self._attr_unique_id = f"{DOMAIN}-{device.node_id}-{suffix}"
+        # One-way RF outlets (DIO, …) accept commands but never report back, and
+        # a per-endpoint outlet reads its state from the dashboard payload. Only
+        # the first case is assumed: Home Assistant then offers on/off buttons
+        # instead of a toggle that would flap back to unknown (#203).
+        self._attr_assumed_state = (
+            endpoint_id is None and not device.profile.supports_electrical_power_read
+        )
 
     @property
     def is_on(self) -> bool | None:

--- a/docs/SUPPORTED_DEVICES.md
+++ b/docs/SUPPORTED_DEVICES.md
@@ -11,7 +11,7 @@ Summary: [ROADMAP.md](ROADMAP.md)
 
 ## Scope
 
-This integration covers **only the Enki / Leroy Merlin ecosystem**: Lexman, Equation, Inspire, Noirot, Edisio, Eglo, Sedea, Evology, Nodon, ACOVA, Envertech, Meari, etc. (exact list: [`lib/enki_scope.py`](../custom_components/enki/lib/enki_scope.py)).
+This integration covers **only the Enki / Leroy Merlin ecosystem**: Lexman, Equation, Inspire, Noirot, Edisio, Eglo, Sedea, Evology, Nodon, ACOVA, Envertech, Meari, DIO, etc. (exact list: [`lib/enki_scope.py`](../custom_components/enki/lib/enki_scope.py)).
 
 **In scope:** anything **visible and working in the Enki app** — Wi‑Fi devices (no hub required) and Zigbee devices paired on the Enki hub.
 
@@ -52,6 +52,7 @@ Fan and light kit are **independent**: turning one on does not turn the other on
 | Edisio outlets | ✅ ON/OFF, ✅ instant consumption (W) |
 | Equation ON/OFF relay | ✅ ON/OFF stable v1.6.8+ (instant consumption may stay unknown) |
 | Evology 2-channel in-wall module | ✅ one `switch` per channel (`check_channel1_electrical_power`, `check_channel2_electrical_power`) |
+| DIO outlets (433 MHz RF) | ✅ ON/OFF, ⚠️ **assumed state** — the RF is one-way, so nothing reports back and Home Assistant shows on/off buttons instead of a toggle |
 
 Multi-circuit nodes may create **one entity per circuit** (BFF endpoint). Timers (`switch_electrical_power_in`, …): not exposed yet.
 

--- a/tests/unit/entities/test_dio_outlet.py
+++ b/tests/unit/entities/test_dio_outlet.py
@@ -1,0 +1,65 @@
+"""DIO outlets: in scope, and assumed-state because the RF is one-way (#203)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from enki.domain.models import EnkiDevice
+from enki.lib.enki_scope import device_in_enki_scope
+from enki.switch import _build_switch_entities
+
+
+def _dio_outlet(**overrides) -> EnkiDevice:
+    # Shape reported by scripts/discover_devices.py on a DIO 2300 W nano outlet.
+    defaults = {
+        "home_id": "home",
+        "device_id": "dev-dio",
+        "node_id": "node-dio",
+        "device_name": "Prise salon",
+        "device_type": "outlets",
+        "bff_device_type": "outlets",
+        "is_enabled": True,
+        "state": "ACTIVE",
+        "capabilities": [
+            "cancel_electrical_power_switch_in",
+            "next_electrical_power_switch_in",
+            "switch_electrical_power",
+            "switch_electrical_power_in",
+        ],
+        "possible_values": {"switch_electrical_power": {"values": ["ON", "OFF"]}},
+        "referentiel_i18n": "tr_device_dio_outlet_2300Watt_nano_label",
+    }
+    defaults.update(overrides)
+    return EnkiDevice(**defaults)
+
+
+def test_dio_is_in_enki_scope() -> None:
+    # DIO is an Enki hub partner (433 MHz RF), not third-party Zigbee.
+    assert device_in_enki_scope(manufacturer="Dio", device_type="outlets") is True
+
+
+def test_unrelated_brand_still_out_of_scope() -> None:
+    assert device_in_enki_scope(manufacturer="Tuya", device_type="outlets") is False
+
+
+def test_dio_outlet_builds_a_switch() -> None:
+    entities = _build_switch_entities(MagicMock(), _dio_outlet())
+    assert len(entities) == 1
+
+
+def test_dio_outlet_is_assumed_state() -> None:
+    # No check_electrical_power: the cloud never learns the real state, so the
+    # entity must not claim to know it.
+    switch = _build_switch_entities(MagicMock(), _dio_outlet())[0]
+    assert switch._attr_assumed_state is True
+    assert switch.is_on is None
+
+
+def test_readable_outlet_is_not_assumed_state() -> None:
+    device = _dio_outlet(
+        capabilities=["switch_electrical_power", "check_electrical_power"],
+        last_reported_value={"electrical_power": "ON"},
+    )
+    switch = _build_switch_entities(MagicMock(), device)[0]
+    assert switch._attr_assumed_state is False
+    assert switch.is_on is True


### PR DESCRIPTION
Le dump de découverte de @rhox14 (#203) confirme l'hypothèse : une prise DIO est une prise ordinaire côté API.

```json
"bff_device_type": "outlets",
"capabilities": ["cancel_electrical_power_switch_in", "next_electrical_power_switch_in",
                 "switch_electrical_power", "switch_electrical_power_in"],
"manufacturer": "Dio",
"possible_values": {"switch_electrical_power": {"values": ["ON", "OFF"]}},
"ha_platforms": ["switch"],
"supported_by_integration": false,
"telemetry_excluded": "out_of_enki_scope"
```

Le profil calcule déjà `switch` comme plateforme cible : seul le filtre de marque l'écartait. DIO est un partenaire du hub Enki en RF 433, pas du Zigbee tiers — ce n'est pas le cas que la règle du README vise à exclure. **C'est la décision de périmètre à valider avant de merger.**

Deux changements :

- `dio` rejoint la liste écosystème dans `enki_scope.py` ;
- une prise sans `check_electrical_power` est marquée `assumed_state`. La RF est unidirectionnelle : rien ne remonte jamais, donc l'entité retombait à `unknown` dès l'expiration de l'écriture optimiste. Home Assistant affiche maintenant deux boutons on/off au lieu d'un interrupteur qui ment. Les prises qui savent se relire ne changent pas de comportement.

Non traité : `switch_electrical_power_in` et compagnie (allumage différé), déjà listés comme non exposés dans la doc.

5 tests, dont la forme exacte du dump.

Refs #203
