### PR TITLE
fix(switch): hold the last command on write-only outlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ---
 
-The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisio, Evology, Noirot, Envertech, …) through the **Leroy Merlin cloud**. This integration exposes in Home Assistant **everything visible in the Enki app** — using Enki **API capabilities** from the referentiel, like the mobile app, rather than a fixed model list.
+The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisio, Evology, Noirot, Envertech, DIO, …) through the **Leroy Merlin cloud**. This integration exposes in Home Assistant **everything visible in the Enki app** — using Enki **API capabilities** from the referentiel, like the mobile app, rather than a fixed model list.
 
 > **Disclaimer — unofficial project:** This is a community-maintained integration. It is **not** official, **not** affiliated with, and **not** endorsed by Leroy Merlin, ADEO, or Enki. The author and maintainers are **independent** and do **not** work for Enki. Full details: [docs/DISCLAIMER.md](docs/DISCLAIMER.md).
 
@@ -53,7 +53,7 @@ The **Enki** app controls hundreds of products (Lexman, Equation, Inspire, Edisi
 
 - **Ventilation** (Inspire Siroco+, Cadix, Radix, …) — `fan`, `light` (LED kit); the **Cadix** exposes its main light and ambient ring as separate lights with optimistic fan/light coupling (since **v1.11**)
 - **Lighting** (Eglo, Lexman, dimmables, RGB) — `light`
-- **Outlets & relays** (Edisio, Equation ON/OFF) — `light` / ON-OFF power; **Evology 2-channel module** — one `switch` per channel
+- **Outlets & relays** (Edisio, Equation ON/OFF) — `light` / ON-OFF power; **Evology 2-channel module** — one `switch` per channel; **DIO outlets** — `switch` with assumed state (one-way 433 MHz RF, nothing reports back) (since **v1.21**)
 - **Water heater relay** (Lexman/Nodon on-off relay re-typed as boiler) — `switch`
 - **Solar** (Envertech-Lexman) — `sensor` (production W)
 - **Sensors** (Lexman, Sedea, Evology multisensor, …) — `binary_sensor` (motion, presence, contact), `sensor` (temp, humidity, battery, brightness)

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -279,7 +280,14 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
                 continue
             for path in list(paths):
                 value, expires_at = paths[path]
-                if now >= expires_at or _override_current(device, path) == value:
+                current = _override_current(device, path)
+                if now >= expires_at or current == value:
+                    del paths[path]
+                    continue
+                # A held-forever value belongs to a device that never reports
+                # back. The moment the cloud does report something — the plug
+                # was switched by its remote, say — it knows better than we do.
+                if math.isinf(expires_at) and current is not None:
                     del paths[path]
                     continue
                 _override_apply(device, path, value)

--- a/custom_components/enki/coordinator.py
+++ b/custom_components/enki/coordinator.py
@@ -202,19 +202,38 @@ class EnkiCoordinator(DataUpdateCoordinator[list[EnkiDevice]]):
         if saved is not None and endpoint_id in saved:
             saved[endpoint_id] = power
 
-    def _record_override(self, node_id: str, path: tuple, value: Any) -> None:
+    def _record_override(
+        self,
+        node_id: str,
+        path: tuple,
+        value: Any,
+        hold_seconds: float | None = None,
+    ) -> None:
+        hold = _OPTIMISTIC_HOLD_SECONDS if hold_seconds is None else hold_seconds
         self._overrides.setdefault(node_id, {})[path] = (
             value,
-            time.monotonic() + _OPTIMISTIC_HOLD_SECONDS,
+            time.monotonic() + hold,
         )
 
-    def update_cached_value(self, node_id: str, key: str, value: Any) -> None:
-        """Optimistically patch cached state after a successful command."""
+    def update_cached_value(
+        self,
+        node_id: str,
+        key: str,
+        value: Any,
+        hold_seconds: float | None = None,
+    ) -> None:
+        """Optimistically patch cached state after a successful command.
+
+        ``hold_seconds`` overrides how long the value outranks the cloud. Pass
+        ``math.inf`` for a device that never reports back: nothing will ever
+        confirm or contradict the command, so expiring it only turns the entity
+        unknown until the next one (#203).
+        """
         device = self.get_device_by_node(node_id)
         if device is None or self.data is None:
             return
         device.last_reported_value[key] = value
-        self._record_override(node_id, ("top", key), value)
+        self._record_override(node_id, ("top", key), value, hold_seconds)
         self._notify()
 
     def update_cached_nested(self, node_id: str, parent_key: str, key: str, value: Any) -> None:

--- a/custom_components/enki/switch.py
+++ b/custom_components/enki/switch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
@@ -244,8 +245,12 @@ class EnkiOutletSwitch(EnkiEntity, SwitchEntity):
         if self._endpoint_id is not None:
             self.coordinator.update_endpoint_power(node_id, self._endpoint_id, power)
             return
-        self.coordinator.update_cached_value(node_id, "electrical_power", power)
-        self.coordinator.update_cached_value(node_id, "power", power)
+        # A one-way outlet is never read back, so the command is the only state
+        # there will ever be — holding it for 45 s just turns the entity unknown
+        # in between (#203).
+        hold = math.inf if self._attr_assumed_state else None
+        self.coordinator.update_cached_value(node_id, "electrical_power", power, hold)
+        self.coordinator.update_cached_value(node_id, "power", power, hold)
 
 
 class EnkiChannelSwitch(EnkiEntity, SwitchEntity):

--- a/tests/unit/core/test_coordinator_lifecycle.py
+++ b/tests/unit/core/test_coordinator_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -271,3 +272,28 @@ def test_override_apply_endpoint_string_replaces_value() -> None:
     device = _device(electrical_endpoints=[{"id": 3, "lastReportedValue": "OFF"}])
     _override_apply(device, ("endpoint", 3), "ON")
     assert device.last_reported_value["electrical_endpoints"][0]["lastReportedValue"] == "ON"
+
+
+def test_infinite_hold_survives_a_silent_poll() -> None:
+    # A write-only outlet: the poll reports nothing, so the command stands (#203).
+    coordinator = _make_coordinator()
+    coordinator.data = [_device()]
+    coordinator.update_cached_value("node", "electrical_power", "ON", math.inf)
+
+    polled = coordinator._apply_optimistic_overrides([_device()])
+
+    assert polled[0].last_reported_value["electrical_power"] == "ON"
+    assert coordinator._overrides["node"]
+
+
+def test_infinite_hold_yields_once_the_cloud_reports() -> None:
+    # If the plug is ever switched by its remote and the cloud does report it,
+    # the held command must not mask the truth forever.
+    coordinator = _make_coordinator()
+    coordinator.data = [_device()]
+    coordinator.update_cached_value("node", "electrical_power", "ON", math.inf)
+
+    polled = coordinator._apply_optimistic_overrides([_device(electrical_power="OFF")])
+
+    assert polled[0].last_reported_value["electrical_power"] == "OFF"
+    assert coordinator._overrides == {}

--- a/tests/unit/entities/test_dio_outlet.py
+++ b/tests/unit/entities/test_dio_outlet.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import math
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from enki.domain.models import EnkiDevice
 from enki.lib.enki_scope import device_in_enki_scope
 from enki.switch import _build_switch_entities
@@ -63,3 +65,33 @@ def test_readable_outlet_is_not_assumed_state() -> None:
     switch = _build_switch_entities(MagicMock(), device)[0]
     assert switch._attr_assumed_state is False
     assert switch.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_assumed_state_outlet_holds_its_last_command() -> None:
+    """The optimistic value must not expire when nothing ever reports back.
+
+    Otherwise the entity turns unknown 45 s after each command, which is what the
+    reporter saw in the history: "off", then "unknown", then "on" (#203).
+    """
+    coordinator = MagicMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    switch = _build_switch_entities(coordinator, _dio_outlet())[0]
+
+    await switch.async_turn_on()
+
+    holds = {call.args[1]: call.args[3] for call in coordinator.update_cached_value.call_args_list}
+    assert holds == {"electrical_power": math.inf, "power": math.inf}
+
+
+@pytest.mark.asyncio
+async def test_readable_outlet_keeps_the_default_hold() -> None:
+    coordinator = MagicMock()
+    coordinator.api.async_switch_electrical_power = AsyncMock()
+    device = _dio_outlet(capabilities=["switch_electrical_power", "check_electrical_power"])
+    switch = _build_switch_entities(coordinator, device)[0]
+
+    await switch.async_turn_off()
+
+    holds = {call.args[1]: call.args[3] for call in coordinator.update_cached_value.call_args_list}
+    assert holds == {"electrical_power": None, "power": None}


### PR DESCRIPTION
Suite de #203 : les prises DIO répondent bien aux commandes, mais l'historique de @rhox14 montre `Éteint 21:00:02` → `Inconnu 21:00:51` → `Allumé`. Ce sont les 45 s de rétention optimiste qui expirent.

Sur une prise qui ne se relit jamais, cette expiration n'a pas de sens : aucun sondage ne viendra jamais confirmer ni contredire la commande, donc oublier la valeur ne fait que rendre l'entité inconnue jusqu'à la commande suivante.

`update_cached_value` accepte maintenant une durée de rétention, et un interrupteur en `assumed_state` passe une rétention infinie. Les prises qui savent se relire gardent le comportement actuel — leur override doit continuer d'expirer pour laisser le cloud reprendre la main.

2 tests.

Refs #203
