### PR TITLE
feat(telemetry): report brands skipped at discovery

### DIFF
--- a/custom_components/enki/domain/telemetry_coverage.py
+++ b/custom_components/enki/domain/telemetry_coverage.py
@@ -198,16 +198,25 @@ def discovery_record_telemetry_exclusion(record: EnkiDiscoveryRecord) -> str | N
     ):
         return "out_of_enki_scope"
 
-    device_type = _normalize_type(record.device_type)
-    bff_type = _normalize_type(record.bff_device_type)
-    if device_type in _GATEWAY_DEVICE_TYPES or bff_type in _GATEWAY_DEVICE_TYPES:
-        return "gateway"
-
-    caps = record.capabilities or []
-    if caps and any(cap in _GATEWAY_CAPABILITY_MARKERS for cap in caps):
+    if discovery_record_is_gateway(record):
         return "gateway"
 
     return None
+
+
+def discovery_record_is_gateway(record: EnkiDiscoveryRecord) -> bool:
+    """True for the hub itself, whatever its brand.
+
+    Checked on its own because the out-of-scope test runs first: an unknown-brand
+    hub would otherwise look like an unsupported product worth reporting.
+    """
+    device_type = _normalize_type(record.device_type)
+    bff_type = _normalize_type(record.bff_device_type)
+    if device_type in _GATEWAY_DEVICE_TYPES or bff_type in _GATEWAY_DEVICE_TYPES:
+        return True
+
+    caps = record.capabilities or []
+    return bool(caps and any(cap in _GATEWAY_CAPABILITY_MARKERS for cap in caps))
 
 
 def discovery_record_eligible_for_telemetry(record: EnkiDiscoveryRecord) -> bool:

--- a/custom_components/enki/domain/unknown_brands.py
+++ b/custom_components/enki/domain/unknown_brands.py
@@ -1,0 +1,166 @@
+"""One-shot census of devices skipped because their brand is unknown.
+
+Per-profile telemetry only ever covers devices the integration already claims:
+anything outside :func:`device_in_enki_scope` is dropped before the nudge, so a
+supportable product can sit on hundreds of accounts without ever being heard of.
+That is exactly what happened with DIO outlets (#203) — a plain
+``switch_electrical_power`` device, missing only from the brand list.
+
+The fix must not turn into noise for people running third-party Zigbee on the
+hub, so this stays deliberately quiet: one aggregated card per brand set, never
+one per device, and the brands that clearly belong in Zigbee2MQTT / ZHA are
+filtered out entirely.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import Counter
+from dataclasses import dataclass
+from urllib.parse import quote
+
+from ..const import TELEMETRY_GITHUB_REPO
+from ..lib.enki_scope import device_in_enki_scope
+from .models import EnkiDiscoveryRecord
+from .telemetry_coverage import discovery_record_is_gateway
+
+# Brands the README already routes to Zigbee2MQTT / ZHA. Missing one only costs
+# a single card, so the list stays short rather than trying to be exhaustive.
+_THIRD_PARTY_BRANDS = frozenset(
+    {
+        "aqara",
+        "blitzwolf",
+        "bosch",
+        "heiman",
+        "ikea",
+        "innr",
+        "lidl",
+        "moes",
+        "osram",
+        "sengled",
+        "silvercrest",
+        "sonoff",
+        "tradfri",
+        "tuya",
+        "xiaomi",
+    }
+)
+
+# Brands Enki drives through a dedicated micro-service: seeing one skipped is a
+# strong signal, not noise — DIO was one of these.
+_ENKI_PARTNER_BRANDS = frozenset(
+    {
+        "avidsen",
+        "diagral",
+        "dio",
+        "enocean",
+        "netatmo",
+        "philips",
+        "sauter",
+        "somfy",
+        "tahoma",
+        "tapo",
+        "wiz",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class UnknownBrandEntry:
+    """One brand / device-type pair seen on the account, with how many."""
+
+    manufacturer: str
+    device_type: str
+    count: int
+    partner: bool
+
+
+def _normalize(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def _is_third_party(manufacturer: str) -> bool:
+    normalized = _normalize(manufacturer)
+    return any(brand in normalized for brand in _THIRD_PARTY_BRANDS)
+
+
+def _is_partner(manufacturer: str) -> bool:
+    normalized = _normalize(manufacturer)
+    return any(brand in normalized for brand in _ENKI_PARTNER_BRANDS)
+
+
+def unknown_brand_census(records: list[EnkiDiscoveryRecord]) -> list[UnknownBrandEntry]:
+    """Group the skipped-by-brand devices worth telling the maintainer about.
+
+    Devices already covered by per-profile telemetry are left out — they nudge on
+    their own — and so are hubs and third-party Zigbee.
+    """
+    counter: Counter[tuple[str, str]] = Counter()
+    for record in records:
+        manufacturer = (record.manufacturer or "").strip()
+        if not manufacturer:
+            continue
+        if device_in_enki_scope(
+            manufacturer=manufacturer,
+            device_type=record.device_type,
+        ):
+            continue
+        if discovery_record_is_gateway(record):
+            # The hub is skipped by design, whatever brand it carries.
+            continue
+        if _is_third_party(manufacturer):
+            continue
+        counter[(manufacturer, record.device_type or "unknown")] += 1
+
+    return [
+        UnknownBrandEntry(
+            manufacturer=manufacturer,
+            device_type=device_type,
+            count=count,
+            partner=_is_partner(manufacturer),
+        )
+        for (manufacturer, device_type), count in sorted(counter.items())
+    ]
+
+
+def unknown_brand_fingerprint(census: list[UnknownBrandEntry]) -> str:
+    """Stable id for a brand set, so the card appears once and not per device.
+
+    Counts are deliberately excluded: buying an eighth plug of a brand already
+    reported must not raise a second card.
+    """
+    brands = sorted({_normalize(entry.manufacturer) for entry in census})
+    return hashlib.sha256("|".join(brands).encode()).hexdigest()
+
+
+def format_unknown_brand_summary(census: list[UnknownBrandEntry]) -> str:
+    return ", ".join(
+        f"{entry.manufacturer} {entry.device_type} (×{entry.count})" for entry in census
+    )
+
+
+def build_unknown_brand_issue_url(census: list[UnknownBrandEntry], fingerprint: str) -> str:
+    """Pre-filled GitHub issue asking whether these brands should be supported."""
+    brands = sorted({entry.manufacturer for entry in census})
+    title = f"[telemetry] Unsupported brands: {', '.join(brands)}"
+    lines = [
+        "Devices on my account that the integration skips because their brand is unknown.",
+        "",
+        "| Brand | Type | Count | Enki micro-service |",
+        "|-------|------|-------|--------------------|",
+    ]
+    lines += [
+        f"| {entry.manufacturer} | {entry.device_type} | {entry.count} | "
+        f"{'yes' if entry.partner else 'unknown'} |"
+        for entry in census
+    ]
+    lines += [
+        "",
+        "Run `python3 scripts/discover_devices.py <email> <password>` for the full "
+        "capability dump of one of these devices.",
+        "",
+        f"Census id: `{fingerprint[:16]}`",
+    ]
+    body = "\n".join(lines)
+    base = f"https://github.com/{TELEMETRY_GITHUB_REPO}/issues/new"
+    return f"{base}?title={quote(title)}&body={quote(body)}&labels={quote('unsupported')}"

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -267,6 +267,10 @@
     "unsupported_device": {
       "title": "Enki — unsupported device",
       "description": "The device profile {summary} is not supported by the integration yet. Use the Learn more link to request support on GitHub."
+    },
+    "unknown_brand_devices": {
+      "title": "Enki — unrecognized device brands",
+      "description": "Your Enki account has devices the integration skips because their brand is unknown to it: {summary}. Some of these are Enki partner products that would only need to be added to the supported list. Use the Learn more link to report them on GitHub — nothing is sent without a click."
     }
   },
   "device_automation": {

--- a/custom_components/enki/telemetry/reporter.py
+++ b/custom_components/enki/telemetry/reporter.py
@@ -18,6 +18,12 @@ from ..domain.profile import (
 )
 from ..domain.telemetry_coverage import discovery_record_needs_telemetry
 from ..domain.telemetry_enrichment import enrich_telemetry_export
+from ..domain.unknown_brands import (
+    build_unknown_brand_issue_url,
+    format_unknown_brand_summary,
+    unknown_brand_census,
+    unknown_brand_fingerprint,
+)
 from ..lib.telemetry_labels import format_telemetry_notification_summary
 
 if TYPE_CHECKING:
@@ -102,12 +108,49 @@ class EnkiTelemetryReporter:
             new_count += 1
             self._notify_new_profile(export_dict, fingerprint)
 
+        await self._notify_unknown_brands(records, reported)
+
         if new_count == 0:
             return
 
         LOGGER.info(
             "Notified about %s new Enki device profile(s) (opt-in telemetry)",
             new_count,
+        )
+
+    async def _notify_unknown_brands(
+        self,
+        records: list[EnkiDiscoveryRecord],
+        reported: set[str],
+    ) -> None:
+        """Raise one card for the brands the integration skips, once per brand set.
+
+        Per-profile telemetry never sees these devices, so without this a
+        supportable product stays invisible (#203). Aggregated on purpose: a user
+        with seven plugs of an unknown brand gets one card, not seven.
+        """
+        census = unknown_brand_census(records)
+        if not census:
+            return
+        fingerprint = unknown_brand_fingerprint(census)
+        if fingerprint in reported:
+            return
+        reported.add(fingerprint)
+        await self._save_reported(reported)
+
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            f"unknown_brands_{fingerprint[:16]}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="unknown_brand_devices",
+            translation_placeholders={"summary": format_unknown_brand_summary(census)},
+            learn_more_url=build_unknown_brand_issue_url(census, fingerprint),
+        )
+        LOGGER.info(
+            "Enki: %s device(s) skipped because their brand is unknown (opt-in telemetry)",
+            sum(entry.count for entry in census),
         )
 
     def _dismiss_profile_notification(self, fingerprint: str) -> None:

--- a/custom_components/enki/translations/en.json
+++ b/custom_components/enki/translations/en.json
@@ -273,6 +273,10 @@
     "unsupported_device": {
       "title": "Enki — unsupported device",
       "description": "The device profile {summary} is not supported by the integration yet. Use the Learn more link to request support on GitHub."
+    },
+    "unknown_brand_devices": {
+      "title": "Enki — unrecognized device brands",
+      "description": "Your Enki account has devices the integration skips because their brand is unknown to it: {summary}. Some of these are Enki partner products that would only need to be added to the supported list. Use the Learn more link to report them on GitHub — nothing is sent without a click."
     }
   },
   "device_automation": {

--- a/custom_components/enki/translations/fr.json
+++ b/custom_components/enki/translations/fr.json
@@ -273,6 +273,10 @@
     "unsupported_device": {
       "title": "Enki — appareil non supporté",
       "description": "Le profil d'appareil {summary} n'est pas encore pris en charge par l'intégration. Utilisez le lien En savoir plus pour demander le support sur GitHub."
+    },
+    "unknown_brand_devices": {
+      "title": "Enki — marques d'appareils non reconnues",
+      "description": "Votre compte Enki contient des appareils que l'intégration ignore car leur marque lui est inconnue : {summary}. Certains sont des produits partenaires Enki qu'il suffirait d'ajouter à la liste des marques gérées. Utilisez le lien « En savoir plus » pour les signaler sur GitHub — rien n'est envoyé sans un clic."
     }
   },
   "device_automation": {

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -28,6 +28,17 @@ When a **new** profile is detected (unique fingerprint) **and support is missing
 
 **Also skipped (no notification, no GitHub link):** Enki hub / gateway profiles, and third-party Zigbee (Sonoff, Tuya, Aqara, …) that the integration deliberately ignores at discovery.
 
+### Unrecognized brands (one aggregated card)
+
+Devices are skipped at discovery when their **brand** is unknown to the integration, so per-profile notifications never see them — that is how DIO outlets stayed invisible until a user happened to mention them ([#203](https://github.com/cyrilcolinet/enki-integration-hass/issues/203)), when supporting them only meant adding the brand.
+
+One **aggregated** repair card therefore lists those brands, with the same pre-filled GitHub link. Deliberately quiet:
+
+- **one card per brand set, per installation** — seven plugs of one unknown brand raise one card, not seven; buying an eighth raises none, since counts are excluded from the fingerprint;
+- **a new brand appearing** later does raise a new card, which is the point;
+- **third-party Zigbee brands stay silent**, as above;
+- brands Enki drives through their own micro-service (DIO, Wiz, Tapo, Somfy, Netatmo, …) are **flagged as partners** in the issue body — those are the ones usually worth supporting.
+
 ### Enriched export
 
 Diagnostics and GitHub prefill now include extra **English** context when available:

--- a/tests/unit/telemetry/test_unknown_brands.py
+++ b/tests/unit/telemetry/test_unknown_brands.py
@@ -1,0 +1,89 @@
+"""Aggregated census of brands the integration skips (#203)."""
+
+from __future__ import annotations
+
+from enki.domain.models import EnkiDiscoveryRecord
+from enki.domain.unknown_brands import (
+    build_unknown_brand_issue_url,
+    format_unknown_brand_summary,
+    unknown_brand_census,
+    unknown_brand_fingerprint,
+)
+
+
+def _record(manufacturer: str | None, device_type: str = "outlets", **overrides):
+    defaults = {
+        "device_type": device_type,
+        "bff_device_type": device_type,
+        "capabilities": ["switch_electrical_power"],
+        "possible_values": {},
+        "manufacturer": manufacturer,
+        "model": None,
+        "firmware_version": None,
+        "supported_by_integration": False,
+    }
+    defaults.update(overrides)
+    return EnkiDiscoveryRecord(**defaults)
+
+
+def test_counts_unknown_brands_per_type() -> None:
+    census = unknown_brand_census(
+        [_record("Acme Home"), _record("Acme Home"), _record("Acme Home", "lights")]
+    )
+    assert [(e.manufacturer, e.device_type, e.count) for e in census] == [
+        ("Acme Home", "lights", 1),
+        ("Acme Home", "outlets", 2),
+    ]
+
+
+def test_known_enki_brand_is_not_reported() -> None:
+    # In scope: it already nudges through the per-profile path.
+    assert unknown_brand_census([_record("Lexman")]) == []
+
+
+def test_dio_is_no_longer_unknown() -> None:
+    # It was the case that motivated this census; it is supported since v1.21.
+    assert unknown_brand_census([_record("Dio")]) == []
+
+
+def test_third_party_zigbee_stays_silent() -> None:
+    # These belong in Zigbee2MQTT / ZHA, nudging about them is noise.
+    assert unknown_brand_census([_record("Sonoff"), _record("Tuya"), _record("Aqara")]) == []
+
+
+def test_gateways_are_not_a_brand_question() -> None:
+    assert unknown_brand_census([_record("Essentielb", "gateways")]) == []
+
+
+def test_records_without_a_brand_are_skipped() -> None:
+    assert unknown_brand_census([_record(None), _record("  ")]) == []
+
+
+def test_enki_partner_brands_are_flagged() -> None:
+    # Wiz has its own Enki micro-service: seeing one skipped is a strong signal,
+    # unlike a brand nobody recognizes.
+    census = unknown_brand_census([_record("Wiz"), _record("Acme Corp")])
+    flags = {entry.manufacturer: entry.partner for entry in census}
+    assert flags == {"Wiz": True, "Acme Corp": False}
+
+
+def test_fingerprint_ignores_counts_so_the_card_shows_once() -> None:
+    one = unknown_brand_census([_record("Acme Home")])
+    seven = unknown_brand_census([_record("Acme Home") for _ in range(7)])
+    assert unknown_brand_fingerprint(one) == unknown_brand_fingerprint(seven)
+
+
+def test_fingerprint_changes_when_a_new_brand_appears() -> None:
+    before = unknown_brand_census([_record("Acme Home")])
+    after = unknown_brand_census([_record("Acme Home"), _record("Acme Corp")])
+    assert unknown_brand_fingerprint(before) != unknown_brand_fingerprint(after)
+
+
+def test_summary_and_issue_url_carry_the_census() -> None:
+    census = unknown_brand_census([_record("Acme Home"), _record("Acme Home")])
+    assert format_unknown_brand_summary(census) == "Acme Home outlets (×2)"
+
+    url = build_unknown_brand_issue_url(census, "abc123")
+    assert url.startswith("https://github.com/cyrilcolinet/enki-integration-hass/issues/new?")
+    assert "Acme" in url
+    assert "labels=unsupported" in url


### PR DESCRIPTION
La télémétrie par profil ne voit que les appareils déjà dans le périmètre : dès que la marque est inconnue, `discovery_record_telemetry_exclusion` renvoie `out_of_enki_scope` et le nudge s'arrête là. Un produit à qui il ne manquait que sa marque dans la liste pouvait donc être présent sur des dizaines de comptes sans qu'on en entende jamais parler — c'est ce qui s'est passé avec les prises DIO (#203), découvertes parce qu'un utilisateur les a mentionnées au détour d'un fil sur les caméras.

## Ce que ça ajoute

Une **carte agrégée unique** listant les marques ignorées, avec le même lien d'issue pré-rempli que le reste de la télémétrie. Le flux par profil ne bouge pas.

Le plafond de bruit est structurel, pas dépendant d'une liste :

- **une carte par ensemble de marques et par installation** — sept prises d'une marque inconnue font une carte, pas sept ; en acheter une huitième n'en fait aucune, les compteurs sont exclus de l'empreinte ;
- une **nouvelle** marque plus tard produit une nouvelle carte, ce qui est précisément le but ;
- les marques Zigbee tierces (Sonoff, Tuya, Aqara, …) restent silencieuses ;
- les marques qu'Enki pilote via leur propre micro-service (DIO, Wiz, Tapo, Somfy, Netatmo, …) sont **signalées comme partenaires** dans le corps de l'issue — ce sont celles qui valent généralement le coup.

## Au passage

`discovery_record_is_gateway` est extraite de la fonction d'exclusion. Le test de périmètre passant en premier, une passerelle de marque inconnue était classée `out_of_enki_scope` et serait remontée comme un produit à supporter.

10 tests, dont un qui vérifie que DIO n'est plus une marque inconnue depuis la v1.21.

Refs #203
