### PR TITLE
chore: align translations, app version, and drop dead code

### DIFF
--- a/custom_components/enki/api/client.py
+++ b/custom_components/enki/api/client.py
@@ -26,7 +26,6 @@ from ..lib.conversion import (
     direction_to_enki_rotation,
     enki_rotation_to_direction,
     merge_light_state_payload,
-    normalize_power_state,
 )
 from ..lib.enki_scope import device_in_enki_scope
 from ..lib.production import parse_production_value
@@ -997,12 +996,6 @@ class EnkiAPI:
     ) -> None:
         """Backward-compatible wrapper for single-field lighting updates."""
         await self.async_change_light_state(home_id, node_id, {parameter: value})
-
-    async def _get_power_state(self, home_id: str, node_id: str, endpoint: int) -> str:
-        """Read one endpoint power state (used by integration tests)."""
-        http = await self._get_http()
-        data = await http.get_electrical_power(home_id, node_id)
-        return normalize_power_state(data.get("lastReportedValue"), endpoint)
 
     async def async_activate_scenario(self, home_id: str, scenario_id: str) -> None:
         """Trigger an Enki cloud scenario."""

--- a/custom_components/enki/api/gateway_keys.py
+++ b/custom_components/enki/api/gateway_keys.py
@@ -157,14 +157,6 @@ class GatewayKeyStore:
         value = self.get_const_value(svc.const_key)
         return value or None
 
-    def suggest_const_updates(self) -> dict[str, str]:
-        """Runtime keys that could replace empty const.py entries."""
-        return {
-            const_key: value
-            for const_key, value in self._runtime.items()
-            if value and not self._defaults.get(const_key)
-        }
-
 
 async def fetch_mobile_config(http_client: Any) -> dict[str, Any]:
     """Fetch Enki app settings (same endpoint as the mobile app GET settings).

--- a/custom_components/enki/const.py
+++ b/custom_components/enki/const.py
@@ -21,7 +21,7 @@ ENKI_OIDC_URL = "https://keycloak-prod.iot.leroymerlin.fr/realms/enki/protocol/o
 ENKI_BASE_URL = "https://enki.api.devportal.adeo.cloud"
 
 # Mobile app version used for gateway key extraction and HTTP impersonation.
-ENKI_APP_VERSION = "2.25.1"
+ENKI_APP_VERSION = "2.26.3"
 ENKI_USER_AGENT = f"Enki/{ENKI_APP_VERSION} (iPhone; iOS 18.0; Scale/3.00) Enki"
 
 

--- a/custom_components/enki/domain/capabilities.py
+++ b/custom_components/enki/domain/capabilities.py
@@ -796,14 +796,6 @@ def is_cover_device(device: EnkiDevice) -> bool:
     return device.profile.is_cover
 
 
-def device_capabilities(device: EnkiDevice) -> set[str]:
-    return set(device.profile.capabilities)
-
-
-def device_possible_values(device: EnkiDevice) -> dict[str, Any]:
-    return device.profile.possible_values
-
-
 def is_fan_device(device: EnkiDevice) -> bool:
     return device.profile.is_fan
 

--- a/custom_components/enki/lib/heating.py
+++ b/custom_components/enki/lib/heating.py
@@ -80,15 +80,3 @@ def thermostat_running_to_hvac_action(running_state: str | None) -> str | None:
     if normalized == "COOL":
         return "cooling"
     return None
-
-
-def enabled_mode_is_on(value: str | None) -> bool | None:
-    """Map ENABLED/DISABLED heating feature toggles to bool."""
-    if not isinstance(value, str):
-        return None
-    normalized = value.upper()
-    if normalized == "ENABLED":
-        return True
-    if normalized == "DISABLED":
-        return False
-    return None

--- a/custom_components/enki/notifications.py
+++ b/custom_components/enki/notifications.py
@@ -51,10 +51,6 @@ class EnkiNotifier:
         self._delete("gateway")
         self._create("connection", translation_key="cloud_unreachable")
 
-    def notify_service_unavailable(self) -> None:
-        """Enki cloud temporarily unavailable (5xx)."""
-        self.notify_connection_failed()
-
     def notify_maintenance_mode(self) -> None:
         """Enki cloud reports active maintenance."""
         self._create(

--- a/custom_components/enki/strings.json
+++ b/custom_components/enki/strings.json
@@ -165,6 +165,12 @@
       },
       "sd_card": {
         "name": "SD card issue"
+      },
+      "connectivity": {
+        "name": "Connectivity"
+      },
+      "firmware_update": {
+        "name": "Firmware update"
       }
     },
     "switch": {

--- a/tests/unit/core/test_translations_parity.py
+++ b/tests/unit/core/test_translations_parity.py
@@ -1,0 +1,60 @@
+"""strings.json is the source of truth for every translated string.
+
+Two entity keys once lived only in translations/*.json: the entities were named
+for users, but the source file the Home Assistant tooling reads had no trace of
+them. Nothing failed loudly — which is why this is checked here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_PACKAGE = Path(__file__).resolve().parents[3] / "custom_components" / "enki"
+_TRANSLATIONS = sorted((_PACKAGE / "translations").glob("*.json"))
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _keys(node: object, prefix: str = "") -> set[str]:
+    if not isinstance(node, dict):
+        return set()
+    found: set[str] = set()
+    for key, value in node.items():
+        path = f"{prefix}.{key}" if prefix else key
+        found.add(path)
+        found |= _keys(value, path)
+    return found
+
+
+def _translation_keys_used_in_code() -> set[str]:
+    source = "\n".join(path.read_text(encoding="utf-8") for path in sorted(_PACKAGE.rglob("*.py")))
+    return set(re.findall(r'translation_key\s*=\s*"([a-z0-9_]+)"', source)) | set(
+        re.findall(r'"translation_key":\s*"([a-z0-9_]+)"', source)
+    )
+
+
+def test_translation_files_exist() -> None:
+    assert _TRANSLATIONS, "no translations shipped"
+
+
+@pytest.mark.parametrize("path", _TRANSLATIONS, ids=lambda path: path.name)
+def test_translation_matches_strings(path: Path) -> None:
+    strings = _keys(_load(_PACKAGE / "strings.json"))
+    translated = _keys(_load(path))
+    assert translated - strings == set(), f"{path.name} declares keys absent from strings.json"
+    assert strings - translated == set(), f"{path.name} is missing keys from strings.json"
+
+
+def test_every_entity_translation_key_is_declared() -> None:
+    strings = _load(_PACKAGE / "strings.json")
+    declared = {key for platform in strings.get("entity", {}).values() for key in platform}
+    declared |= set(strings.get("issues", {}))
+    # Dynamic keys, built from a tuple rather than a literal assignment.
+    declared |= {"fan_light_main", "fan_light_ambient", "fan_light_numbered"}
+    assert _translation_keys_used_in_code() - declared == set()


### PR DESCRIPTION
Passe d'audit sur `main`. Trois trouvailles, aucune régression fonctionnelle.

## 1. Deux entités nommées hors de `strings.json`

`binary_sensor.connectivity` et `binary_sensor.firmware_update` sont utilisées dans le code et traduites dans `translations/en.json` et `fr.json`, mais absentes de `strings.json` — le fichier que lit l'outillage Home Assistant. Les utilisateurs voyaient bien les noms, mais la source de vérité était désynchronisée, et une régénération ou une validation les aurait perdues.

Ajoutées, et surtout : un test vérifie désormais la parité dans les deux sens entre `strings.json`, chaque fichier de traduction, et les `translation_key` réellement utilisées dans le code. Vérifié qu'il échoue bien sans le correctif.

## 2. User-Agent périmé

`ENKI_APP_VERSION` annonçait `2.25.1` alors que les clés passerelle qu'on embarque viennent de la **2.26.3** — c'est la version que j'ai vérifiée en analysant l'APK sur #190. Aligné. Adeo ferme déjà des produits d'API, autant ne pas se signaler avec une version incohérente.

## 3. Code mort

Six membres sans aucun appelant, ni dans le code, ni dans les tests, ni dans les scripts :

| Membre | Pourquoi il est mort |
|--------|----------------------|
| `device_capabilities`, `device_possible_values` | passe-plats vers `device.profile` |
| `enabled_mode_is_on` | `EnkiConfigSwitch` fait le mapping lui-même, et gère aussi LOCK/UNLOCK |
| `_get_power_state` | sa docstring dit « used by integration tests » — aucun test ne le référence |
| `notify_service_unavailable` | alias d'une ligne vers `notify_connection_failed` |
| `suggest_const_updates` | aucun consommateur, ni package ni scripts |

## Non traité, à ta main

- `normalize_power_state` n'a plus d'appelant en production depuis la suppression de `_get_power_state`, mais c'est un utilitaire exporté par `lib` et couvert par ses propres tests. Je ne l'ai pas supprimé de moi-même — dis-moi si tu veux qu'il parte aussi.
- `REFERENTIEL_VERSION = "2.26.0"` contre 2.26.3 côté APK. Je n'y ai pas touché : ce paramètre change le jeu de capacités renvoyé par l'API, donc ça se teste sur un vrai compte, ce n'est pas du polish.
- `api/client.py` fait 1026 lignes et concentre découverte, lecture d'état et commandes. Découpable, mais c'est un refactor, pas une passe de finition.

561 tests, lint et format OK.
